### PR TITLE
fix: add stackHeight field in CompiledInstruction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -137,6 +137,8 @@ type CompiledInstruction struct {
 
 	// The program input data encoded in a base-58 string.
 	Data Base58 `json:"data"`
+
+	StackHeight uint16 `json:"stackHeight"`
 }
 
 func (ci *CompiledInstruction) ResolveInstructionAccounts(message *Message) ([]*AccountMeta, error) {


### PR DESCRIPTION
fix: add stackHeight field in CompiledInstruction

The original `CompiledInstruction` struct is missing the field `stackHeight`. Because in this sdk `CompiledInstruction` is used to parse inner instruction while the inner instruction raw response is like: 

```json
{
                    "programIdIndex": 22,
                    "accounts": [10],
                    "data": "18y7nEsq5",
                    "stackHeight": 2
}
```

```go
type CompiledInstruction struct {
	// Index into the message.accountKeys array indicating the program account that executes this instruction.
	// NOTE: it is actually a uint8, but using a uint16 because uint8 is treated as a byte everywhere,
	// and that can be an issue.
	ProgramIDIndex uint16 `json:"programIdIndex"`

	// List of ordered indices into the message.accountKeys array indicating which accounts to pass to the program.
	// NOTE: it is actually a []uint8, but using a uint16 because []uint8 is treated as a []byte everywhere,
	// and that can be an issue.
	Accounts []uint16 `json:"accounts"`

	// The program input data encoded in a base-58 string.
	Data Base58 `json:"data"`

	StackHeight uint16 `json:"stackHeight"`
}
```

Without this field, parse inner instruction would miss part of the stack height data. 


rpc/types.go
```
type InnerInstruction struct {
	// TODO: <number> == int64 ???
	// Index of the transaction instruction from which the inner instruction(s) originated
	Index uint16 `json:"index"`

	// Ordered list of inner program instructions that were invoked during a single transaction instruction.
	Instructions []solana.CompiledInstruction `json:"instructions"`
}
```
