### PR TITLE
Client close method

### DIFF
--- a/rpc/client-with-ratelimit.go
+++ b/rpc/client-with-ratelimit.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
@@ -49,7 +50,7 @@ func (wr *clientWithRateLimiting) CallWithCallback(
 
 // Close closes clientWithRateLimiting.
 func (cl *clientWithRateLimiting) Close() error {
-	if c, ok := cl.rpcClient.(closer); ok {
+	if c, ok := cl.rpcClient.(io.Closer); ok {
 		return c.Close()
 	}
 	return nil

--- a/rpc/client-with-ratelimit.go
+++ b/rpc/client-with-ratelimit.go
@@ -1,0 +1,56 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+	"go.uber.org/ratelimit"
+)
+
+var _ JSONRPCClient = &clientWithRateLimiting{}
+
+type clientWithRateLimiting struct {
+	rpcClient   jsonrpc.RPCClient
+	rateLimiter ratelimit.Limiter
+}
+
+// NewWithRateLimit creates a new rate-limitted Solana RPC client.
+func NewWithRateLimit(
+	rpcEndpoint string,
+	rps int, // requests per second
+) JSONRPCClient {
+	opts := &jsonrpc.RPCClientOpts{
+		HTTPClient: newHTTP(),
+	}
+
+	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts)
+
+	return &clientWithRateLimiting{
+		rpcClient:   rpcClient,
+		rateLimiter: ratelimit.New(rps),
+	}
+}
+
+func (wr *clientWithRateLimiting) CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error {
+	wr.rateLimiter.Take()
+	return wr.rpcClient.CallForInto(ctx, &out, method, params)
+}
+
+func (wr *clientWithRateLimiting) CallWithCallback(
+	ctx context.Context,
+	method string,
+	params []interface{},
+	callback func(*http.Request, *http.Response) error,
+) error {
+	wr.rateLimiter.Take()
+	return wr.rpcClient.CallWithCallback(ctx, method, params, callback)
+}
+
+// Close closes clientWithRateLimiting.
+func (cl *clientWithRateLimiting) Close() error {
+	if c, ok := cl.rpcClient.(closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -20,6 +20,7 @@ package rpc
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -42,10 +43,6 @@ type JSONRPCClient interface {
 	CallWithCallback(ctx context.Context, method string, params []interface{}, callback func(*http.Request, *http.Response) error) error
 }
 
-type closer interface {
-	Close() error
-}
-
 // New creates a new Solana JSON RPC client.
 // Client is safe for concurrent use by multiple goroutines.
 func New(rpcEndpoint string) *Client {
@@ -59,7 +56,10 @@ func New(rpcEndpoint string) *Client {
 
 // Close closes the client.
 func (cl *Client) Close() error {
-	if c, ok := cl.rpcClient.(closer); ok {
+	if cl.rpcClient == nil {
+		return nil
+	}
+	if c, ok := cl.rpcClient.(io.Closer); ok {
 		return c.Close()
 	}
 	return nil

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 	"github.com/klauspost/compress/gzhttp"
-	"go.uber.org/ratelimit"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -43,13 +42,27 @@ type JSONRPCClient interface {
 	CallWithCallback(ctx context.Context, method string, params []interface{}, callback func(*http.Request, *http.Response) error) error
 }
 
+type closer interface {
+	Close() error
+}
+
 // New creates a new Solana JSON RPC client.
+// Client is safe for concurrent use by multiple goroutines.
 func New(rpcEndpoint string) *Client {
 	opts := &jsonrpc.RPCClientOpts{
 		HTTPClient: newHTTP(),
 	}
+
 	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts)
 	return NewWithCustomRPCClient(rpcClient)
+}
+
+// Close closes the client.
+func (cl *Client) Close() error {
+	if c, ok := cl.rpcClient.(closer); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 // NewWithCustomRPCClient creates a new Solana RPC client
@@ -57,45 +70,6 @@ func New(rpcEndpoint string) *Client {
 func NewWithCustomRPCClient(rpcClient JSONRPCClient) *Client {
 	return &Client{
 		rpcClient: rpcClient,
-	}
-}
-
-var _ JSONRPCClient = &clientWithRateLimiting{}
-
-type clientWithRateLimiting struct {
-	rpcClient   jsonrpc.RPCClient
-	rateLimiter ratelimit.Limiter
-}
-
-func (wr *clientWithRateLimiting) CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error {
-	wr.rateLimiter.Take()
-	return wr.rpcClient.CallForInto(ctx, &out, method, params)
-}
-
-func (wr *clientWithRateLimiting) CallWithCallback(
-	ctx context.Context,
-	method string,
-	params []interface{},
-	callback func(*http.Request, *http.Response) error,
-) error {
-	wr.rateLimiter.Take()
-	return wr.rpcClient.CallWithCallback(ctx, method, params, callback)
-}
-
-// NewWithRateLimit creates a new rate-limitted Solana RPC client.
-func NewWithRateLimit(
-	rpcEndpoint string,
-	rps int, // requests per second
-) JSONRPCClient {
-	opts := &jsonrpc.RPCClientOpts{
-		HTTPClient: newHTTP(),
-	}
-
-	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts)
-
-	return &clientWithRateLimiting{
-		rpcClient:   rpcClient,
-		rateLimiter: ratelimit.New(rps),
 	}
 }
 

--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -120,6 +120,7 @@ type RPCClient interface {
 
 	CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error
 	CallWithCallback(ctx context.Context, method string, params []interface{}, callback func(*http.Request, *http.Response) error) error
+	Close() error
 }
 
 // RPCRequest represents a JSON-RPC request object.
@@ -237,6 +238,7 @@ type HTTPError struct {
 // HTTPClient is an abstraction for a HTTP client
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
+	CloseIdleConnections()
 }
 
 func NewHTTPError(code int, err error) *HTTPError {
@@ -351,6 +353,13 @@ func (client *rpcClient) Call(ctx context.Context, method string, params ...inte
 	}
 
 	return client.doCall(ctx, request)
+}
+
+func (client *rpcClient) Close() error {
+	if client.httpClient != nil {
+		client.httpClient.CloseIdleConnections()
+	}
+	return nil
 }
 
 func (client *rpcClient) CallForInto(


### PR DESCRIPTION
This PR adds a `Close() error` method to the RPC client.

The closing logic calls `CloseIdleConnections` on the HTTP client.

Closes #79 

@leoluk 