### PR TITLE
Added version information in MarshalWithEncoder, UnmarshalWithDecoder methods of GetTransactionResult

### DIFF
--- a/rpc/getParsedTransaction.go
+++ b/rpc/getParsedTransaction.go
@@ -131,7 +131,7 @@ func (obj GetParsedTransactionResult) MarshalWithEncoder(encoder *bin.Encoder) (
 	return nil
 }
 
-func (obj GetParsedTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+func (obj *GetParsedTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
 	// Deserialize `Slot`:
 	obj.Slot, err = decoder.ReadUint64(bin.LE)
 	if err != nil {

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -231,6 +231,16 @@ func (obj GetTransactionResult) MarshalWithEncoder(encoder *bin.Encoder) (err er
 			}
 		}
 	}
+	{
+		buf, err := json.Marshal(obj.Version)
+		if err != nil {
+			return err
+		}
+		err = encoder.WriteBytes(buf, true)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -281,6 +291,16 @@ func (obj *GetTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err
 			if err != nil {
 				return err
 			}
+		}
+	}
+	{
+		buf, err := decoder.ReadByteSlice()
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(buf, &obj.Version)
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Also fixes typo in `UnmarshalWithDecoder` method reciever of `GetParsedTransactionResult`.