### PR TITLE
Feature: Add get parsed transaction

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2068,7 +2068,7 @@ func TestClient_GetTransaction(t *testing.T) {
 			"params": []interface{}{
 				tx,
 				map[string]interface{}{
-					"encoding":   string(solana.EncodingBase64),
+					"encoding":   string(solana.EncodingJSONParsed),
 					"commitment": string(CommitmentMax),
 				},
 			},
@@ -2082,7 +2082,7 @@ func TestClient_GetTransaction(t *testing.T) {
 		Slot:      83311386,
 		BlockTime: &blockTime,
 		Transaction: &TransactionResultEnvelope{
-			asParsedTransaction: &ParsedTransaction{
+			asParsedTransaction: &CompiledTransaction{
 				Signatures: []solana.Signature{
 					solana.MustSignatureFromBase58("QPzWhnwHnCwk3nj1zVCcjz1VP7EcAKouPg9Joietje3GnQTVQ5XyWxyPC3zHby8K5ahSn9SbQupauDbVRvv5DuL"),
 				},
@@ -2095,7 +2095,7 @@ func TestClient_GetTransaction(t *testing.T) {
 						solana.MustPublicKeyFromBase58("Vote111111111111111111111111111111111111111"),
 					},
 					RecentBlockhash: solana.MustHashFromBase58("6o9C27iJ5rPi7wEpvQu1cFbB1WnRudtsPnbY8GvFWrgR"),
-					Instructions: []ParsedInstruction{
+					Instructions: []CompiledInstruction{
 						{
 							Accounts: []int64{
 								1,
@@ -2149,6 +2149,60 @@ func TestClient_GetTransaction(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, out, "both deserialized values must be equal")
+}
+
+func TestClient_GetParsedTransaction(t *testing.T) {
+	responseBody := `{"blockTime":1660570006,"meta":{"err":null,"fee":10000,"innerInstructions":[{"index":2,"instructions":[{"parsed":{"info":{"account":"BMnsyyG6S6zkaE3K5X3nbRMKdvBS5dT6HhcMozBVL7Ly","amount":"47444666","authority":"7oPa2PHQdZmjSPqvpZN7MQxnC7Dcf3uL4oLqknGLk2S3","mint":"E942z7FnS7GpswTvF5Vggvo7cMTbvZojjLbFgsrDVff1"},"type":"burn"},"program":"spl-token","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},{"parsed":{"info":{"destination":"9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxeintHy","lamports":100,"source":"G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo"},"type":"transfer"},"program":"system","programId":"11111111111111111111111111111111"},{"accounts":["2yVjuQwpsvdsrywzsJJVs9Ueh4zayyo5DYJbBNc3DDpn","3KEmPDRc6WEvhomG8awhfv2k33HgeqfGJmE1dptFmzhR"],"data":"2Af7uakYAFq8MGzDZQhLpcgRrAP9WHnAaA61z8nFafM8rFGNsKkksFcD6dDnAebHD6LCZBXqP6iyo8mX8XnteCsiEagZSqRLbe1QTRBpzZmwtFBVwY4SLyqBMxXKX35SM7zKVA7GYiTa2UDCaDvqQ3SQdHvRNaF5AED3HcJpYC1eFGhPpSjESVZHPN2rYYZXwma","programId":"worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"}]}],"loadedAddresses":{"readonly":[],"writable":[]},"logMessages":["Program 11111111111111111111111111111111 invoke [1]","Program 11111111111111111111111111111111 success"],"postBalances":[72226420],"postTokenBalances":[{"accountIndex":4,"mint":"E942z7FnS7GpswTvF5Vggvo7cMTbvZojjLbFgsrDVff1","owner":"G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","uiTokenAmount":{"amount":"0","decimals":6,"uiAmount":null,"uiAmountString":"0"}}],"preBalances":[74714380],"preTokenBalances":[{"accountIndex":4,"mint":"E942z7FnS7GpswTvF5Vggvo7cMTbvZojjLbFgsrDVff1","owner":"G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","uiTokenAmount":{"amount":"47444666","decimals":6,"uiAmount":47.444666,"uiAmountString":"47.444666"}}],"rewards":[],"status":{"Ok":null}},"slot":146099091,"transaction":{"message":{"accountKeys":[{"pubkey":"G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo","signer":true,"writable":true}],"addressTableLookups":null,"instructions":[{"parsed":{"info":{"destination":"9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxeintHy","lamports":100,"source":"G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo"},"type":"transfer"},"program":"system","programId":"11111111111111111111111111111111"},{"parsed":{"info":{"amount":"47444666","delegate":"7oPa2PHQdZmjSPqvpZN7MQxnC7Dcf3uL4oLqknGLk2S3","owner":"G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo","source":"BMnsyyG6S6zkaE3K5X3nbRMKdvBS5dT6HhcMozBVL7Ly"},"type":"approve"},"program":"spl-token","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},{"accounts":["G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo"],"data":"2dmnzvSCNoP8bNbUnUtk7FTYod5czhUfk4E7LSPNMtK4V1FHgQVYeQ2GnsEtCKZCyLLHXvnkReP","programId":"wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb"}],"recentBlockhash":"9L8FEB81LfZ67ejxpMaaZmC9EmXBpV38dhNaiF9UbzZi"},"signatures":["2x1QBpfcEQetAx7zETLEmvVvjue9311s9AWroEvMAboFkqaHZVp1sUpTFXroc5Q6tkPmZK5pYfmPFteoZPVRLF89"]}}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	tx := "KBVcTWwgEhVzwywtunhAXRKjXYYEdPcSCpuEkg484tiE3dFGzHDu9LKKH23uBMdfYt3JCPHeaVeDTZWecboyTrd"
+
+	opts := GetParsedTransactionOpts{
+		Commitment: CommitmentMax,
+	}
+	out, err := client.GetParsedTransaction(
+		context.Background(),
+		solana.MustSignatureFromBase58(tx),
+		&opts,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		map[string]interface{}{
+			"id":      float64(0),
+			"jsonrpc": "2.0",
+			"method":  "getTransaction",
+			"params": []interface{}{
+				tx,
+				map[string]interface{}{
+					"encoding":   string(solana.EncodingJSONParsed),
+					"commitment": string(CommitmentMax),
+				},
+			},
+		},
+		server.RequestBody(t),
+	)
+
+	assert.Equal(t, uint64(2), out.Meta.InnerInstructions[0].Index)
+	assert.Equal(t, &InstructionInfo{
+		Info: map[string]interface{}{
+			"account":   "BMnsyyG6S6zkaE3K5X3nbRMKdvBS5dT6HhcMozBVL7Ly",
+			"amount":    "47444666",
+			"authority": "7oPa2PHQdZmjSPqvpZN7MQxnC7Dcf3uL4oLqknGLk2S3",
+			"mint":      "E942z7FnS7GpswTvF5Vggvo7cMTbvZojjLbFgsrDVff1",
+		},
+		InstructionType: "burn",
+	}, out.Meta.InnerInstructions[0].Instructions[0].Parsed.asInstructionInfo)
+	assert.Equal(t, &InstructionInfo{
+		Info: map[string]interface{}{
+			"destination": "9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxeintHy",
+			"lamports":    float64(100),
+			"source":      "G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo",
+		},
+		InstructionType: "transfer",
+	}, out.Transaction.Message.Instructions[0].Parsed.asInstructionInfo)
 }
 
 func TestClient_GetTransactionCount(t *testing.T) {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2068,7 +2068,7 @@ func TestClient_GetTransaction(t *testing.T) {
 			"params": []interface{}{
 				tx,
 				map[string]interface{}{
-					"encoding":   string(solana.EncodingJSONParsed),
+					"encoding":   string(solana.EncodingBase64),
 					"commitment": string(CommitmentMax),
 				},
 			},

--- a/rpc/getParsedTransaction.go
+++ b/rpc/getParsedTransaction.go
@@ -1,0 +1,162 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+)
+
+type GetParsedTransactionOpts struct {
+	Commitment CommitmentType `json:"commitment,omitempty"`
+}
+
+type GetParsedTransactionResult struct {
+	Slot        uint64
+	BlockTime   *solana.UnixTimeSeconds
+	Transaction *ParsedTransaction
+	Meta        *ParsedTransactionMeta
+}
+
+func (cl *Client) GetParsedTransaction(
+	ctx context.Context,
+	txSig solana.Signature,
+	opts *GetParsedTransactionOpts,
+) (out *GetParsedTransactionResult, err error) {
+	params := []interface{}{txSig}
+	obj := M{}
+	if opts != nil {
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+	}
+	obj["encoding"] = solana.EncodingJSONParsed
+	params = append(params, obj)
+	err = cl.rpcClient.CallForInto(ctx, &out, "getTransaction", params)
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, ErrNotFound
+	}
+	return
+}
+
+func (wrap InstructionInfoEnvelope) MarshalJSON() ([]byte, error) {
+	if wrap.asString != "" {
+		return json.Marshal(wrap.asString)
+	}
+	return json.Marshal(wrap.asInstructionInfo)
+}
+
+func (wrap *InstructionInfoEnvelope) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || (len(data) == 4 && string(data) == "null") {
+		// TODO: is this an error?
+		return nil
+	}
+
+	firstChar := data[0]
+
+	switch firstChar {
+	// Check if first character is `[`, standing for a JSON array.
+	case '"':
+		// It's base64 (or similar)
+		{
+			err := json.Unmarshal(data, &wrap.asString)
+			if err != nil {
+				return err
+			}
+		}
+	case '{':
+		// It's JSON, most likely.
+		{
+			return json.Unmarshal(data, &wrap.asInstructionInfo)
+		}
+	default:
+		return fmt.Errorf("Unknown kind: %v", data)
+	}
+
+	return nil
+}
+
+func (obj GetParsedTransactionResult) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	err = encoder.WriteUint64(obj.Slot, bin.LE)
+	if err != nil {
+		return err
+	}
+	{
+		if obj.BlockTime == nil {
+			err = encoder.WriteBool(false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteBool(true)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteInt64(int64(*obj.BlockTime), bin.LE)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	{
+		if obj.Transaction == nil {
+			err = encoder.WriteBool(false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteBool(true)
+			if err != nil {
+				return err
+			}
+			err = encoder.Encode(obj.Transaction)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (obj GetParsedTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	// Deserialize `Slot`:
+	obj.Slot, err = decoder.ReadUint64(bin.LE)
+	if err != nil {
+		return err
+	}
+	// Deserialize `BlockTime` (optional):
+	{
+		ok, err := decoder.ReadBool()
+		if err != nil {
+			return err
+		}
+		if ok {
+			err = decoder.Decode(&obj.BlockTime)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	{
+		ok, err := decoder.ReadBool()
+		if err != nil {
+			return err
+		}
+		if ok {
+			// NOTE: storing as JSON bytes:
+			buf, err := decoder.ReadByteSlice()
+			if err != nil {
+				return err
+			}
+			err = json.Unmarshal(buf, &obj.Transaction)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -46,7 +46,7 @@ func (cl *Client) GetTransaction(
 				opts.Encoding,
 				// Valid encodings:
 				// solana.EncodingJSON, // TODO
-				//solana.EncodingJSONParsed, // TODO
+				// solana.EncodingJSONParsed, // TODO
 				solana.EncodingBase58,
 				solana.EncodingBase64,
 				solana.EncodingBase64Zstd,

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -46,7 +46,7 @@ func (cl *Client) GetTransaction(
 				opts.Encoding,
 				// Valid encodings:
 				// solana.EncodingJSON, // TODO
-				// solana.EncodingJSONParsed, // TODO
+				//solana.EncodingJSONParsed, // TODO
 				solana.EncodingBase58,
 				solana.EncodingBase64,
 				solana.EncodingBase64Zstd,
@@ -85,12 +85,12 @@ type GetTransactionResult struct {
 	Meta        *TransactionMeta           `json:"meta,omitempty" bin:"optional"`
 }
 
-// TransactionResultEnvelope will contain a *ParsedTransaction if the requested encoding is `solana.EncodingJSON`
+// TransactionResultEnvelope will contain a *CompiledTransaction if the requested encoding is `solana.EncodingJSON`
 // (which is also the default when the encoding is not specified),
 // or a `solana.Data` in case of EncodingBase58, EncodingBase64.
 type TransactionResultEnvelope struct {
 	asDecodedBinary     solana.Data
-	asParsedTransaction *ParsedTransaction
+	asParsedTransaction *CompiledTransaction
 }
 
 func (wrap TransactionResultEnvelope) MarshalJSON() ([]byte, error) {
@@ -140,9 +140,9 @@ func (dt *TransactionResultEnvelope) GetData() solana.Data {
 	return dt.asDecodedBinary
 }
 
-// GetRawJSON returns a *ParsedTransaction when the data
+// GetRawJSON returns a *CompiledTransaction when the data
 // encoding is EncodingJSON.
-func (dt *TransactionResultEnvelope) GetParsedTransaction() *ParsedTransaction {
+func (dt *TransactionResultEnvelope) GetParsedTransaction() *CompiledTransaction {
 	return dt.asParsedTransaction
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -469,7 +469,7 @@ type ParsedInstruction struct {
 	Program   string                   `json:"program,omitempty"`
 	ProgramId solana.PublicKey         `json:"programId,omitempty"`
 	Parsed    *InstructionInfoEnvelope `json:"parsed,omitempty"`
-	Data      string                   `json:"data,omitempty"`
+	Data      solana.Base58            `json:"data,omitempty"`
 	Accounts  []solana.PublicKey       `json:"accounts,omitempty"`
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -190,12 +190,7 @@ type InnerInstruction struct {
 	Index uint16 `json:"index"`
 
 	// Ordered list of inner program instructions that were invoked during a single transaction instruction.
-	Instructions []CompiledInstructionEnvelope `json:"instructions"`
-}
-
-type CompiledInstructionEnvelope struct {
-	asCompiledInstruction solana.CompiledInstruction
-	asParsedInstruction   *CompiledInstruction
+	Instructions []CompiledInstruction `json:"instructions"`
 }
 
 // 	Ok  interface{} `json:"Ok"`  // <null> Transaction was successful
@@ -468,17 +463,6 @@ type ParsedMessage struct {
 	AccountKeys     []ParsedMessageAccount `json:"accountKeys"`
 	Instructions    []*ParsedInstruction   `json:"instructions"`
 	RecentBlockHash string                 `json:"recentBlockhash"`
-}
-
-type ParsedInstructionEnvelope struct {
-	asParsedInstruction           *ParsedInstruction
-	asPartiallyDecodedInstruction *PartiallyDecodedInstruction
-}
-
-type PartiallyDecodedInstruction struct {
-	ProgramId solana.PublicKey   `json:"programId"`
-	Accounts  []solana.PublicKey `json:"accounts"`
-	Data      string             `json:"data"`
 }
 
 type ParsedInstruction struct {


### PR DESCRIPTION
Add a new RPC method: `getParsedTransaction` which returns parsed accounts & transactions & inner transactions.

It directly call the `GetTransaction` method with `encoding.jsonparsed`