### PR TITLE
Feature/is blockhash valid

### DIFF
--- a/cmd/slnc/cmd/is_blockhash_valid.go
+++ b/cmd/slnc/cmd/is_blockhash_valid.go
@@ -1,8 +1,4 @@
 // Copyright 2021 github.com/gagliardetto
-// This file has been modified by github.com/gagliardetto
-//
-// Copyright 2020 dfuse Platform Inc.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/slnc/cmd/is_blockhash_valid.go
+++ b/cmd/slnc/cmd/is_blockhash_valid.go
@@ -1,0 +1,51 @@
+// Copyright 2021 github.com/gagliardetto
+// This file has been modified by github.com/gagliardetto
+//
+// Copyright 2020 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/spf13/cobra"
+)
+
+var isBlockhashValidCmd = &cobra.Command{
+	Use:   "isblockhashvalid {blockhash}",
+	Short: "Checks if a given blockhash is valid",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := getClient()
+
+		resp, err := client.IsBlockhashValid(
+			cmd.Context(),
+			solana.MustHashFromBase58(args[0]),
+			"",
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(resp.Value)
+
+		return nil
+	},
+}
+
+func init() {
+	getCmd.AddCommand(isBlockhashValidCmd)
+}

--- a/cmd/slnc/cmd/is_blockhash_valid.go
+++ b/cmd/slnc/cmd/is_blockhash_valid.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/rpc/examples/isBlockhashValid/isValidBlockhash.go
+++ b/rpc/examples/isBlockhashValid/isValidBlockhash.go
@@ -1,0 +1,42 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+func main() {
+	endpoint := rpc.MainNetBeta_RPC
+	client := rpc.New(endpoint)
+
+	blockHash := solana.MustHashFromBase58("krakeNd6ednDPEXxHAmoBs1qKVM8kLg79PvWF2mhXV1")
+	out, err := client.IsBlockhashValid(
+		context.TODO(),
+		blockHash,
+		rpc.CommitmentFinalized,
+	)
+	if err != nil {
+		panic(err)
+	}
+	spew.Dump(out)
+	spew.Dump(out.Value) // true or false
+
+	fmt.Println("is blockhash valid:", out.Value)
+}

--- a/rpc/isBlockhashValid.go
+++ b/rpc/isBlockhashValid.go
@@ -1,0 +1,24 @@
+package rpc
+
+import (
+	"context"
+	"github.com/gagliardetto/solana-go"
+)
+
+// IsBlockhashValid returns the balance of the account of provided publicKey.
+func (cl *Client) IsBlockhashValid(
+	ctx context.Context,
+	// Blockhash to be queried. Required.
+	blockHash solana.Hash,
+
+	// Commitment requirement. Optional.
+	commitment CommitmentType,
+) (out *IsValidBlockhashResult, err error) {
+	params := []interface{}{blockHash}
+	if commitment != "" {
+		params = append(params, M{"commitment": string(commitment)})
+	}
+
+	err = cl.rpcClient.CallForInto(ctx, &out, "isBlockhashValid", params)
+	return
+}

--- a/rpc/isBlockhashValid.go
+++ b/rpc/isBlockhashValid.go
@@ -6,6 +6,8 @@ import (
 )
 
 // IsBlockhashValid returns the balance of the account of provided publicKey.
+//
+// NEW: This method is only available in solana-core v1.9 or newer. Please use getFeeCalculatorForBlockhash for solana-core v1.8
 func (cl *Client) IsBlockhashValid(
 	ctx context.Context,
 	// Blockhash to be queried. Required.

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -200,6 +200,11 @@ type GetAccountInfoResult struct {
 	Value *Account `json:"value"`
 }
 
+type IsValidBlockhashResult struct {
+	RPCContext
+	Value bool `json:"value"`
+}
+
 type Account struct {
 	// Number of lamports assigned to this account
 	Lamports uint64 `json:"lamports"`


### PR DESCRIPTION
Adds the RPC call for [isBlockhashValid](https://docs.solana.com/developing/clients/jsonrpc-api#isblockhashvalid).

This feature will be available when Solana validators are upgraded to [1.9.0](https://github.com/solana-labs/solana/issues/21851). So we need to wait until they do. 