### PR TITLE
Added tpuQuic and pubsub in GetClusterNodesResult struct

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -892,7 +892,7 @@ func TestClient_GetBlockTime(t *testing.T) {
 }
 
 func TestClient_GetClusterNodes(t *testing.T) {
-	responseBody := `[{"featureSet":743297851,"gossip":"162.55.111.250:8001","pubkey":"DMeohMfD3JzmYZA34jL9iiTXp5N7tpAR3rAoXMygdH3U","rpc":"135.181.114.15:8005","shredVersion":18122,"tpu":"162.55.111.250:8004","version":"1.7.3"},{"featureSet":743297851,"gossip":"136.243.131.82:8000","pubkey":"59TSbYfnbb4zx4xf54ApjE8fJRhwzTiSjh9vdHfgyg1U","rpc":"136.243.131.82:8899","shredVersion":18122,"tpu":"136.243.131.82:8003","version":"1.7.3"},{"featureSet":743297851,"gossip":"135.181.114.15:8001","pubkey":"7vu7Q2d4uu9V4xnySHXieeyWvoNh37321kqTd2ATuoj6","rpc":"135.181.114.15:8005","shredVersion":18122,"tpu":"135.181.114.15:8006","version":"1.7.3"}]`
+	responseBody := `[{"featureSet":3580551090,"gossip":"34.147.255.155:8000","pubkey":"hyp3Eo67t6FgeuWg5Qxbeme8NPXJPXXdKT4iJ4DsLf2","pubsub":"34.147.255.155:8900","rpc":"34.147.255.155:8899","shredVersion":50093,"tpu":"34.147.255.155:8009","tpuQuic":"34.147.255.155:8015","version":"1.17.22"},{"featureSet":3746964731,"gossip":"162.19.222.39:8001","pubkey":"EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4","pubsub":"162.19.222.39:8900","rpc":"162.19.222.39:8899","shredVersion":50093,"tpu":"208.91.106.87:8005","tpuQuic":"208.91.106.87:8011","version":"1.17.27"},{"featureSet":3746964731,"gossip":"205.209.104.74:8000","pubkey":"J87afqF2bDQQLTQpks4SdF7hXPr96SPTdJ28UJXXWr9N","pubsub":"205.209.104.74:8900","rpc":"205.209.104.74:8899","shredVersion":50093,"tpu":"205.209.104.74:8003","tpuQuic":"205.209.104.74:8009","version":"1.17.27"}]`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
 	defer closer()
 	client := New(server.URL)

--- a/rpc/getClusterNodes.go
+++ b/rpc/getClusterNodes.go
@@ -38,6 +38,12 @@ type GetClusterNodesResult struct {
 	// TPU network address for the node.
 	TPU *string `json:"tpu,omitempty"`
 
+	// TPU QUIC network address for the node.
+	TPUQUIC *string `json:"tpuQuic,omitempty"`
+
+	// RPC WebSocket network address for the node, or empty if the WebSocket RPC service is not enabled.
+	PubSub *string `json:"pubsub,omitempty"`
+
 	// JSON RPC network address for the node, or empty if the JSON RPC service is not enabled.
 	RPC *string `json:"rpc,omitempty"`
 


### PR DESCRIPTION
Updated GetClusterNodesResult struct to get GetClusterNodes to return also tpuQuic and pubsub addresses

![Screenshot 2024-03-25 at 20 20 58](https://github.com/gagliardetto/solana-go/assets/25622792/3936d8a8-88a5-4fa9-b5d3-dcac82bc717c)
