### PR TITLE
fix memory leak in ws client

### DIFF
--- a/rpc/ws/client.go
+++ b/rpc/ws/client.go
@@ -333,6 +333,7 @@ func (c *Client) subscribe(
 	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
 	err = c.conn.WriteMessage(websocket.TextMessage, data)
 	if err != nil {
+		delete(c.subscriptionByRequestID, req.ID)
 		return nil, fmt.Errorf("unable to write request: %w", err)
 	}
 


### PR DESCRIPTION
if the write fails then an error is returned but the sub still exists in the map with no way to clear it

sub objects are pretty large which leads to a significant memory leak on repeated calls with write failures