### PR TITLE
serum: return error when iterating orderbook Items

### DIFF
--- a/programs/serum/types.go
+++ b/programs/serum/types.go
@@ -145,7 +145,9 @@ func (o *Orderbook) Items(descending bool, f func(node *SlabLeafNode) error) err
 			if traceEnabled {
 				zlog.Debug("found leaf", zap.Int("leaf", int(index)))
 			}
-			f(s)
+			if err := f(s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
The error returned by the Items() callback function is currently ignored. Return the error if non-nil.