### PR TITLE
fix: base account should be optional in CreateAccountWithSeed

### DIFF
--- a/programs/system/CreateAccountWithSeed.go
+++ b/programs/system/CreateAccountWithSeed.go
@@ -119,7 +119,9 @@ func (inst *CreateAccountWithSeed) SetBaseAccount(baseAccount ag_solanago.Public
 
 func (inst *CreateAccountWithSeed) GetBaseAccount() *ag_solanago.AccountMeta {
 	if len(inst.AccountMetaSlice) <= 2 {
-		return nil
+		// Base account is optional. It may be the same as the funding account and provided as account 0.
+		// Ref: https://docs.rs/solana-program/1.10.8/solana_program/system_instruction/enum.SystemInstruction.html#variant.CreateAccountWithSeed
+		return inst.AccountMetaSlice[0]
 	}
 	return inst.AccountMetaSlice[2]
 }
@@ -197,11 +199,9 @@ func (inst *CreateAccountWithSeed) EncodeToTree(parent ag_treeout.Branches) {
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("Funding", inst.AccountMetaSlice[0]))
-						accountsBranch.Child(ag_format.Meta("Created", inst.AccountMetaSlice[1]))
-						if len(inst.AccountMetaSlice) > 2 {
-							accountsBranch.Child(ag_format.Meta("   Base", inst.AccountMetaSlice[2]))
-						}
+						accountsBranch.Child(ag_format.Meta("Funding", inst.GetFundingAccount()))
+						accountsBranch.Child(ag_format.Meta("Created", inst.GetCreatedAccount()))
+						accountsBranch.Child(ag_format.Meta("   Base", inst.GetBaseAccount()))
 					})
 				})
 		})

--- a/programs/system/CreateAccountWithSeed.go
+++ b/programs/system/CreateAccountWithSeed.go
@@ -199,7 +199,9 @@ func (inst *CreateAccountWithSeed) EncodeToTree(parent ag_treeout.Branches) {
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("Funding", inst.AccountMetaSlice[0]))
 						accountsBranch.Child(ag_format.Meta("Created", inst.AccountMetaSlice[1]))
-						accountsBranch.Child(ag_format.Meta("   Base", inst.AccountMetaSlice[2]))
+						if len(inst.AccountMetaSlice) > 2 {
+							accountsBranch.Child(ag_format.Meta("   Base", inst.AccountMetaSlice[2]))
+						}
 					})
 				})
 		})

--- a/programs/system/CreateAccountWithSeed.go
+++ b/programs/system/CreateAccountWithSeed.go
@@ -118,6 +118,9 @@ func (inst *CreateAccountWithSeed) SetBaseAccount(baseAccount ag_solanago.Public
 }
 
 func (inst *CreateAccountWithSeed) GetBaseAccount() *ag_solanago.AccountMeta {
+	if len(inst.AccountMetaSlice) <= 2 {
+		return nil
+	}
 	return inst.AccountMetaSlice[2]
 }
 

--- a/programs/system/CreateAccountWithSeed_test.go
+++ b/programs/system/CreateAccountWithSeed_test.go
@@ -92,5 +92,18 @@ func TestEncDec(t *testing.T) {
 			ag_require.NoError(t, err)
 			ag_require.Equal(t, instruction, got)
 		}
+
+		{
+			got := new(CreateAccountWithSeed)
+			err = decodeT(got, instr)
+			got.AccountMetaSlice = solana.AccountMetaSlice{
+				solana.Meta(payerAccount.PublicKey()).WRITE().SIGNER(),
+				solana.Meta(newSubAccount).WRITE(),
+			}
+			ag_require.NoError(t, err)
+			ag_require.Equal(t, got.AccountMetaSlice[0], got.GetFundingAccount())
+			ag_require.Equal(t, got.AccountMetaSlice[1], got.GetCreatedAccount())
+			ag_require.Nil(t, got.GetBaseAccount())
+		}
 	}
 }

--- a/programs/system/CreateAccountWithSeed_test.go
+++ b/programs/system/CreateAccountWithSeed_test.go
@@ -104,12 +104,11 @@ func TestEncDec(t *testing.T) {
 				solana.Meta(payerAccount.PublicKey()).WRITE().SIGNER(),
 				solana.Meta(newSubAccount).WRITE(),
 				// base account is optional
-				// ref: https://docs.rs/solana-program/1.10.8/solana_program/system_instruction/enum.SystemInstruction.html#variant.CreateAccountWithSeed
 			}
 			ag_require.NoError(t, err)
 			ag_require.Equal(t, got.AccountMetaSlice[0], got.GetFundingAccount())
 			ag_require.Equal(t, got.AccountMetaSlice[1], got.GetCreatedAccount())
-			ag_require.Nil(t, got.GetBaseAccount())
+			ag_require.Equal(t, got.AccountMetaSlice[0], got.GetBaseAccount())
 
 			got.EncodeToTree(text.NewTreeEncoder(ioutil.Discard, ""))
 		}

--- a/programs/system/CreateAccountWithSeed_test.go
+++ b/programs/system/CreateAccountWithSeed_test.go
@@ -16,12 +16,14 @@ package system
 
 import (
 	"bytes"
+	"io/ioutil"
 	"strconv"
 	"testing"
 
 	bin "github.com/gagliardetto/binary"
 	ag_gofuzz "github.com/gagliardetto/gofuzz"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/text"
 	ag_require "github.com/stretchr/testify/require"
 )
 
@@ -91,6 +93,8 @@ func TestEncDec(t *testing.T) {
 			}
 			ag_require.NoError(t, err)
 			ag_require.Equal(t, instruction, got)
+
+			got.EncodeToTree(text.NewTreeEncoder(ioutil.Discard, ""))
 		}
 
 		{
@@ -99,11 +103,15 @@ func TestEncDec(t *testing.T) {
 			got.AccountMetaSlice = solana.AccountMetaSlice{
 				solana.Meta(payerAccount.PublicKey()).WRITE().SIGNER(),
 				solana.Meta(newSubAccount).WRITE(),
+				// base account is optional
+				// ref: https://docs.rs/solana-program/1.10.8/solana_program/system_instruction/enum.SystemInstruction.html#variant.CreateAccountWithSeed
 			}
 			ag_require.NoError(t, err)
 			ag_require.Equal(t, got.AccountMetaSlice[0], got.GetFundingAccount())
 			ag_require.Equal(t, got.AccountMetaSlice[1], got.GetCreatedAccount())
 			ag_require.Nil(t, got.GetBaseAccount())
+
+			got.EncodeToTree(text.NewTreeEncoder(ioutil.Discard, ""))
 		}
 	}
 }


### PR DESCRIPTION
I ran into a panic while calling `GetBaseAccount` on a `CreateAccountWithSeed` instruction : `panic: runtime error: index out of range [2] with length 2`. The instruction was decoded using `solana.DecodeInstruction` with real Solana data.

Here's an example of offending transaction: https://explorer.solana.com/tx/2xsXsEtxAouk58aFJoPYRa2DtEHDbEmRBZn8JqvdiowvK1wjqSR4DZ7S2DU78nPziUf2FBoWb2SWxYXVosRZoVe3

Its instruction data has only two accounts:
```
{ProgramIDIndex:7 Accounts:[0 1] Data:Zfn8kcNjVTJHkHFvtLJgJFyLF9k9RmsaHPGsAxywnvkqMpejbQcBDSjRdRfzeURhXpwdrEXe7J8ZNRGshfekC7fxQmKzbo6G1mQnBa8QmKGLrgHkjpxserMziPZSbYPcUqFaT5AGJmZvspZGY16yC6VV}
```

According to the doc [here](https://docs.rs/solana-program/1.10.8/solana_program/system_instruction/enum.SystemInstruction.html#variant.CreateAccountWithSeed), the base account field should be optional.