### PR TITLE
fix: Add `ShortID` option for some WebSocket RPC which not support int63/uint64 ID

### DIFF
--- a/rpc/ws/client.go
+++ b/rpc/ws/client.go
@@ -43,6 +43,7 @@ type Client struct {
 	subscriptionByRequestID map[uint64]*Subscription
 	subscriptionByWSSubID   map[uint64]*Subscription
 	reconnectOnErr          bool
+	shortID                 bool
 }
 
 const (
@@ -74,6 +75,10 @@ func ConnectWithOptions(ctx context.Context, rpcEndpoint string, opt *Options) (
 		Proxy:             http.ProxyFromEnvironment,
 		HandshakeTimeout:  DefaultHandshakeTimeout,
 		EnableCompression: true,
+	}
+
+	if opt != nil && opt.ShortID {
+		c.shortID = opt.ShortID
 	}
 
 	if opt != nil && opt.HandshakeTimeout > 0 {
@@ -285,7 +290,7 @@ func (c *Client) closeSubscription(reqID uint64, err error) {
 }
 
 func (c *Client) unsubscribe(subID uint64, method string) error {
-	req := newRequest([]interface{}{subID}, method, nil)
+	req := newRequest([]interface{}{subID}, method, nil, c.shortID)
 	data, err := req.encode()
 	if err != nil {
 		return fmt.Errorf("unable to encode unsubscription message for subID %d and method %s", subID, method)
@@ -309,7 +314,7 @@ func (c *Client) subscribe(
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	req := newRequest(params, subscriptionMethod, conf)
+	req := newRequest(params, subscriptionMethod, conf, c.shortID)
 	data, err := req.encode()
 	if err != nil {
 		return nil, fmt.Errorf("subscribe: unable to encode subsciption request: %w", err)

--- a/rpc/ws/types.go
+++ b/rpc/ws/types.go
@@ -32,15 +32,21 @@ type request struct {
 	ID      uint64      `json:"id"`
 }
 
-func newRequest(params []interface{}, method string, configuration map[string]interface{}) *request {
+func newRequest(params []interface{}, method string, configuration map[string]interface{}, shortID bool) *request {
 	if params != nil && configuration != nil {
 		params = append(params, configuration)
+	}
+	var ID uint64
+	if !shortID {
+		ID = uint64(rand.Int63())
+	} else {
+		ID = uint64(rand.Int31())
 	}
 	return &request{
 		Version: "2.0",
 		Method:  method,
 		Params:  params,
-		ID:      uint64(rand.Int63()),
+		ID:      ID,
 	}
 }
 
@@ -66,6 +72,7 @@ type params struct {
 type Options struct {
 	HttpHeader       http.Header
 	HandshakeTimeout time.Duration
+	ShortID          bool // some RPC do not support int63/uint64 id, so need to enable it to rand a int31/uint32 id
 }
 
 var DefaultHandshakeTimeout = 45 * time.Second


### PR DESCRIPTION
avoid ID field overflow when use some WebSocket RPC.

![image](https://github.com/gagliardetto/solana-go/assets/155265132/51554244-08b6-4c2b-a51d-1cf8a67aef37)

![image](https://github.com/gagliardetto/solana-go/assets/155265132/41b118e3-70cf-4386-954a-524a2b46da58)
