### PR TITLE
fix: simulateTransaction response decoding

### DIFF
--- a/rpc/simulateTransaction.go
+++ b/rpc/simulateTransaction.go
@@ -25,6 +25,11 @@ import (
 )
 
 type SimulateTransactionResponse struct {
+	RPCContext
+	Value *SimulateTransactionResult `json:"value"`
+}
+
+type SimulateTransactionResult struct {
 	// Error if transaction failed, null if transaction succeeded.
 	Err interface{} `json:"err,omitempty"`
 


### PR DESCRIPTION
`simulateTransaction` response should decode from the typical structure
```
{
  "jsonrpc": "2.0",
  "result": {
    "context": [slot context],
    "value": [expected data]
  },
  "id": 1
}
```
https://docs.solana.com/developing/clients/jsonrpc-api#simulatetransaction