### PR TITLE
Add `ComputeUnitsConsumed` to `TransactionMeta`

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -214,6 +214,8 @@ type TransactionMeta struct {
 	Rewards []BlockReward `json:"rewards"`
 
 	LoadedAddresses LoadedAddresses `json:"loadedAddresses"`
+	
+	ComputeUnitsConsumed *uint64 `json:"computeUnitsConsumed"`
 }
 
 type InnerInstruction struct {


### PR DESCRIPTION
`GetTransaction` now returns this field.

Ref: https://docs.solana.com/api/http#gettransaction