### PR TITLE
Send raw transaction

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2464,12 +2464,10 @@ func TestClient_SendRawTransaction(t *testing.T) {
 
 	client := New(server.URL)
 
-	// rawTx := []byte(encodedTx)
 	rawTx, err := base64.StdEncoding.DecodeString(encodedTx)
 	require.NoError(t, err)
-	//rawTx[10] = 1
+
 	out, err := client.SendRawTransaction(context.Background(), rawTx)
-	panic("aiohsd")
 	require.NoError(t, err)
 
 	expected := mustJSONToInterface([]byte(responseBody))

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -20,10 +20,13 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	stdjson "encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/AlekSi/pointer"
+	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2411,8 +2414,69 @@ func TestClient_GetTokenAccountsByOwner(t *testing.T) {
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
 }
 
+var encodedTx string = "AfjEs3XhTc3hrxEvlnMPkm/cocvAUbFNbCl00qKnrFue6J53AhEqIFmcJJlJW3EDP5RmcMz+cNTTcZHW/WJYwAcBAAEDO8hh4VddzfcO5jbCt95jryl6y8ff65UcgukHNLWH+UQGgxCGGpgyfQVQV02EQYqm4QwzUt2qf9f1gVLM7rI4hwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6ANIF55zOZWROWRkeh+lExxZBnKFqbvIxZDLE7EijjoBAgIAAQwCAAAAOTAAAAAAAAA="
+var txSignatureString string = "5yUSwqQqeZLEEYKxnG4JC4XhaaBpV3RS4nQbK8bQTyjLX5btVq9A1Ja5nuJzV7Z3Zq8G6EVKFvN4DKUL6PSAxmTk"
+
 func TestClient_SendTransaction(t *testing.T) {
-	// TODO
+	responseBody := fmt.Sprintf(`"%s"`, txSignatureString)
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+
+	data, err := base64.StdEncoding.DecodeString(encodedTx)
+	require.NoError(t, err)
+
+	tx, err := solana.TransactionFromDecoder(bin.NewBinDecoder(data))
+	require.NoError(t, err)
+
+	client := New(server.URL)
+
+	out, err := client.SendTransaction(context.Background(), tx)
+	require.NoError(t, err)
+
+	expected := mustJSONToInterface([]byte(responseBody))
+
+	got := mustJSONToInterface(mustAnyToJSON(out))
+
+	assert.Equal(t, expected, got, "both deserialized values must be equal")
+}
+
+func TestClient_SendEncodedTransaction(t *testing.T) {
+	responseBody := fmt.Sprintf(`"%s"`, txSignatureString)
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+
+	client := New(server.URL)
+
+	out, err := client.SendEncodedTransaction(context.Background(), encodedTx)
+	require.NoError(t, err)
+
+	expected := mustJSONToInterface([]byte(responseBody))
+
+	got := mustJSONToInterface(mustAnyToJSON(out))
+
+	assert.Equal(t, expected, got, "both deserialized values must be equal")
+}
+
+func TestClient_SendRawTransaction(t *testing.T) {
+	responseBody := fmt.Sprintf(`"%s"`, txSignatureString)
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+
+	client := New(server.URL)
+
+	// rawTx := []byte(encodedTx)
+	rawTx, err := base64.StdEncoding.DecodeString(encodedTx)
+	require.NoError(t, err)
+	//rawTx[10] = 1
+	out, err := client.SendRawTransaction(context.Background(), rawTx)
+	panic("aiohsd")
+	require.NoError(t, err)
+
+	expected := mustJSONToInterface([]byte(responseBody))
+
+	got := mustJSONToInterface(mustAnyToJSON(out))
+
+	assert.Equal(t, expected, got, "both deserialized values must be equal")
 }
 
 func TestClient_SimulateTransaction(t *testing.T) {

--- a/rpc/examples/sendEncodedTransaction/sendEncodedTransaction.go
+++ b/rpc/examples/sendEncodedTransaction/sendEncodedTransaction.go
@@ -16,30 +16,17 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
-	bin "github.com/gagliardetto/binary"
-	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
 
 func main() {
 	endpoint := rpc.TestNet_RPC
 	client := rpc.New(endpoint)
-	base64Tx := "AfjEs3XhTc3hrxEvlnMPkm/cocvAUbFNbCl00qKnrFue6J53AhEqIFmcJJlJW3EDP5RmcMz+cNTTcZHW/WJYwAcBAAEDO8hh4VddzfcO5jbCt95jryl6y8ff65UcgukHNLWH+UQGgxCGGpgyfQVQV02EQYqm4QwzUt2qf9f1gVLM7rI4hwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6ANIF55zOZWROWRkeh+lExxZBnKFqbvIxZDLE7EijjoBAgIAAQwCAAAAOTAAAAAAAAA="
+	base64Tx := "AepZ357SXFu9tOBeX8v8aqkPNyGq/RUN4EvDzWAT/Fsg1htQu0Zp6F6OxO645I5z98VI4XacPKJp8rtHOE7Q9Q0BAAED8gJOoYf0IvSirfhOq6ZFf3R3ekB5vFWlaGTEq3irvwFakK+tD9il+9jzzs+gU1wzZxkmXZqyeBhbaXogNlk1GQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAou6RU2rKBCg2RzcJqZwEr4y2VBsWbkYLYMKFcOz64j4BAgIAAQwCAAAAAOH1BQAAAAA="
 
-	data, err := base64.StdEncoding.DecodeString(base64Tx)
-	if err != nil {
-		panic(err)
-	}
-
-	tx, err := solana.TransactionFromDecoder(bin.NewBinDecoder(data))
-	if err != nil {
-		panic(err)
-	}
-
-	sig, err := client.SendTransaction(context.TODO(), tx)
+	sig, err := client.SendEncodedTransaction(context.TODO(), base64Tx)
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/examples/sendRawTransaction/sendRawTransaction.go
+++ b/rpc/examples/sendRawTransaction/sendRawTransaction.go
@@ -19,8 +19,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	bin "github.com/gagliardetto/binary"
-	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
 
@@ -29,17 +27,12 @@ func main() {
 	client := rpc.New(endpoint)
 	base64Tx := "AfjEs3XhTc3hrxEvlnMPkm/cocvAUbFNbCl00qKnrFue6J53AhEqIFmcJJlJW3EDP5RmcMz+cNTTcZHW/WJYwAcBAAEDO8hh4VddzfcO5jbCt95jryl6y8ff65UcgukHNLWH+UQGgxCGGpgyfQVQV02EQYqm4QwzUt2qf9f1gVLM7rI4hwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6ANIF55zOZWROWRkeh+lExxZBnKFqbvIxZDLE7EijjoBAgIAAQwCAAAAOTAAAAAAAAA="
 
-	data, err := base64.StdEncoding.DecodeString(base64Tx)
+	txRaw, err := base64.StdEncoding.DecodeString(base64Tx)
 	if err != nil {
 		panic(err)
 	}
 
-	tx, err := solana.TransactionFromDecoder(bin.NewBinDecoder(data))
-	if err != nil {
-		panic(err)
-	}
-
-	sig, err := client.SendTransaction(context.TODO(), tx)
+	sig, err := client.SendRawTransaction(context.TODO(), txRaw)
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/sendEncodedTransaction.go
+++ b/rpc/sendEncodedTransaction.go
@@ -18,12 +18,12 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 )
 
 // SendEncodedTransaction submits a signed base64 encoded transaction to the cluster for processing.
+// The only difference between this function and SignTransaction is that the latter takes a *solana.Transaction value, as the former takes a raw base64 string
 func (cl *Client) SendEncodedTransaction(
 	ctx context.Context,
 	encodedTx string,
@@ -37,14 +37,12 @@ func (cl *Client) SendEncodedTransaction(
 }
 
 // SendEncodedTransaction submits a signed base64 encoded transaction to the cluster for processing.
-// The only difference between this function and SignTransaction is that the latter takes a *solana.Transaction value, as the former takes a raw base64 string
 func (cl *Client) SendEncodedTransactionWithOpts(
 	ctx context.Context,
 	encodedTx string,
 	skipPreflight bool, // if true, skip the preflight transaction checks (default: false)
 	preflightCommitment CommitmentType, // optional; Commitment level to use for preflight (default: "finalized").
 ) (signature solana.Signature, err error) {
-	fmt.Println("SendEncodedTransaction: ", encodedTx)
 
 	obj := M{
 		"encoding": "base64",
@@ -58,7 +56,7 @@ func (cl *Client) SendEncodedTransactionWithOpts(
 	}
 
 	params := []interface{}{
-		encodedTx,
+        encodedTx,
 		obj,
 	}
 

--- a/rpc/sendEncodedTransaction.go
+++ b/rpc/sendEncodedTransaction.go
@@ -1,0 +1,67 @@
+// Copyright 2021 github.com/gagliardetto
+// This file has been modified by github.com/gagliardetto
+//
+// Copyright 2020 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package rpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// SendEncodedTransaction submits a signed base64 encoded transaction to the cluster for processing.
+func (cl *Client) SendEncodedTransaction(
+	ctx context.Context,
+	encodedTx string,
+) (signature solana.Signature, err error) {
+	return cl.SendEncodedTransactionWithOpts(
+		ctx,
+		encodedTx,
+		false,
+		"",
+	)
+}
+
+// SendEncodedTransaction submits a signed base64 encoded transaction to the cluster for processing.
+// The only difference between this function and SignTransaction is that the latter takes a *solana.Transaction value, as the former takes a raw base64 string
+func (cl *Client) SendEncodedTransactionWithOpts(
+	ctx context.Context,
+	encodedTx string,
+	skipPreflight bool, // if true, skip the preflight transaction checks (default: false)
+	preflightCommitment CommitmentType, // optional; Commitment level to use for preflight (default: "finalized").
+) (signature solana.Signature, err error) {
+	fmt.Println("SendEncodedTransaction: ", encodedTx)
+
+	obj := M{
+		"encoding": "base64",
+	}
+
+	if skipPreflight {
+		obj["skipPreflight"] = skipPreflight
+	}
+	if preflightCommitment != "" {
+		obj["preflightCommitment"] = preflightCommitment
+	}
+
+	params := []interface{}{
+		encodedTx,
+		obj,
+	}
+
+	err = cl.rpcClient.CallForInto(ctx, &signature, "sendTransaction", params)
+	return
+}

--- a/rpc/sendEncodedTransaction.go
+++ b/rpc/sendEncodedTransaction.go
@@ -36,7 +36,7 @@ func (cl *Client) SendEncodedTransaction(
 	)
 }
 
-// SendEncodedTransaction submits a signed base64 encoded transaction to the cluster for processing.
+// SendEncodedTransactionWithOpts submits a signed base64 encoded transaction to the cluster for processing.
 func (cl *Client) SendEncodedTransactionWithOpts(
 	ctx context.Context,
 	encodedTx string,
@@ -56,7 +56,7 @@ func (cl *Client) SendEncodedTransactionWithOpts(
 	}
 
 	params := []interface{}{
-        encodedTx,
+		encodedTx,
 		obj,
 	}
 

--- a/rpc/sendRawTransaction.go
+++ b/rpc/sendRawTransaction.go
@@ -19,7 +19,6 @@ package rpc
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 )
@@ -30,7 +29,6 @@ func (cl *Client) SendRawTransaction(
 	ctx context.Context,
 	rawTx []byte,
 ) (signature solana.Signature, err error) {
-	fmt.Println("SendRawTransaction: ", rawTx)
 	return cl.SendEncodedTransactionWithOpts(
 		ctx,
 		base64.StdEncoding.EncodeToString(rawTx),

--- a/rpc/sendRawTransaction.go
+++ b/rpc/sendRawTransaction.go
@@ -29,10 +29,25 @@ func (cl *Client) SendRawTransaction(
 	ctx context.Context,
 	rawTx []byte,
 ) (signature solana.Signature, err error) {
+	return cl.SendRawTransactionWithOpts(
+		ctx,
+		rawTx,
+		false,
+		"",
+	)
+}
+
+// SendRawTransactionWithOpts submits a raw encoded transaction as a byte array to the cluster for processing.
+func (cl *Client) SendRawTransactionWithOpts(
+	ctx context.Context,
+	rawTx []byte,
+	skipPreflight bool, // if true, skip the preflight transaction checks (default: false)
+	preflightCommitment CommitmentType, // optional; Commitment level to use for preflight (default: "finalized").
+) (signature solana.Signature, err error) {
 	return cl.SendEncodedTransactionWithOpts(
 		ctx,
 		base64.StdEncoding.EncodeToString(rawTx),
-		false,
-		"",
+		skipPreflight,
+		preflightCommitment,
 	)
 }

--- a/rpc/sendRawTransaction.go
+++ b/rpc/sendRawTransaction.go
@@ -1,0 +1,40 @@
+// Copyright 2021 github.com/gagliardetto
+// This file has been modified by github.com/gagliardetto
+//
+// Copyright 2020 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package rpc
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// SendRawTransaction submits a signed transaction to the cluster for processing.
+// The only difference between this function and SignTransaction is that the latter takes a *solana.Transaction value, as the former takes a transaction in wire format as a byte array
+func (cl *Client) SendRawTransaction(
+	ctx context.Context,
+	rawTx []byte,
+) (signature solana.Signature, err error) {
+	fmt.Println("SendRawTransaction: ", rawTx)
+	return cl.SendEncodedTransactionWithOpts(
+		ctx,
+		base64.StdEncoding.EncodeToString(rawTx),
+		false,
+		"",
+	)
+}

--- a/rpc/sendTransaction.go
+++ b/rpc/sendTransaction.go
@@ -73,22 +73,10 @@ func (cl *Client) SendTransactionWithOpts(
 		return solana.Signature{}, fmt.Errorf("send transaction: encode transaction: %w", err)
 	}
 
-	obj := M{
-		"encoding": "base64",
-	}
-
-	if skipPreflight {
-		obj["skipPreflight"] = skipPreflight
-	}
-	if preflightCommitment != "" {
-		obj["preflightCommitment"] = preflightCommitment
-	}
-
-	params := []interface{}{
+	return cl.SendEncodedTransactionWithOpts(
+		ctx,
 		base64.StdEncoding.EncodeToString(txData),
-		obj,
-	}
-
-	err = cl.rpcClient.CallForInto(ctx, &signature, "sendTransaction", params)
-	return
+		skipPreflight,
+		preflightCommitment,
+	)
 }


### PR DESCRIPTION
As discussed in https://github.com/gagliardetto/solana-go/issues/15, this PR implements two new functions for the `rpc.Client` struct:
- `SendRawTransaction`, that sends a transaction encoded in wire format as a bytes array, and
- `SendEncodedTransaction`, that sends a transaction encoded in wire format as a base64 string

Examples and tests were added to these functions as well