### PR TITLE
added maxSupportedTransactionVersion field to getTransaction opts

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2049,9 +2049,11 @@ func TestClient_GetTransaction(t *testing.T) {
 
 	tx := "KBVcTWwgEhVzwywtunhAXRKjXYYEdPcSCpuEkg484tiE3dFGzHDu9LKKH23uBMdfYt3JCPHeaVeDTZWecboyTrd"
 
+	maxSupportedTransactionVersion := uint64(0)
 	opts := GetTransactionOpts{
-		Encoding:   solana.EncodingBase64,
-		Commitment: CommitmentMax,
+		Encoding:                       solana.EncodingBase64,
+		Commitment:                     CommitmentMax,
+		MaxSupportedTransactionVersion: &maxSupportedTransactionVersion,
 	}
 	out, err := client.GetTransaction(
 		context.Background(),
@@ -2068,8 +2070,9 @@ func TestClient_GetTransaction(t *testing.T) {
 			"params": []interface{}{
 				tx,
 				map[string]interface{}{
-					"encoding":   string(solana.EncodingBase64),
-					"commitment": string(CommitmentMax),
+					"encoding":                       string(solana.EncodingBase64),
+					"commitment":                     string(CommitmentMax),
+					"maxSupportedTransactionVersion": float64(maxSupportedTransactionVersion),
 				},
 			},
 		},

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -27,6 +27,10 @@ type GetTransactionOpts struct {
 
 	// Desired commitment. "processed" is not supported. If parameter not provided, the default is "finalized".
 	Commitment CommitmentType `json:"commitment,omitempty"`
+
+	// Max transaction version to return in responses.
+	// If the requested block contains a transaction with a higher version, an error will be returned.
+	MaxSupportedTransactionVersion *uint64
 }
 
 // GetTransaction returns transaction details for a confirmed transaction.
@@ -57,6 +61,9 @@ func (cl *Client) GetTransaction(
 		}
 		if opts.Commitment != "" {
 			obj["commitment"] = opts.Commitment
+		}
+		if opts.MaxSupportedTransactionVersion != nil {
+			obj["maxSupportedTransactionVersion"] = *opts.MaxSupportedTransactionVersion
 		}
 		if len(obj) > 0 {
 			params = append(params, obj)


### PR DESCRIPTION
https://docs.solana.com/developing/clients/jsonrpc-api#gettransaction https://twitter.com/solana_devs/status/1571964879271067655?s=12&t=n3v_ka9QXdVqMTXewDMlAg