### PR TITLE
feat: add support for getRecentPrioritizationFees RPC method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2256,6 +2256,7 @@ import (
   "context"
 
   "github.com/davecgh/go-spew/spew"
+  "github.com/gagliardetto/solana-go"
   "github.com/gagliardetto/solana-go/rpc"
 )
 
@@ -2267,7 +2268,7 @@ func main() {
     context.TODO(),
     []solana.PublicKey{
       solana.MustPublicKeyFromBase58("q5BgreVhTyBH1QCeriVb7kQYEPneanFXPLjvyjdf8M3"),
-    }
+    },
   )
   if err != nil {
     panic(err)

--- a/README.md
+++ b/README.md
@@ -872,6 +872,7 @@ func main() {
     - To be used with **solana v1.8**
     - For solana v1.9 or newer: **DEPRECATED: Please use [GetLatestBlockhash](#index--rpc--getlatestblockhash) instead** (This method is expected to be removed in **solana-core v2.0**)
   - [GetRecentPerformanceSamples](#index--rpc--getrecentperformancesamples)
+  - [GetRecentPrioritizationFees](#index--rpc--getrecentprioritizationfees)
   - [GetSignatureStatuses](#index--rpc--getsignaturestatuses)
   - [GetSignaturesForAddress](#index--rpc--getsignaturesforaddress)
   - [GetSlot](#index--rpc--getslot)
@@ -2218,7 +2219,6 @@ func main() {
   spew.Dump(recent)
 }
 ```
-
 #### [index](#contents) > [RPC](#rpc-methods) > GetRecentPerformanceSamples
 
 ```go
@@ -2239,6 +2239,35 @@ func main() {
   out, err := client.GetRecentPerformanceSamples(
     context.TODO(),
     &limit,
+  )
+  if err != nil {
+    panic(err)
+  }
+  spew.Dump(out)
+}
+```
+
+#### [index](#contents) > [RPC](#rpc-methods) > GetRecentPrioritizationFees
+
+```go
+package main
+
+import (
+  "context"
+
+  "github.com/davecgh/go-spew/spew"
+  "github.com/gagliardetto/solana-go/rpc"
+)
+
+func main() {
+  endpoint := rpc.TestNet_RPC
+  client := rpc.New(endpoint)
+
+  out, err := client.GetRecentPrioritizationFees(
+    context.TODO(),
+    []solana.PublicKey{
+      solana.MustPublicKeyFromBase58("q5BgreVhTyBH1QCeriVb7kQYEPneanFXPLjvyjdf8M3"),
+    }
   )
   if err != nil {
     panic(err)

--- a/rpc/getRecentPrioritizationFees.go
+++ b/rpc/getRecentPrioritizationFees.go
@@ -20,7 +20,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
-// TODO: add comments
+// GetRecentPrioritizationFees returns a list of prioritization fees from recent blocks.
+// Currently, a node's prioritization-fee cache stores data from up to 150 blocks.
 func (cl *Client) GetRecentPrioritizationFees(
 	ctx context.Context,
 	accounts solana.PublicKeySlice, // optional
@@ -32,6 +33,9 @@ func (cl *Client) GetRecentPrioritizationFees(
 }
 
 type PriorizationFeeResult struct {
-	Slot              uint64 `json:"slot"`
+	// Slot in which the fee was observed
+	Slot uint64 `json:"slot"`
+
+	// The per-compute-unit fee paid by at least one successfully landed transaction, specified in increments of 0.000001 lamports
 	PrioritizationFee uint64 `json:"prioritizationFee"`
 }

--- a/rpc/getRecentPrioritizationFees.go
+++ b/rpc/getRecentPrioritizationFees.go
@@ -1,0 +1,37 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// TODO: add comments
+func (cl *Client) GetRecentPrioritizationFees(
+	ctx context.Context,
+	accounts solana.PublicKeySlice, // optional
+) (out []PriorizationFeeResult, err error) {
+	params := []interface{}{accounts}
+	err = cl.rpcClient.CallForInto(ctx, &out, "getRecentPrioritizationFees", params)
+
+	return
+}
+
+type PriorizationFeeResult struct {
+	Slot              uint64 `json:"slot"`
+	PrioritizationFee uint64 `json:"prioritizationFee"`
+}


### PR DESCRIPTION
This PR adds support for the [getRecentPrioritizationFees](https://docs.solana.com/api/http#getrecentprioritizationfees) JSON-RPC method.