### PR TITLE
Fix nil pointer dereference in GetBinary (Fixes #264)

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -376,6 +376,9 @@ func (wrap *DataBytesOrJSON) UnmarshalJSON(data []byte) error {
 // GetBinary returns the decoded bytes if the encoding is
 // "base58", "base64", or "base64+zstd".
 func (dt *DataBytesOrJSON) GetBinary() []byte {
+	if dt == nil || dt.asDecodedBinary == nil {
+		return nil
+	}
 	return dt.asDecodedBinary.Content
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -376,7 +376,7 @@ func (wrap *DataBytesOrJSON) UnmarshalJSON(data []byte) error {
 // GetBinary returns the decoded bytes if the encoding is
 // "base58", "base64", or "base64+zstd".
 func (dt *DataBytesOrJSON) GetBinary() []byte {
-	if dt == nil || dt.asDecodedBinary == nil {
+	if dt == nil {
 		return nil
 	}
 	return dt.asDecodedBinary.Content


### PR DESCRIPTION
This PR resolves issue [#264](https://github.com/gagliardetto/solana-go/issues/264) by adding `nil` checks in the `GetBinary` method of DataBytesOrJSON