### PR TITLE
Check for malformed responses in getAccountInfo/getMultipleAccounts

### DIFF
--- a/rpc/getAccountInfo.go
+++ b/rpc/getAccountInfo.go
@@ -124,7 +124,7 @@ func (cl *Client) GetAccountInfoWithOpts(
 	if err != nil {
 		return nil, err
 	}
-	if out.Value == nil {
+	if out == nil || out.Value == nil {
 		return nil, ErrNotFound
 	}
 

--- a/rpc/getMultipleAccounts.go
+++ b/rpc/getMultipleAccounts.go
@@ -74,7 +74,7 @@ func (cl *Client) GetMultipleAccountsWithOpts(
 	if err != nil {
 		return nil, err
 	}
-	if out.Value == nil {
+	if out == nil || out.Value == nil {
 		return nil, ErrNotFound
 	}
 	return


### PR DESCRIPTION
GetObject could unmarshal into nil which would cause a panic when referring to out.Value.

This is unlikely since a node will typically return well formed responses but still worth fixing.