### PR TITLE
Method to get the marketAuthority(PDA) from the Market Initialization

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -675,3 +675,19 @@ func FindTokenMetadataAddress(mint PublicKey) (PublicKey, uint8, error) {
 	}
 	return FindProgramAddress(seed, TokenMetadataProgramID)
 }
+
+// Get the marketAuthority(PDA) from the Market Initialization
+func GetAssociatedAuthority(programID PublicKey, marketAddr PublicKey) (PublicKey, uint8, error) {
+	var address PublicKey
+	var err error
+	bumpSeed := uint8(0)
+	endSeed := []byte{0, 0, 0, 0, 0, 0, 0}
+	for bumpSeed < 100 {
+		address, err = CreateProgramAddress([][]byte{marketAddr[:], []byte{byte(bumpSeed)}, endSeed}, programID)
+		if err == nil {
+			return address, bumpSeed, nil
+		}
+		bumpSeed++
+	}
+	return PublicKey{}, bumpSeed, errors.New("unable to find a valid program address")
+}


### PR DESCRIPTION
While grabbing token information to buy/sell in Raydium, I missed this method that allow  to calculate pda for the marketAuthority.
I didn't find anything related, so I decided to implement myself. 

Btw, nice work and I hope this PR can help.

The Reference: https://github.com/raydium-io/raydium-sdk/blob/f4b7f47e744c12a8b0119b85e16d0d8274aa5ba9/src/serum/serum.ts#L41