### PR TITLE
Fixed GetTokenAccountsResult unmarshalling

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2310,7 +2310,7 @@ func TestClient_GetTokenAccountBalance(t *testing.T) {
 }
 
 func TestClient_GetTokenAccountsByDelegate(t *testing.T) {
-	responseBody := `{"context":{"slot":1114},"value":[{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4}]}`
+	responseBody := `{"context":{"slot":1114},"value":[{"account":{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}]}`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
 	defer closer()
 	client := New(server.URL)
@@ -2361,7 +2361,7 @@ func TestClient_GetTokenAccountsByDelegate(t *testing.T) {
 }
 
 func TestClient_GetTokenAccountsByOwner(t *testing.T) {
-	responseBody := `{"context":{"slot":1114},"value":[{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":null,"delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4}]}`
+	responseBody := `{"context":{"slot":1114},"value":[{"account":{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":null,"delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}]}`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
 	defer closer()
 	client := New(server.URL)

--- a/rpc/getTokenAccountsByDelegate.go
+++ b/rpc/getTokenAccountsByDelegate.go
@@ -93,26 +93,10 @@ func (cl *Client) GetTokenAccountsByDelegate(
 
 type GetTokenAccountsResult struct {
 	RPCContext
-	Value []*Account `json:"value"`
+	Value []*TokenAccount `json:"value"`
 }
 
-func (r *GetTokenAccountsResult) UnmarshalJSON(b []byte) error {
-	s := struct {
-		RPCContext
-		Value []struct {
-			Account Account
-		}
-	}{}
-
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-
-	(*r).RPCContext = s.RPCContext
-	(*r).Value = make([]*Account, len(s.Value))
-
-	for i := range s.Value {
-		(*r).Value[i] = &s.Value[i].Account
-	}
-	return nil
+type TokenAccount struct {
+	Pubkey  solana.PublicKey `json:"pubkey"`
+	Account Account `json:"account"`
 }


### PR DESCRIPTION
Current implementation of the library incorrectly unmarshalls result obtained from the network.

The network response:
```json
{
    "context": {
        "slot": 88881251
    },
    "value": [
        {
            "account": {
                "data": {
                    "parsed": {
                        "info": {
                            "isNative": false,
                            "mint": "7duMWSNdYMof6WKZHs5X1wdmmxUa6cDGqqKShhMSGkgg",
                            "owner": "5VpgCCusY5wqQdsW4auwBKLrAcPatvhJqP3RsdWCVhGc",
                            "state": "initialized",
                            "tokenAmount": {
                                "amount": "160000000000",
                                "decimals": 9,
                                "uiAmount": 160.0,
                                "uiAmountString": "160"
                            }
                        },
                        "type": "account"
                    },
                    "program": "spl-token",
                    "space": 165
                },
                "executable": false,
                "lamports": 2039280,
                "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
                "rentEpoch": 204
            },
            "pubkey": "FogtU272rSRCbVhcga2UGDCXnvdvcPHXtEBrd6PTwAeK"
        },
        {
            "account": {
                "data": {
                    "parsed": {
                        "info": {
                            "isNative": false,
                            "mint": "6E8tJq85M64wqerfwBN6iYQGJPVcUFzgc8wKqc3tcKeD",
                            "owner": "5VpgCCusY5wqQdsW4auwBKLrAcPatvhJqP3RsdWCVhGc",
                            "state": "initialized",
                            "tokenAmount": {
                                "amount": "25000000000",
                                "decimals": 9,
                                "uiAmount": 25.0,
                                "uiAmountString": "25"
                            }
                        },
                        "type": "account"
                    },
                    "program": "spl-token",
                    "space": 165
                },
                "executable": false,
                "lamports": 2039280,
                "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
                "rentEpoch": 205
            },
            "pubkey": "sRstQnQayXAK5HYW9VjZZdWjczDzsacP1mN6Ya5WUnE"
        },
        {
            "account": {
                "data": {
                    "parsed": {
                        "info": {
                            "isNative": false,
                            "mint": "GAB8JrLm2CbLG9e3j769qt69bAuJzErRh3XVbazYCHyH",
                            "owner": "5VpgCCusY5wqQdsW4auwBKLrAcPatvhJqP3RsdWCVhGc",
                            "state": "initialized",
                            "tokenAmount": {
                                "amount": "1",
                                "decimals": 0,
                                "uiAmount": 1.0,
                                "uiAmountString": "1"
                            }
                        },
                        "type": "account"
                    },
                    "program": "spl-token",
                    "space": 165
                },
                "executable": false,
                "lamports": 2039280,
                "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
                "rentEpoch": 205
            },
            "pubkey": "1Cn2825y8DZgmJW34iD1T5GMNRXhzQ16yXnbzz64WLc"
        }
    ]
}
```
The current go struct:
```go
type GetTokenAccountsResult struct {
	RPCContext
	Value []*Account `json:"value"`
}
```
So the slice of accounts can't be unmarshalled correctly because the network response contains additional "account" key in every slice element.
This PR fixes the problem without breaking the API of the package.