### PR TITLE
perf: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/slnc/cmd/common.go
+++ b/cmd/slnc/cmd/common.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -38,7 +39,7 @@ func getClient() *rpc.Client {
 	for _, header := range httpHeaders {
 		headerArray := strings.SplitN(header, ": ", 2)
 		if len(headerArray) != 2 || strings.Contains(headerArray[0], " ") {
-			errorCheck("validating http headers", fmt.Errorf("invalid HTTP Header format"))
+			errorCheck("validating http headers", errors.New("invalid HTTP Header format"))
 		}
 		headers[headerArray[0]] = headerArray[1]
 	}

--- a/cmd/slnc/cmd/get_balance.go
+++ b/cmd/slnc/cmd/get_balance.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
@@ -41,7 +42,7 @@ var getBalanceCmd = &cobra.Command{
 		}
 
 		if resp.Value == 0 {
-			return fmt.Errorf("account not found")
+			return errors.New("account not found")
 		}
 
 		fmt.Println(resp.Value, "lamports")

--- a/cmd/slnc/cmd/get_program_accounts.go
+++ b/cmd/slnc/cmd/get_program_accounts.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -45,7 +46,7 @@ var getProgramAccountsCmd = &cobra.Command{
 		}
 
 		if resp == nil {
-			return fmt.Errorf("program account not found")
+			return errors.New("program account not found")
 		}
 
 		for _, keyedAcct := range resp {

--- a/message.go
+++ b/message.go
@@ -19,8 +19,8 @@ package solana
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
-
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/treeout"
 
@@ -120,7 +120,7 @@ type Message struct {
 // NOTE: you can call this once.
 func (mx *Message) SetAddressTables(tables map[PublicKey]PublicKeySlice) error {
 	if mx.addressTables != nil {
-		return fmt.Errorf("address tables already set")
+		return errors.New("address tables already set")
 	}
 	mx.addressTables = tables
 	return nil
@@ -644,7 +644,7 @@ func (m Message) checkPreconditions() error {
 	// but the address table is empty,
 	// then we can't build the account meta list:
 	if m.IsVersioned() && m.AddressTableLookups.NumLookups() > 0 && (m.addressTables == nil || len(m.addressTables) == 0) {
-		return fmt.Errorf("cannot build account meta list without address tables")
+		return errors.New("cannot build account meta list without address tables")
 	}
 
 	return nil

--- a/programs/address-lookup-table/address-lookup.go
+++ b/programs/address-lookup-table/address-lookup.go
@@ -2,6 +2,7 @@ package addresslookuptable
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
@@ -36,7 +37,7 @@ func GetAddressLookupTable(
 		return nil, err
 	}
 	if account == nil {
-		return nil, fmt.Errorf("account not found")
+		return nil, errors.New("account not found")
 	}
 	return DecodeAddressLookupTableState(account.GetBinary())
 }
@@ -52,7 +53,7 @@ func GetAddressLookupTableStateWithOpts(
 		return nil, err
 	}
 	if account == nil {
-		return nil, fmt.Errorf("account not found")
+		return nil, errors.New("account not found")
 	}
 	return DecodeAddressLookupTableState(account.GetBinary())
 }

--- a/programs/bpf-loader/loader.go
+++ b/programs/bpf-loader/loader.go
@@ -2,6 +2,7 @@ package bpfloader
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
@@ -45,19 +46,19 @@ func completePartialProgramInit(
 	allowExcessiveBalance bool,
 ) (instructions []solana.Instruction, balanceNeeded uint64, err error) {
 	if account.Executable {
-		err = fmt.Errorf("buffer account is already executable")
+		err = errors.New("buffer account is already executable")
 		return
 	}
 	if !account.Owner.Equals(loaderId) &&
 		!account.Owner.Equals(solana.SystemProgramID) {
-		err = fmt.Errorf(
+		err = errors.New(
 			"buffer account passed is already in use by another program",
 		)
 		return
 	}
 	if len(account.Data.GetBinary()) > 0 &&
 		len(account.Data.GetBinary()) < accountDataLen {
-		err = fmt.Errorf(
+		err = errors.New(
 			"buffer account passed is not large enough, may have been for a " +
 				" different deploy?",
 		)

--- a/programs/serum/rpc.go
+++ b/programs/serum/rpc.go
@@ -20,6 +20,7 @@ package serum
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	rice "github.com/GeertJohan/go.rice"
@@ -36,7 +37,7 @@ import (
 func KnownMarket() ([]*MarketMeta, error) {
 	box := rice.MustFindBox("data").MustBytes("markets.json")
 	if box == nil {
-		return nil, fmt.Errorf("unable to retrieve known markets")
+		return nil, errors.New("unable to retrieve known markets")
 	}
 
 	dec := json.NewDecoder(bytes.NewReader(box))

--- a/programs/system/CreateAccountWithSeed.go
+++ b/programs/system/CreateAccountWithSeed.go
@@ -17,7 +17,6 @@ package system
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
 	ag_solanago "github.com/gagliardetto/solana-go"
@@ -166,10 +165,10 @@ func (inst *CreateAccountWithSeed) Validate() error {
 	// Check whether all accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
-			return fmt.Errorf("FundingAccount is not set")
+			return errors.New("FundingAccount is not set")
 		}
 		if inst.AccountMetaSlice[1] == nil {
-			return fmt.Errorf("CreatedAccount is not set")
+			return errors.New("CreatedAccount is not set")
 		}
 	}
 	return nil

--- a/programs/token/Approve.go
+++ b/programs/token/Approve.go
@@ -154,7 +154,7 @@ func (inst *Approve) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/ApproveChecked.go
+++ b/programs/token/ApproveChecked.go
@@ -190,7 +190,7 @@ func (inst *ApproveChecked) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[3].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/Burn.go
+++ b/programs/token/Burn.go
@@ -154,7 +154,7 @@ func (inst *Burn) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/BurnChecked.go
+++ b/programs/token/BurnChecked.go
@@ -172,7 +172,7 @@ func (inst *BurnChecked) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/CloseAccount.go
+++ b/programs/token/CloseAccount.go
@@ -138,7 +138,7 @@ func (inst *CloseAccount) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/InitializeMultisig.go
+++ b/programs/token/InitializeMultisig.go
@@ -145,13 +145,13 @@ func (inst *InitializeMultisig) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.Accounts[0] == nil {
-			return fmt.Errorf("accounts.Account is not set")
+			return errors.New("accounts.Account is not set")
 		}
 		if inst.Accounts[1] == nil {
-			return fmt.Errorf("accounts.SysVarRentPubkey is not set")
+			return errors.New("accounts.SysVarRentPubkey is not set")
 		}
 		if len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/InitializeMultisig2.go
+++ b/programs/token/InitializeMultisig2.go
@@ -118,7 +118,7 @@ func (inst *InitializeMultisig2) Validate() error {
 			return errors.New("accounts.Account is not set")
 		}
 		if len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/MintTo.go
+++ b/programs/token/MintTo.go
@@ -154,7 +154,7 @@ func (inst *MintTo) Validate() error {
 			return errors.New("accounts.Authority is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/MintToChecked.go
+++ b/programs/token/MintToChecked.go
@@ -170,7 +170,7 @@ func (inst *MintToChecked) Validate() error {
 			return errors.New("accounts.Authority is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/Revoke.go
+++ b/programs/token/Revoke.go
@@ -118,7 +118,7 @@ func (inst *Revoke) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[1].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/SetAuthority.go
+++ b/programs/token/SetAuthority.go
@@ -144,7 +144,7 @@ func (inst *SetAuthority) Validate() error {
 			return errors.New("accounts.Authority is not set")
 		}
 		if !inst.Accounts[1].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/ThawAccount.go
+++ b/programs/token/ThawAccount.go
@@ -137,7 +137,7 @@ func (inst *ThawAccount) Validate() error {
 			return errors.New("accounts.Authority is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/Transfer.go
+++ b/programs/token/Transfer.go
@@ -147,16 +147,16 @@ func (inst *Transfer) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.Accounts[0] == nil {
-			return fmt.Errorf("accounts.Source is not set")
+			return errors.New("accounts.Source is not set")
 		}
 		if inst.Accounts[1] == nil {
-			return fmt.Errorf("accounts.Destination is not set")
+			return errors.New("accounts.Destination is not set")
 		}
 		if inst.Accounts[2] == nil {
-			return fmt.Errorf("accounts.Owner is not set")
+			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/TransferChecked.go
+++ b/programs/token/TransferChecked.go
@@ -192,7 +192,7 @@ func (inst *TransferChecked) Validate() error {
 			return errors.New("accounts.Owner is not set")
 		}
 		if !inst.Accounts[3].IsSigner && len(inst.Signers) == 0 {
-			return fmt.Errorf("accounts.Signers is not set")
+			return errors.New("accounts.Signers is not set")
 		}
 		if len(inst.Signers) > MAX_SIGNERS {
 			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))

--- a/programs/token/rpc.go
+++ b/programs/token/rpc.go
@@ -19,6 +19,7 @@ package token
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
@@ -52,7 +53,7 @@ func FetchMints(ctx context.Context, rpcCli *rpc.Client) (out []*Mint, err error
 		return nil, err
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("resp empty... program account not found")
+		return nil, errors.New("resp empty... program account not found")
 	}
 
 	for _, keyedAcct := range resp {

--- a/programs/tokenregistry/instruction.go
+++ b/programs/tokenregistry/instruction.go
@@ -20,6 +20,7 @@ package tokenregistry
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go/text"
@@ -138,7 +139,7 @@ type RegisterToken struct {
 
 func (i *RegisterToken) SetAccounts(accounts []*solana.AccountMeta) error {
 	if len(accounts) < 9 {
-		return fmt.Errorf("insufficient account")
+		return errors.New("insufficient account")
 	}
 	i.Accounts = &RegisterTokenAccounts{
 		TokenMeta: accounts[0],

--- a/programs/tokenregistry/rpc.go
+++ b/programs/tokenregistry/rpc.go
@@ -19,6 +19,7 @@ package tokenregistry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
@@ -44,7 +45,7 @@ func GetTokenRegistryEntry(ctx context.Context, rpcCli *rpc.Client, mintAddress 
 		return nil, err
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("resp empty... cannot find account")
+		return nil, errors.New("resp empty... cannot find account")
 	}
 
 	for _, keyedAcct := range resp {
@@ -74,7 +75,7 @@ func GetEntries(ctx context.Context, rpcCli *rpc.Client) (out []*TokenMeta, err 
 		return nil, err
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("resp empty... cannot find accounts")
+		return nil, errors.New("resp empty... cannot find accounts")
 	}
 
 	for _, keyedAcct := range resp {

--- a/transaction.go
+++ b/transaction.go
@@ -20,6 +20,7 @@ package solana
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -230,7 +231,7 @@ type addressTablePubkeyWithIndex struct {
 
 func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...TransactionOption) (*Transaction, error) {
 	if len(instructions) == 0 {
-		return nil, fmt.Errorf("requires at-least one instruction to create a transaction")
+		return nil, errors.New("requires at-least one instruction to create a transaction")
 	}
 
 	options := transactionOptions{}
@@ -249,7 +250,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("cannot determine fee payer. You can ether pass the fee payer via the 'TransactionWithInstructions' option parameter or it falls back to the first instruction's first signer")
+			return nil, errors.New("cannot determine fee payer. You can ether pass the fee payer via the 'TransactionWithInstructions' option parameter or it falls back to the first instruction's first signer")
 		}
 	}
 
@@ -506,7 +507,7 @@ func (tx *Transaction) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
 			return fmt.Errorf("unable to read numSignatures: %w", err)
 		}
 		if numSignatures < 0 {
-			return fmt.Errorf("numSignatures is negative")
+			return errors.New("numSignatures is negative")
 		}
 		if numSignatures > decoder.Remaining()/64 {
 			return fmt.Errorf("numSignatures %d is too large for remaining bytes %d", numSignatures, decoder.Remaining())


### PR DESCRIPTION
If you don't need to format the string, recommended to use error.New().