### PR TITLE
Support partial sign & marshal binary of partial signed transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -402,7 +402,7 @@ func (tx *Transaction) Sign(getter privateKeyGetter) (out []Signature, err error
 	signerKeys := tx.Message.signerKeys()
 	for _, key := range signerKeys {
 		if getter(key) == nil {
-			return nil, fmt.Errorf("failed to signed with key %q: %w", key.String(), err)
+			return nil, fmt.Errorf("signer key %q not found. Ensure all the signer keys are in the vault", key.String())
 		}
 	}
 	return tx.PartialSign(getter)


### PR DESCRIPTION
Hi, 

I recently added some features to my forked repo and need to contribute back to the origin repo. 
**All features including**
- feat: added `PartialSign` along with `Sign` transaction
- fix: new signed signatures are only added on success to prevent unwanted signatures stacking on failed cases (https://github.com/imalic3/solana-go/blob/feature/partial_sign/transaction.go#L397)
- remove a `signature verification checked` while marshal binary which will be available to marshal partial-signed transaction.
- tests: added partial sign and sign tests

Thanks for your awesome work 
