### PR TITLE
Add number of reward partitions field to getBlock response

### DIFF
--- a/rpc/getBlock.go
+++ b/rpc/getBlock.go
@@ -163,6 +163,10 @@ type GetBlockResult struct {
 
 	// The number of blocks beneath this block.
 	BlockHeight *uint64 `json:"blockHeight"`
+
+	// The number of reward partitions.
+	// Present for the first block in the epoch otherwise Nil.
+	NumRewardPartitions *uint64 `json:"numRewardPartitions"`
 }
 
 func (cl *Client) GetParsedBlockWithOpts(
@@ -230,6 +234,10 @@ type GetParsedBlockResult struct {
 
 	// The number of blocks beneath this block.
 	BlockHeight *uint64 `json:"blockHeight"`
+
+	// The number of reward partitions.
+	// Present for the first block in the epoch otherwise Nil.
+	NumRewardPartitions *uint64 `json:"numRewardPartitions"`
 }
 
 type ParsedTransactionWithMeta struct {


### PR DESCRIPTION
[Partitioned rewards distribution](https://docs.anza.xyz/proposals/partitioned-inflationary-rewards-distribution/) is now live on mainnet. This PR adds the `NumRewardPartitions` field to the `getBlock` response to allow implementation as described [here](https://github.com/anza-xyz/agave/issues/3619)