### PR TITLE
Implement MarshalText for Hash, Signature

### DIFF
--- a/nativetype_test.go
+++ b/nativetype_test.go
@@ -30,6 +30,18 @@ func TestMustHashFromBase58(t *testing.T) {
 	})
 }
 
+func TestHash_UnmarshalText(t *testing.T) {
+	in := MustHashFromBase58("uoEAQCWCKjV9ecsBvngctJ7upNBZX7hpN4SfdR6TaUz")
+
+	out, err := in.MarshalText()
+	assert.NoError(t, err)
+
+	var ha Hash
+	err = ha.UnmarshalText(out)
+	assert.NoError(t, err)
+	assert.Equal(t, in, ha)
+}
+
 func TestHashFromBase58(t *testing.T) {
 	in := "uoEAQCWCKjV9ecsBvngctJ7upNBZX7hpN4SfdR6TaUz"
 	out, err := HashFromBase58(in)
@@ -48,6 +60,18 @@ func TestHashFromBase58(t *testing.T) {
 	assert.True(t, out.Equals(ha))
 	assert.False(t, out.Equals(Hash{}))
 	assert.False(t, out.IsZero())
+}
+
+func TestSignature_UnmarshalText(t *testing.T) {
+	in := MustSignatureFromBase58("gD3jeeaPNiyuJvTKXNEv1gntazWEkvpocofEmrz2rL6Fi4prWSsBH6a9SrwyZEatAozyMsnK2fnk3APXNFxD2Mq")
+
+	out, err := in.MarshalText()
+	assert.NoError(t, err)
+
+	var sig Signature
+	err = sig.UnmarshalText(out)
+	assert.NoError(t, err)
+	assert.Equal(t, in, sig)
 }
 
 func TestSignatureFromBase58(t *testing.T) {

--- a/nativetypes.go
+++ b/nativetypes.go
@@ -48,6 +48,20 @@ func HashFromBytes(in []byte) Hash {
 	return Hash(PublicKeyFromBytes(in))
 }
 
+func (ha Hash) MarshalText() ([]byte, error) {
+	s := base58.Encode(ha[:])
+	return []byte(s), nil
+}
+
+func (ha *Hash) UnmarshalText(data []byte) (err error) {
+	tmp, err := HashFromBase58(string(data))
+	if err != nil {
+		return fmt.Errorf("invalid hash %q: %w", string(data), err)
+	}
+	*ha = tmp
+	return
+}
+
 func (ha Hash) MarshalJSON() ([]byte, error) {
 	return json.Marshal(base58.Encode(ha[:]))
 }
@@ -58,11 +72,11 @@ func (ha *Hash) UnmarshalJSON(data []byte) (err error) {
 		return err
 	}
 
-	tmp, err := PublicKeyFromBase58(s)
+	tmp, err := HashFromBase58(s)
 	if err != nil {
-		return fmt.Errorf("invalid public key %q: %w", s, err)
+		return fmt.Errorf("invalid hash %q: %w", s, err)
 	}
-	*ha = Hash(tmp)
+	*ha = tmp
 	return
 }
 
@@ -125,6 +139,20 @@ func SignatureFromBytes(in []byte) (out Signature) {
 	}
 
 	copy(out[:], in[0:max])
+	return
+}
+
+func (p Signature) MarshalText() ([]byte, error) {
+	s := base58.Encode(p[:])
+	return []byte(s), nil
+}
+
+func (p *Signature) UnmarshalText(data []byte) (err error) {
+	tmp, err := SignatureFromBase58(string(data))
+	if err != nil {
+		return fmt.Errorf("invalid signature %q: %w", string(data), err)
+	}
+	*p = tmp
 	return
 }
 


### PR DESCRIPTION
Same as #42

This time for YAML, which requires `MarshalText` instead of `MarshalJSON`