### PR TITLE
Add CreateIdempotent instruction

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -644,11 +644,13 @@ func FindProgramAddress(seed [][]byte, programID PublicKey) (PublicKey, uint8, e
 func FindAssociatedTokenAddress(
 	wallet PublicKey,
 	mint PublicKey,
+	tokenProgramID PublicKey,
 ) (PublicKey, uint8, error) {
 	return findAssociatedTokenAddressAndBumpSeed(
 		wallet,
 		mint,
 		SPLAssociatedTokenAccountProgramID,
+		tokenProgramID,
 	)
 }
 
@@ -656,10 +658,11 @@ func findAssociatedTokenAddressAndBumpSeed(
 	walletAddress PublicKey,
 	splTokenMintAddress PublicKey,
 	programID PublicKey,
+	tokenProgramID PublicKey,
 ) (PublicKey, uint8, error) {
 	return FindProgramAddress([][]byte{
 		walletAddress[:],
-		TokenProgramID[:],
+		tokenProgramID[:],
 		splTokenMintAddress[:],
 	},
 		programID,

--- a/program_ids.go
+++ b/program_ids.go
@@ -46,6 +46,9 @@ var (
 	// A Token program on the Solana blockchain.
 	// This program defines a common implementation for Fungible and Non Fungible tokens.
 	TokenProgramID = MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+	// Superset of Token Program
+	// https://spl.solana.com/token-2022
+	Token2022ProgramID = MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb")
 
 	// A Uniswap-like exchange for the Token program on the Solana blockchain,
 	// implementing multiple automated market maker (AMM) curves.

--- a/programs/associated-token-account/Create.go
+++ b/programs/associated-token-account/Create.go
@@ -79,6 +79,7 @@ func (inst Create) Build() *Instruction {
 	associatedTokenAddress, _, _ := solana.FindAssociatedTokenAddress(
 		inst.Wallet,
 		inst.Mint,
+		TokenProgramID,
 	)
 
 	keys := []*solana.AccountMeta{
@@ -150,6 +151,7 @@ func (inst *Create) Validate() error {
 	_, _, err := solana.FindAssociatedTokenAddress(
 		inst.Wallet,
 		inst.Mint,
+		TokenProgramID,
 	)
 	if err != nil {
 		return fmt.Errorf("error while FindAssociatedTokenAddress: %w", err)

--- a/programs/associated-token-account/CreateIdempotent.go
+++ b/programs/associated-token-account/CreateIdempotent.go
@@ -1,0 +1,204 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package associatedtokenaccount
+
+import (
+	"errors"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+	format "github.com/gagliardetto/solana-go/text/format"
+	treeout "github.com/gagliardetto/treeout"
+)
+
+type CreateIdempotent struct {
+	Payer  solana.PublicKey `bin:"-" borsh_skip:"true"`
+	Wallet solana.PublicKey `bin:"-" borsh_skip:"true"`
+	Mint   solana.PublicKey `bin:"-" borsh_skip:"true"`
+
+	// [0] = [WRITE, SIGNER] Payer
+	// ··········· Funding account
+	//
+	// [1] = [WRITE] AssociatedTokenAccount
+	// ··········· Associated token account address to be created
+	//
+	// [2] = [] Wallet
+	// ··········· Wallet address for the new associated token account
+	//
+	// [3] = [] TokenMint
+	// ··········· The token mint for the new associated token account
+	//
+	// [4] = [] SystemProgram
+	// ··········· System program ID
+	//
+	// [5] = [] TokenProgram
+	// ··········· SPL token program ID
+	//
+	// [6] = [] SysVarRent
+	// ··········· SysVarRentPubkey
+	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewCreateIdempotentInstructionBuilder creates a new `CreateIdempotent` instruction builder.
+func NewCreateIdempotentInstructionBuilder() *CreateIdempotent {
+	nd := &CreateIdempotent{}
+	return nd
+}
+
+func (inst *CreateIdempotent) SetPayer(payer solana.PublicKey) *CreateIdempotent {
+	inst.Payer = payer
+	return inst
+}
+
+func (inst *CreateIdempotent) SetWallet(wallet solana.PublicKey) *CreateIdempotent {
+	inst.Wallet = wallet
+	return inst
+}
+
+func (inst *CreateIdempotent) SetMint(mint solana.PublicKey) *CreateIdempotent {
+	inst.Mint = mint
+	return inst
+}
+
+func (inst CreateIdempotent) Build() *Instruction {
+
+	// Find the associatedTokenAddress;
+	associatedTokenAddress, _, _ := solana.FindAssociatedTokenAddress(
+		inst.Wallet,
+		inst.Mint,
+		TokenProgramID,
+	)
+
+	keys := []*solana.AccountMeta{
+		{
+			PublicKey:  inst.Payer,
+			IsSigner:   true,
+			IsWritable: true,
+		},
+		{
+			PublicKey:  associatedTokenAddress,
+			IsSigner:   false,
+			IsWritable: true,
+		},
+		{
+			PublicKey:  inst.Wallet,
+			IsSigner:   false,
+			IsWritable: false,
+		},
+		{
+			PublicKey:  inst.Mint,
+			IsSigner:   false,
+			IsWritable: false,
+		},
+		{
+			PublicKey:  solana.SystemProgramID,
+			IsSigner:   false,
+			IsWritable: false,
+		},
+		{
+			PublicKey:  TokenProgramID,
+			IsSigner:   false,
+			IsWritable: false,
+		},
+		{
+			PublicKey:  solana.SysVarRentPubkey,
+			IsSigner:   false,
+			IsWritable: false,
+		},
+	}
+
+	inst.AccountMetaSlice = keys
+
+	return &Instruction{BaseVariant: bin.BaseVariant{
+		Impl:   inst,
+		TypeID: bin.TypeIDFromUint8(1),
+	}}
+}
+
+// ValidateAndBuild validates the instruction accounts.
+// If there is a validation error, return the error.
+// Otherwise, build and return the instruction.
+func (inst CreateIdempotent) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *CreateIdempotent) Validate() error {
+	if inst.Payer.IsZero() {
+		return errors.New("Payer not set")
+	}
+	if inst.Wallet.IsZero() {
+		return errors.New("Wallet not set")
+	}
+	if inst.Mint.IsZero() {
+		return errors.New("Mint not set")
+	}
+	_, _, err := solana.FindAssociatedTokenAddress(
+		inst.Wallet,
+		inst.Mint,
+		TokenProgramID,
+	)
+	if err != nil {
+		return fmt.Errorf("error while FindAssociatedTokenAddress: %w", err)
+	}
+	return nil
+}
+
+func (inst *CreateIdempotent) EncodeToTree(parent treeout.Branches) {
+	parent.Child(format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch treeout.Branches) {
+			programBranch.Child(format.Instruction("CreateIdempotent")).
+				//
+				ParentFunc(func(instructionBranch treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params[len=0]").ParentFunc(func(paramsBranch treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts[len=7").ParentFunc(func(accountsBranch treeout.Branches) {
+						accountsBranch.Child(format.Meta("                 payer", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("associatedTokenAddress", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("                wallet", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("             tokenMint", inst.AccountMetaSlice.Get(3)))
+						accountsBranch.Child(format.Meta("         systemProgram", inst.AccountMetaSlice.Get(4)))
+						accountsBranch.Child(format.Meta("          tokenProgram", inst.AccountMetaSlice.Get(5)))
+						accountsBranch.Child(format.Meta("            sysVarRent", inst.AccountMetaSlice.Get(6)))
+					})
+				})
+		})
+}
+
+func (inst CreateIdempotent) MarshalWithEncoder(encoder *bin.Encoder) error {
+	return encoder.WriteBytes([]byte{}, false)
+}
+
+func (inst *CreateIdempotent) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	return nil
+}
+
+func NewCreateIdempotentInstruction(
+	payer solana.PublicKey,
+	walletAddress solana.PublicKey,
+	splTokenMintAddress solana.PublicKey,
+) *CreateIdempotent {
+	return NewCreateIdempotentInstructionBuilder().
+		SetPayer(payer).
+		SetWallet(walletAddress).
+		SetMint(splTokenMintAddress)
+}

--- a/programs/associated-token-account/instructions.go
+++ b/programs/associated-token-account/instructions.go
@@ -25,10 +25,15 @@ import (
 )
 
 var ProgramID solana.PublicKey = solana.SPLAssociatedTokenAccountProgramID
+var TokenProgramID solana.PublicKey = solana.TokenProgramID
 
 func SetProgramID(pubkey solana.PublicKey) {
 	ProgramID = pubkey
 	solana.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
+}
+
+func SetTokenProgramID(pubkey solana.PublicKey) {
+	TokenProgramID = pubkey
 }
 
 const ProgramName = "AssociatedTokenAccount"

--- a/programs/associated-token-account/instructions.go
+++ b/programs/associated-token-account/instructions.go
@@ -15,6 +15,7 @@
 package associatedtokenaccount
 
 import (
+	"bytes"
 	"fmt"
 
 	spew "github.com/davecgh/go-spew/spew"
@@ -55,10 +56,13 @@ func (inst *Instruction) EncodeToTree(parent treeout.Branches) {
 }
 
 var InstructionImplDef = bin.NewVariantDefinition(
-	bin.NoTypeIDEncoding, // NOTE: the associated-token-account program has no ID encoding.
+	bin.Uint8TypeIDEncoding,
 	[]bin.VariantType{
 		{
 			"Create", (*Create)(nil),
+		},
+		{
+			"CreateIdempotent", (*CreateIdempotent)(nil),
 		},
 	},
 )
@@ -72,7 +76,11 @@ func (inst *Instruction) Accounts() (out []*solana.AccountMeta) {
 }
 
 func (inst *Instruction) Data() ([]byte, error) {
-	return []byte{}, nil
+	buf := new(bytes.Buffer)
+	if err := bin.NewBinEncoder(buf).Encode(inst); err != nil {
+		return nil, fmt.Errorf("unable to encode instruction: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func (inst *Instruction) TextEncode(encoder *text.Encoder, option *text.Option) error {
@@ -84,6 +92,10 @@ func (inst *Instruction) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 }
 
 func (inst Instruction) MarshalWithEncoder(encoder *bin.Encoder) error {
+	err := encoder.WriteUint8(inst.TypeID.Uint8())
+	if err != nil {
+		return fmt.Errorf("unable to write variant type: %w", err)
+	}
 	return encoder.Encode(inst.Impl)
 }
 


### PR DESCRIPTION
Adding support for the [CreateIdempotent](https://github.com/solana-labs/solana-program-library/blob/6384308a3fa6bef5debfa2e1a0809b24431ddfbd/associated-token-account/program/src/instruction.rs#L36) instruction. Also adds support for the Token2022Program for the `FindAssociatedTokenAddress` method. The instruction seems identical to the `Create` instruction.