### PR TITLE
fix: token mint Decode

### DIFF
--- a/programs/token/rpc.go
+++ b/programs/token/rpc.go
@@ -28,7 +28,6 @@ import (
 const MINT_SIZE = 82
 
 func (mint *Mint) Decode(data []byte) error {
-	mint = new(Mint)
 	dec := bin.NewBinDecoder(data)
 	if err := dec.Decode(&mint); err != nil {
 		return fmt.Errorf("unable to decode mint: %w", err)


### PR DESCRIPTION
The original decode method could not be applied to the mint object.
after the fix, it now works