### PR TITLE
fix panic

### DIFF
--- a/rpc/ws/client.go
+++ b/rpc/ws/client.go
@@ -246,7 +246,9 @@ func (c *Client) handleSubscriptionMessage(subID uint64, message []byte) {
 		return
 	}
 
-	sub.stream <- result
+	if !sub.closed {
+		sub.stream <- result
+	}
 	return
 }
 

--- a/rpc/ws/subscription.go
+++ b/rpc/ws/subscription.go
@@ -23,6 +23,7 @@ type Subscription struct {
 	stream            chan result
 	err               chan error
 	closeFunc         func(err error)
+	closed            bool
 	unsubscribeMethod string
 	decoderFunc       decoderFunc
 }
@@ -61,6 +62,7 @@ func (s *Subscription) Unsubscribe() {
 
 func (s *Subscription) unsubscribe(err error) {
 	s.closeFunc(err)
+	s.closed = true
 	close(s.stream)
 	close(s.err)
 }


### PR DESCRIPTION
panic: send on closed channel

goroutine 15857 [running]:
github.com/gagliardetto/solana-go/rpc/ws.(*Client).handleSubscriptionMessage(0xc000b89800, 0x191827, {0xc004e0a200, 0x1897, 0x1b00})
	github.com/gagliardetto/solana-go@v1.10.0/rpc/ws/client.go:249 +0x3cf
github.com/gagliardetto/solana-go/rpc/ws.(*Client).handleMessage(0xc000b89800, {0xc004e0a200, 0x1897, 0x1b00})
	github.com/gagliardetto/solana-go@v1.10.0/rpc/ws/client.go:183 +0x10e
github.com/gagliardetto/solana-go/rpc/ws.(*Client).receiveMessages(0xc000b89800)
	github.com/gagliardetto/solana-go@v1.10.0/rpc/ws/client.go:145 +0x1f
created by github.com/gagliardetto/solana-go/rpc/ws.ConnectWithOptions in goroutine 54
	github.com/gagliardetto/solana-go@v1.10.0/rpc/ws/client.go:113 +0x327