### PR TITLE
read transaction version from response

### DIFF
--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -90,6 +90,7 @@ type GetTransactionResult struct {
 
 	Transaction *TransactionResultEnvelope `json:"transaction" bin:"optional"`
 	Meta        *TransactionMeta           `json:"meta,omitempty" bin:"optional"`
+	Version     TransactionVersion         `json:"version"`
 }
 
 // TransactionResultEnvelope will contain a *CompiledTransaction if the requested encoding is `solana.EncodingJSON`

--- a/rpc/transaction_version.go
+++ b/rpc/transaction_version.go
@@ -1,0 +1,34 @@
+package rpc
+
+import "strconv"
+
+type TransactionVersion int
+
+const (
+	LegacyTransactionVersion TransactionVersion = -1
+	legacyVersion                               = `"legacy"`
+)
+
+func (a *TransactionVersion) UnmarshalJSON(b []byte) error {
+	// Ignore null, like in the main JSON package.
+	s := string(b)
+	if s == "null" || s == `""` || s == legacyVersion {
+		*a = LegacyTransactionVersion
+		return nil
+	}
+
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+	*a = TransactionVersion(v)
+	return nil
+}
+
+func (a TransactionVersion) MarshalJSON() ([]byte, error) {
+	if a == LegacyTransactionVersion {
+		return []byte(legacyVersion), nil
+	} else {
+		return []byte(strconv.Itoa(int(a))), nil
+	}
+}

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -97,7 +97,8 @@ const (
 type TransactionWithMeta struct {
 	Transaction *DataBytesOrJSON `json:"transaction"`
 	// Transaction status metadata object
-	Meta *TransactionMeta `json:"meta,omitempty"`
+	Meta    *TransactionMeta   `json:"meta,omitempty"`
+	Version TransactionVersion `json:"version"`
 }
 
 func (twm TransactionWithMeta) MustGetTransaction() *solana.Transaction {


### PR DESCRIPTION
we should be able to replace https://github.com/gagliardetto/solana-go/blob/main/message.go#L68 with version in the response

https://docs.solana.com/developing/clients/jsonrpc-api#results-43

