### PR TITLE
Feature: added maxSupportedTransactionVersion field to getBlock opts

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -489,13 +489,15 @@ func TestClient_GetBlockWithOpts(t *testing.T) {
 
 	block := 33
 	rewards := true
+	maxSupportedTransactionVersion := uint64(0)
 	_, err := client.GetBlockWithOpts(
 		context.Background(),
 		uint64(block),
 		&GetBlockOpts{
-			TransactionDetails: TransactionDetailsSignatures,
-			Rewards:            &rewards,
-			Commitment:         CommitmentMax,
+			TransactionDetails:             TransactionDetailsSignatures,
+			Rewards:                        &rewards,
+			Commitment:                     CommitmentMax,
+			MaxSupportedTransactionVersion: &maxSupportedTransactionVersion,
 		},
 	)
 	require.NoError(t, err)
@@ -508,10 +510,11 @@ func TestClient_GetBlockWithOpts(t *testing.T) {
 			"params": []interface{}{
 				float64(block),
 				map[string]interface{}{
-					"encoding":           string(solana.EncodingBase64),
-					"transactionDetails": string(TransactionDetailsSignatures),
-					"rewards":            rewards,
-					"commitment":         string(CommitmentMax),
+					"encoding":                       string(solana.EncodingBase64),
+					"transactionDetails":             string(TransactionDetailsSignatures),
+					"rewards":                        rewards,
+					"commitment":                     string(CommitmentMax),
+					"maxSupportedTransactionVersion": float64(maxSupportedTransactionVersion),
 				},
 			},
 		},

--- a/rpc/getBlock.go
+++ b/rpc/getBlock.go
@@ -57,6 +57,10 @@ type GetBlockOpts struct {
 	//
 	// This parameter is optional.
 	Commitment CommitmentType
+
+	// Max transaction version to return in responses.
+	// If the requested block contains a transaction with a higher version, an error will be returned.
+	MaxSupportedTransactionVersion *uint64
 }
 
 // GetBlock returns identity and transaction information about a confirmed block in the ledger.
@@ -108,6 +112,9 @@ func (cl *Client) GetBlockWithOpts(
 				return nil, fmt.Errorf("provided encoding is not supported: %s", opts.Encoding)
 			}
 			obj["encoding"] = opts.Encoding
+		}
+		if opts.MaxSupportedTransactionVersion != nil {
+			obj["maxSupportedTransactionVersion"] = *opts.MaxSupportedTransactionVersion
 		}
 	}
 


### PR DESCRIPTION
Referenced to 
https://docs.solana.com/developing/clients/jsonrpc-api#getblock
https://github.com/solana-labs/solana/issues/25287#issuecomment-1129135910