### PR TITLE
Add FindTokenMetadataAddress()

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -355,3 +355,13 @@ func findAssociatedTokenAddressAndBumpSeed(
 		programID,
 	)
 }
+
+// FindTokenMetadataAddress returns the token metadata program-derived address given a SPL token mint address.
+func FindTokenMetadataAddress(mint PublicKey) (PublicKey, uint8, error) {
+	seed := [][]byte{
+		[]byte("metadata"),
+		TokenMetadataProgramID[:],
+		mint[:],
+	}
+	return FindProgramAddress(seed, TokenMetadataProgramID)
+}

--- a/keys_test.go
+++ b/keys_test.go
@@ -260,3 +260,14 @@ func TestFindProgramAddress(t *testing.T) {
 		require.Equal(t, address, got)
 	}
 }
+
+func TestFindTokenMetadataAddress(t *testing.T) {
+	// Zuuper Grapes (TOILET)
+	// https://solscan.io/token/77K8mr457qxUSSNSfi4sSj5euP8DyuJJWHAUQVW8QCp3
+	mint := MustPublicKeyFromBase58("77K8mr457qxUSSNSfi4sSj5euP8DyuJJWHAUQVW8QCp3")
+	metadataPDA, bumpSeed, err := FindTokenMetadataAddress(mint)
+	require.NoError(t, err)
+	// https://solscan.io/account/GfihrEYCPrvUyrMyMQPdhGEStxa9nKEK2Wfn9iK4AZq2
+	assert.Equal(t, metadataPDA, MustPublicKeyFromBase58("GfihrEYCPrvUyrMyMQPdhGEStxa9nKEK2Wfn9iK4AZq2"))
+	assert.Equal(t, bumpSeed, uint8(0xfd))
+}


### PR DESCRIPTION
Adds a utility function that returns the token metadata program-derived account given a SPL token mint address.

`Signed-off-by: Richard Patel <richard@blockdaemon.com>`