### PR TITLE
add new GetAccountInfoWithRpcContext method

### DIFF
--- a/rpc/getAccountInfo.go
+++ b/rpc/getAccountInfo.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -94,6 +94,21 @@ func (cl *Client) GetAccountInfoWithOpts(
 	ctx context.Context,
 	account solana.PublicKey,
 	opts *GetAccountInfoOpts,
+) (*GetAccountInfoResult, error) {
+	out, err := cl.getAccountInfoWithOpts(ctx, account, opts)
+	if err != nil {
+		return nil, err
+	}
+	if out.Value == nil {
+		return nil, ErrNotFound
+	}
+	return out, nil
+}
+
+func (cl *Client) getAccountInfoWithOpts(
+	ctx context.Context,
+	account solana.PublicKey,
+	opts *GetAccountInfoOpts,
 ) (out *GetAccountInfoResult, err error) {
 
 	obj := M{
@@ -134,9 +149,5 @@ func (cl *Client) GetAccountInfoWithOpts(
 	if out == nil {
 		return nil, errors.New("expected a value, got null result")
 	}
-	if out.Value == nil {
-		return nil, ErrNotFound
-	}
-
 	return out, nil
 }

--- a/rpc/getAccountInfoWithRpcContext.go
+++ b/rpc/getAccountInfoWithRpcContext.go
@@ -1,0 +1,36 @@
+// Copyright 2021 github.com/gagliardetto
+// This file has been modified by github.com/gagliardetto
+//
+// Copyright 2020 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package rpc
+
+import (
+	"context"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// GetAccountInfoWithRpcContext is similar to GetAccountInfoWithOpts but will return rpcContext and nil account if account is not found
+func (cl *Client) GetAccountInfoWithRpcContext(
+	ctx context.Context,
+	account solana.PublicKey,
+	opts *GetAccountInfoOpts,
+) (*Account, *RPCContext, error) {
+	out, err := cl.getAccountInfoWithOpts(ctx, account, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out.Value, &out.RPCContext, nil
+}


### PR DESCRIPTION
that always returns RpcContext event if account is not found, 

otherwise the existing GetAccountInfo just returns a notFound error if account is not found so we are not able to get the slot from the response

alternatively, we can decorate the existing ErrNotFound with RpcContext.. but that may break alot of existing clients

and explicitly not returning error seems to make the most sense

what are your thoughts?

thanks