### PR TITLE
fix: Handle client.newRequest returning nil request

### DIFF
--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -447,7 +447,7 @@ func (client *rpcClient) newRequest(ctx context.Context, req interface{}) (*http
 
 	request, err := http.NewRequestWithContext(ctx, "POST", client.endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return request, err
 	}
 
 	request.Header.Set("Content-Type", "application/json")
@@ -514,10 +514,12 @@ func (client *rpcClient) doCallWithCallbackOnHTTPResponse(
 	RPCRequest *RPCRequest,
 	callback func(*http.Request, *http.Response) error,
 ) error {
-
 	httpRequest, err := client.newRequest(ctx, RPCRequest)
 	if err != nil {
-		return fmt.Errorf("rpc call %v() on %v: %v", RPCRequest.Method, httpRequest.URL.String(), err.Error())
+		if httpRequest != nil {
+			return fmt.Errorf("rpc call %v() on %v: %v", RPCRequest.Method, httpRequest.URL.String(), err.Error())
+		}
+		return fmt.Errorf("rpc call %v(): %v", RPCRequest.Method, err.Error())
 	}
 	httpResponse, err := client.httpClient.Do(httpRequest)
 	if err != nil {
@@ -531,7 +533,10 @@ func (client *rpcClient) doCallWithCallbackOnHTTPResponse(
 func (client *rpcClient) doBatchCall(ctx context.Context, rpcRequest []*RPCRequest) ([]*RPCResponse, error) {
 	httpRequest, err := client.newRequest(ctx, rpcRequest)
 	if err != nil {
-		return nil, fmt.Errorf("rpc batch call on %v: %v", httpRequest.URL.String(), err.Error())
+		if httpRequest != nil {
+			return nil, fmt.Errorf("rpc batch call on %v: %v", httpRequest.URL.String(), err.Error())
+		}
+		return nil, fmt.Errorf("rpc batch call: %v", err.Error())
 	}
 	httpResponse, err := client.httpClient.Do(httpRequest)
 	if err != nil {


### PR DESCRIPTION
Fixes this error:

    runtime/debug.Stack()
    	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
    golang.org/x/sync/singleflight.newPanicError({0x19069a0, 0x32c0130})
    	/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/singleflight/singleflight.go:35 +0x2c
    golang.org/x/sync/singleflight.(*Group).doCall.func2.1()
    	/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/singleflight/singleflight.go:188 +0x3b
    panic({0x19069a0, 0x32c0130})
    	/usr/local/go/src/runtime/panic.go:1038 +0x215
    github.com/gagliardetto/solana-go/rpc/jsonrpc.(*rpcClient).doCallWithCallbackOnHTTPResponse(0xc000528fa0, {0x2434ba0, 0xc000bb0ba0}, 0xc001aa78c0, 0xc0016115d8)
    	/go/pkg/mod/github.com/gagliardetto/solana-go@v1.0.2/rpc/jsonrpc/jsonrpc.go:520 +0x26c
    github.com/gagliardetto/solana-go/rpc/jsonrpc.(*rpcClient).doCall(0xc000471230, {0x2434ba0, 0xc000bb0ba0}, 0xc001aa78c0)
    	/go/pkg/mod/github.com/gagliardetto/solana-go@v1.0.2/rpc/jsonrpc/jsonrpc.go:470 +0x85
    github.com/gagliardetto/solana-go/rpc/jsonrpc.(*rpcClient).CallForInto(0xa, {0x2434ba0, 0xc000bb0ba0}, {0x181e280, 0xc0013fb740}, {0x1b88b10, 0x7}, {0xc000471230, 0x1, 0x1})
    	/go/pkg/mod/github.com/gagliardetto/solana-go@v1.0.2/rpc/jsonrpc/jsonrpc.go:367 +0x105
    github.com/gagliardetto/solana-go/rpc.(*Client).GetSlot(0xc00198f830, {0x2434ba0, 0xc000bb0ba0}, {0x1b8d677, 0x4107d4})
    	/go/pkg/mod/github.com/gagliardetto/solana-go@v1.0.2/rpc/getSlot.go:33 +0x177