### PR TITLE
stake program add missing instructions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,6 @@ require (
 	github.com/gagliardetto/gofuzz v1.2.2
 	github.com/gagliardetto/treeout v0.1.4
 	github.com/google/uuid v1.6.0
-)
-
-require (
 	cloud.google.com/go v0.56.0 // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
@@ -46,9 +43,6 @@ require (
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-require (
 	filippo.io/edwards25519 v1.0.0-rc.1
 	github.com/AlekSi/pointer v1.1.0
 	github.com/GeertJohan/go.rice v1.0.0
@@ -81,3 +75,4 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.29.0
 )
+

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,42 @@ module github.com/gagliardetto/solana-go
 go 1.19
 
 require (
+	filippo.io/edwards25519 v1.0.0-rc.1
+	github.com/AlekSi/pointer v1.1.0
+	github.com/GeertJohan/go.rice v1.0.0
+	github.com/buger/jsonparser v1.1.1
+	github.com/davecgh/go-spew v1.1.1
+	github.com/fatih/color v1.9.0
 	github.com/gagliardetto/binary v0.8.0
 	github.com/gagliardetto/gofuzz v1.2.2
 	github.com/gagliardetto/treeout v0.1.4
+	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/rpc v1.2.0
+	github.com/gorilla/websocket v1.4.2
+	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.13.6
+	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1
+	github.com/mr-tron/base58 v1.2.0
+	github.com/onsi/gomega v1.10.1
+	github.com/pkg/errors v0.9.1
+	github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f
+	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.7.1
+	github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091
+	github.com/stretchr/testify v1.7.0
+	go.mongodb.org/mongo-driver v1.12.2
+	go.uber.org/ratelimit v0.2.0
+	go.uber.org/zap v1.21.0
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	google.golang.org/api v0.29.0
+)
+
+require (
 	cloud.google.com/go v0.56.0 // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
@@ -30,10 +62,12 @@ require (
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	go.opencensus.io v0.22.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
@@ -43,36 +77,4 @@ require (
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	filippo.io/edwards25519 v1.0.0-rc.1
-	github.com/AlekSi/pointer v1.1.0
-	github.com/GeertJohan/go.rice v1.0.0
-	github.com/buger/jsonparser v1.1.1
-	github.com/davecgh/go-spew v1.1.1
-	github.com/fatih/color v1.9.0
-	github.com/google/go-cmp v0.5.2
-	github.com/gorilla/rpc v1.2.0
-	github.com/gorilla/websocket v1.4.2
-	github.com/json-iterator/go v1.1.12
-	github.com/klauspost/compress v1.13.6
-	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1
-	github.com/mr-tron/base58 v1.2.0
-	github.com/onsi/gomega v1.10.1
-	github.com/pkg/errors v0.9.1
-	github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f
-	github.com/spf13/cobra v1.1.1
-	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.7.1
-	github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091
-	github.com/stretchr/testify v1.7.0
-	go.mongodb.org/mongo-driver v1.12.2
-	go.opencensus.io v0.22.5 // indirect
-	go.uber.org/ratelimit v0.2.0
-	go.uber.org/zap v1.21.0
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
-	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-	google.golang.org/api v0.29.0
 )
-

--- a/programs/stake/Authorize.go
+++ b/programs/stake/Authorize.go
@@ -1,0 +1,174 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+type Authorize struct {
+	NewAuthority  *ag_solanago.PublicKey
+	AuthorityType StakeAuthorize
+
+	// [0] = [WRITE] StakeAccount
+	// ··········· The stake account to authorize.
+	//
+	// [1] = [] ClockSysvar
+	// ··········· Clock sysvar account.
+	//
+	// [2] = [] StakeOrWithdrawAuthority
+	// ··········· Stake or withdraw authority.
+	//
+	// [3...] = [SIGNER] Signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *Authorize) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.Accounts, inst.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (inst Authorize) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	accounts = append(accounts, inst.Signers...)
+	return
+}
+
+func (inst *Authorize) Validate() error {
+	// Check whether all (required) parameters are set:
+	if inst.NewAuthority == nil {
+		return errors.New("NewAuthority parameter is not set")
+	}
+
+	// Check whether all (required) accounts are set:
+	if inst.Accounts[0] == nil {
+		return errors.New("accounts.StakeAccount is not set")
+	}
+	if inst.Accounts[1] == nil {
+		return errors.New("accounts.ClockSysvar is not set")
+	}
+	if inst.Accounts[2] == nil {
+		return errors.New("accounts.StakeOrWithdrawAuthority is not set")
+	}
+	if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+		return fmt.Errorf("accounts.Signers is not set")
+	}
+	if len(inst.Signers) > MAX_SIGNERS {
+		return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+	}
+	return nil
+}
+
+func (inst *Authorize) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("Authorize")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("NewAuthority", *inst.NewAuthority))
+						paramsBranch.Child(ag_format.Param("AuthorityType", inst.AuthorityType))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("StakeOrWithdrawAuthority", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (inst Authorize) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `NewAuthority` param:
+	err = encoder.Encode(inst.NewAuthority)
+	if err != nil {
+		return err
+	}
+	// Serialize `AuthorityType` param:
+	err = encoder.Encode(inst.AuthorityType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *Authorize) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `NewAuthority`:
+	err = decoder.Decode(&inst.NewAuthority)
+	if err != nil {
+		return err
+	}
+	// Deserialize `AuthorityType`:
+	err = decoder.Decode(&inst.AuthorityType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst Authorize) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_Authorize, ag_binary.LE),
+	}}
+}
+
+func NewAuthorizeInstruction(
+	newAuthority ag_solanago.PublicKey,
+	authorityType StakeAuthorize,
+	stakeAccount ag_solanago.PublicKey,
+	clockSysvar ag_solanago.PublicKey,
+	stakeOrWithdrawAuthority ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *Authorize {
+	return &Authorize{
+		NewAuthority:  &newAuthority,
+		AuthorityType: authorityType,
+		Accounts: ag_solanago.AccountMetaSlice{
+			ag_solanago.Meta(stakeAccount).WRITE(),
+			ag_solanago.Meta(clockSysvar),
+			ag_solanago.Meta(stakeOrWithdrawAuthority),
+		},
+		Signers: func(keys []ag_solanago.PublicKey) ag_solanago.AccountMetaSlice {
+			metas := make(ag_solanago.AccountMetaSlice, len(keys))
+			for i, key := range keys {
+				metas[i] = ag_solanago.Meta(key).SIGNER()
+			}
+			return metas
+		}(multisigSigners),
+	}
+}

--- a/programs/stake/Authorize.go
+++ b/programs/stake/Authorize.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/stake/AuthorizeChecked.go
+++ b/programs/stake/AuthorizeChecked.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -184,14 +185,14 @@ func (inst *AuthorizeChecked) EncodeToTree(parent ag_treeout.Branches) {
 
 					// Parameters of the instruction:
 					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
-						paramsBranch.Child(ag_format.Param("NewAuthority", *inst.NewAuthority))
+						paramsBranch.Child(ag_format.Param(" NewAuthority", *inst.NewAuthority))
 						paramsBranch.Child(ag_format.Param("AuthorityType", *inst.AuthorityType))
 					})
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.Accounts[0]))
-						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta(" ClockSysvar", inst.Accounts[1]))
 						accountsBranch.Child(ag_format.Meta("OldAuthority", inst.Accounts[2]))
 						accountsBranch.Child(ag_format.Meta("NewAuthority", inst.Accounts[3]))
 

--- a/programs/stake/AuthorizeChecked.go
+++ b/programs/stake/AuthorizeChecked.go
@@ -1,0 +1,258 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+const MAX_SIGNERS = 11
+
+type AuthorizeChecked struct {
+	// The new authority to be set.
+	NewAuthority *ag_solanago.PublicKey
+
+	// The type of authority to be set.
+	AuthorityType *AuthorityType
+
+	// [0] = [WRITE] StakeAccount
+	// ··········· The stake account to be authorized.
+	//
+	// [1] = [] ClockSysvar
+	// ··········· Clock sysvar account.
+	//
+	// [2] = [] OldAuthority
+	// ··········· The old authority account.
+	//
+	// [3] = [SIGNER] NewAuthority
+	// ··········· The new authority account.
+	//
+	// [4...] = [SIGNER] Signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *AuthorizeChecked) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.Accounts, inst.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(4)
+	return nil
+}
+
+func (inst AuthorizeChecked) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	accounts = append(accounts, inst.Signers...)
+	return
+}
+
+// NewAuthorizeCheckedInstructionBuilder creates a new `AuthorizeChecked` instruction builder.
+func NewAuthorizeCheckedInstructionBuilder() *AuthorizeChecked {
+	nd := &AuthorizeChecked{
+		Accounts: make(ag_solanago.AccountMetaSlice, 4),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetNewAuthority sets the "new authority" parameter.
+func (inst *AuthorizeChecked) SetNewAuthority(newAuthority ag_solanago.PublicKey) *AuthorizeChecked {
+	inst.NewAuthority = &newAuthority
+	return inst
+}
+
+// SetAuthorityType sets the "authority type" parameter.
+func (inst *AuthorizeChecked) SetAuthorityType(authorityType AuthorityType) *AuthorizeChecked {
+	inst.AuthorityType = &authorityType
+	return inst
+}
+
+// SetStakeAccount sets the "stake account" account.
+func (inst *AuthorizeChecked) SetStakeAccount(stakeAccount ag_solanago.PublicKey) *AuthorizeChecked {
+	inst.Accounts[0] = ag_solanago.Meta(stakeAccount).WRITE()
+	return inst
+}
+
+// GetStakeAccount gets the "stake account" account.
+func (inst *AuthorizeChecked) GetStakeAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetClockSysvarAccount sets the "clock sysvar" account.
+func (inst *AuthorizeChecked) SetClockSysvarAccount(clockSysvar ag_solanago.PublicKey) *AuthorizeChecked {
+	inst.Accounts[1] = ag_solanago.Meta(clockSysvar)
+	return inst
+}
+
+// GetClockSysvarAccount gets the "clock sysvar" account.
+func (inst *AuthorizeChecked) GetClockSysvarAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetOldAuthorityAccount sets the "old authority" account.
+func (inst *AuthorizeChecked) SetOldAuthorityAccount(oldAuthority ag_solanago.PublicKey) *AuthorizeChecked {
+	inst.Accounts[2] = ag_solanago.Meta(oldAuthority)
+	return inst
+}
+
+// GetOldAuthorityAccount gets the "old authority" account.
+func (inst *AuthorizeChecked) GetOldAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+// SetNewAuthorityAccount sets the "new authority" account.
+func (inst *AuthorizeChecked) SetNewAuthorityAccount(newAuthority ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *AuthorizeChecked {
+	inst.Accounts[3] = ag_solanago.Meta(newAuthority).SIGNER()
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetNewAuthorityAccount gets the "new authority" account.
+func (inst *AuthorizeChecked) GetNewAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[3]
+}
+
+func (inst AuthorizeChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_AuthorizeChecked, ag_binary.LE),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst AuthorizeChecked) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *AuthorizeChecked) Validate() error {
+	if inst.NewAuthority == nil {
+		return errors.New("NewAuthority parameter is not set")
+	}
+	if inst.AuthorityType == nil {
+		return errors.New("AuthorityType parameter is not set")
+	}
+
+	if inst.Accounts[0] == nil {
+		return errors.New("accounts.StakeAccount is not set")
+	}
+	if inst.Accounts[1] == nil {
+		return errors.New("accounts.ClockSysvar is not set")
+	}
+	if inst.Accounts[2] == nil {
+		return errors.New("accounts.OldAuthority is not set")
+	}
+	if inst.Accounts[3] == nil {
+		return errors.New("accounts.NewAuthority is not set")
+	}
+	if len(inst.Signers) > MAX_SIGNERS {
+		return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+	}
+	return nil
+}
+
+func (inst *AuthorizeChecked) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("AuthorizeChecked")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("NewAuthority", *inst.NewAuthority))
+						paramsBranch.Child(ag_format.Param("AuthorityType", *inst.AuthorityType))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("OldAuthority", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("NewAuthority", inst.Accounts[3]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("Signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (inst AuthorizeChecked) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `NewAuthority` param:
+	err = encoder.Encode(inst.NewAuthority)
+	if err != nil {
+		return err
+	}
+	// Serialize `AuthorityType` param:
+	err = encoder.Encode(inst.AuthorityType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *AuthorizeChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `NewAuthority`:
+	err = decoder.Decode(&inst.NewAuthority)
+	if err != nil {
+		return err
+	}
+	// Deserialize `AuthorityType`:
+	err = decoder.Decode(&inst.AuthorityType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewAuthorizeCheckedInstruction declares a new AuthorizeChecked instruction with the provided parameters and accounts.
+func NewAuthorizeCheckedInstruction(
+	// Parameters:
+	newAuthority ag_solanago.PublicKey,
+	authorityType AuthorityType,
+	// Accounts:
+	stakeAccount ag_solanago.PublicKey,
+	clockSysvar ag_solanago.PublicKey,
+	oldAuthority ag_solanago.PublicKey,
+	newAuthorityAccount ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *AuthorizeChecked {
+	return NewAuthorizeCheckedInstructionBuilder().
+		SetNewAuthority(newAuthority).
+		SetAuthorityType(authorityType).
+		SetStakeAccount(stakeAccount).
+		SetClockSysvarAccount(clockSysvar).
+		SetOldAuthorityAccount(oldAuthority).
+		SetNewAuthorityAccount(newAuthorityAccount, multisigSigners...)
+}

--- a/programs/stake/AuthorizeCheckedWithSeed.go
+++ b/programs/stake/AuthorizeCheckedWithSeed.go
@@ -1,0 +1,301 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// AuthorizeCheckedWithSeed instruction
+type AuthorizeCheckedWithSeed struct {
+	// The new authority's public key
+	NewAuthority *ag_solanago.PublicKey
+
+	// The authority type
+	AuthorityType *uint32
+
+	// The base public key
+	Base *ag_solanago.PublicKey
+
+	// The seed
+	Seed *string
+
+	// The owner public key
+	Owner *ag_solanago.PublicKey
+
+	// [0] = [WRITE] StakeAccount
+	// ··········· The stake account to authorize
+	//
+	// [1] = [] ClockSysvar
+	// ··········· Clock sysvar account
+	//
+	// [2] = [] AuthorityBase
+	// ··········· The base public key account
+	//
+	// [3...] = [SIGNER] Signers
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *AuthorizeCheckedWithSeed) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.Accounts, inst.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (inst AuthorizeCheckedWithSeed) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	accounts = append(accounts, inst.Signers...)
+	return
+}
+
+// NewAuthorizeCheckedWithSeedInstructionBuilder creates a new `AuthorizeCheckedWithSeed` instruction builder.
+func NewAuthorizeCheckedWithSeedInstructionBuilder() *AuthorizeCheckedWithSeed {
+	nd := &AuthorizeCheckedWithSeed{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetNewAuthority sets the "new authority" parameter.
+func (inst *AuthorizeCheckedWithSeed) SetNewAuthority(newAuthority ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	inst.NewAuthority = &newAuthority
+	return inst
+}
+
+// SetAuthorityType sets the "authority type" parameter.
+func (inst *AuthorizeCheckedWithSeed) SetAuthorityType(authorityType uint32) *AuthorizeCheckedWithSeed {
+	inst.AuthorityType = &authorityType
+	return inst
+}
+
+// SetBase sets the "base" parameter.
+func (inst *AuthorizeCheckedWithSeed) SetBase(base ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	inst.Base = &base
+	return inst
+}
+
+// SetSeed sets the "seed" parameter.
+func (inst *AuthorizeCheckedWithSeed) SetSeed(seed string) *AuthorizeCheckedWithSeed {
+	inst.Seed = &seed
+	return inst
+}
+
+// SetOwner sets the "owner" parameter.
+func (inst *AuthorizeCheckedWithSeed) SetOwner(owner ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	inst.Owner = &owner
+	return inst
+}
+
+// SetStakeAccount sets the "stake account" account.
+func (inst *AuthorizeCheckedWithSeed) SetStakeAccount(stakeAccount ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	inst.Accounts[0] = ag_solanago.Meta(stakeAccount).WRITE()
+	return inst
+}
+
+// SetClockSysvarAccount sets the "clock sysvar" account.
+func (inst *AuthorizeCheckedWithSeed) SetClockSysvarAccount(clockSysvar ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	inst.Accounts[1] = ag_solanago.Meta(clockSysvar)
+	return inst
+}
+
+// SetAuthorityBaseAccount sets the "authority base" account.
+func (inst *AuthorizeCheckedWithSeed) SetAuthorityBaseAccount(authorityBase ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	inst.Accounts[2] = ag_solanago.Meta(authorityBase)
+	return inst
+}
+
+// SetSigners sets the "signers" accounts.
+func (inst *AuthorizeCheckedWithSeed) SetSigners(signers ...ag_solanago.PublicKey) *AuthorizeCheckedWithSeed {
+	for _, signer := range signers {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+func (inst AuthorizeCheckedWithSeed) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_AuthorizeCheckedWithSeed, ag_binary.LE),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst AuthorizeCheckedWithSeed) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *AuthorizeCheckedWithSeed) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.NewAuthority == nil {
+			return errors.New("NewAuthority parameter is not set")
+		}
+		if inst.AuthorityType == nil {
+			return errors.New("AuthorityType parameter is not set")
+		}
+		if inst.Base == nil {
+			return errors.New("Base parameter is not set")
+		}
+		if inst.Seed == nil {
+			return errors.New("Seed parameter is not set")
+		}
+		if inst.Owner == nil {
+			return errors.New("Owner parameter is not set")
+		}
+	}
+
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.StakeAccount is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.ClockSysvar is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.AuthorityBase is not set")
+		}
+		if len(inst.Signers) == 0 {
+			return errors.New("accounts.Signers is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *AuthorizeCheckedWithSeed) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("AuthorizeCheckedWithSeed")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("NewAuthority", *inst.NewAuthority))
+						paramsBranch.Child(ag_format.Param("AuthorityType", *inst.AuthorityType))
+						paramsBranch.Child(ag_format.Param("Base", *inst.Base))
+						paramsBranch.Child(ag_format.Param("Seed", *inst.Seed))
+						paramsBranch.Child(ag_format.Param("Owner", *inst.Owner))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.Accounts[1]))
+						signersBranch := accountsBranch.Child(fmt.Sprintf("Signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+						}
+					})
+				})
+		})
+}
+
+func (inst AuthorizeCheckedWithSeed) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `NewAuthority` param:
+	err = encoder.Encode(inst.NewAuthority)
+	if err != nil {
+		return err
+	}
+	// Serialize `AuthorityType` param:
+	err = encoder.Encode(inst.AuthorityType)
+	if err != nil {
+		return err
+	}
+	// Serialize `Base` param:
+	err = encoder.Encode(inst.Base)
+	if err != nil {
+		return err
+	}
+	// Serialize `Seed` param:
+	err = encoder.Encode(inst.Seed)
+	if err != nil {
+		return err
+	}
+	// Serialize `Owner` param:
+	err = encoder.Encode(inst.Owner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *AuthorizeCheckedWithSeed) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `NewAuthority`:
+	err = decoder.Decode(&inst.NewAuthority)
+	if err != nil {
+		return err
+	}
+	// Deserialize `AuthorityType`:
+	err = decoder.Decode(&inst.AuthorityType)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Base`:
+	err = decoder.Decode(&inst.Base)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Seed`:
+	err = decoder.Decode(&inst.Seed)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Owner`:
+	err = decoder.Decode(&inst.Owner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewAuthorizeCheckedWithSeedInstruction declares a new AuthorizeCheckedWithSeed instruction with the provided parameters and accounts.
+func NewAuthorizeCheckedWithSeedInstruction(
+	// Parameters:
+	newAuthority ag_solanago.PublicKey,
+	authorityType uint32,
+	base ag_solanago.PublicKey,
+	seed string,
+	owner ag_solanago.PublicKey,
+	// Accounts:
+	stakeAccount ag_solanago.PublicKey,
+	clockSysvar ag_solanago.PublicKey,
+	authorityBase ag_solanago.PublicKey,
+	signers []ag_solanago.PublicKey,
+) *AuthorizeCheckedWithSeed {
+	return NewAuthorizeCheckedWithSeedInstructionBuilder().
+		SetNewAuthority(newAuthority).
+		SetAuthorityType(authorityType).
+		SetBase(base).
+		SetSeed(seed).
+		SetOwner(owner).
+		SetStakeAccount(stakeAccount).
+		SetClockSysvarAccount(clockSysvar).
+		SetAuthorityBaseAccount(authorityBase).
+		SetSigners(signers...)
+}

--- a/programs/stake/AuthorizeCheckedWithSeed.go
+++ b/programs/stake/AuthorizeCheckedWithSeed.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -196,17 +197,17 @@ func (inst *AuthorizeCheckedWithSeed) EncodeToTree(parent ag_treeout.Branches) {
 
 					// Parameters of the instruction:
 					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
-						paramsBranch.Child(ag_format.Param("NewAuthority", *inst.NewAuthority))
+						paramsBranch.Child(ag_format.Param(" NewAuthority", *inst.NewAuthority))
 						paramsBranch.Child(ag_format.Param("AuthorityType", *inst.AuthorityType))
-						paramsBranch.Child(ag_format.Param("Base", *inst.Base))
-						paramsBranch.Child(ag_format.Param("Seed", *inst.Seed))
-						paramsBranch.Child(ag_format.Param("Owner", *inst.Owner))
+						paramsBranch.Child(ag_format.Param("         Base", *inst.Base))
+						paramsBranch.Child(ag_format.Param("         Seed", *inst.Seed))
+						paramsBranch.Child(ag_format.Param("        Owner", *inst.Owner))
 					})
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.Accounts[0]))
-						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta(" ClockSysvar", inst.Accounts[1]))
 						signersBranch := accountsBranch.Child(fmt.Sprintf("Signers[len=%v]", len(inst.Signers)))
 						for i, v := range inst.Signers {
 							signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))

--- a/programs/stake/AuthorizeCheckedWithSeed.go
+++ b/programs/stake/AuthorizeCheckedWithSeed.go
@@ -160,13 +160,13 @@ func (inst *AuthorizeCheckedWithSeed) Validate() error {
 			return errors.New("AuthorityType parameter is not set")
 		}
 		if inst.Base == nil {
-			return errors.New("Base parameter is not set")
+			return errors.New("base parameter is not set")
 		}
 		if inst.Seed == nil {
-			return errors.New("Seed parameter is not set")
+			return errors.New("seed parameter is not set")
 		}
 		if inst.Owner == nil {
-			return errors.New("Owner parameter is not set")
+			return errors.New("owner parameter is not set")
 		}
 	}
 

--- a/programs/stake/AuthorizeWithSeed.go
+++ b/programs/stake/AuthorizeWithSeed.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/stake/AuthorizeWithSeed.go
+++ b/programs/stake/AuthorizeWithSeed.go
@@ -1,0 +1,231 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/text/format"
+)
+
+type AuthorizeWithSeed struct {
+	// The public key of the base account used to derive the authority address
+	Base *solana.PublicKey
+
+	// The seed used to derive the authority address
+	Seed *string
+
+	// The public key of the owner program used to derive the authority address
+	Owner *solana.PublicKey
+
+	// The public key of the new authority
+	NewAuthority *solana.PublicKey
+
+	// The type of authority to authorize
+	AuthorityType *AuthorityType
+
+	// [0] = [WRITE] StakeAccount
+	// ··········· The stake account to authorize
+	//
+	// [1] = [] BaseAccount
+	// ··········· The base account used to derive the authority address
+	//
+	// [2] = [] ClockSysvar
+	// ··········· Clock sysvar account
+	//
+	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *AuthorizeWithSeed) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := dec.Decode(&inst.Base); err != nil {
+		return err
+	}
+	if err := dec.Decode(&inst.Seed); err != nil {
+		return err
+	}
+	if err := dec.Decode(&inst.Owner); err != nil {
+		return err
+	}
+	if err := dec.Decode(&inst.NewAuthority); err != nil {
+		return err
+	}
+	if err := dec.Decode(&inst.AuthorityType); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *AuthorizeWithSeed) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.Encode(*inst.Base); err != nil {
+		return err
+	}
+	if err := encoder.Encode(*inst.Seed); err != nil {
+		return err
+	}
+	if err := encoder.Encode(*inst.Owner); err != nil {
+		return err
+	}
+	if err := encoder.Encode(*inst.NewAuthority); err != nil {
+		return err
+	}
+	if err := encoder.Encode(*inst.AuthorityType); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *AuthorizeWithSeed) Validate() error {
+	if inst.Base == nil {
+		return errors.New("base parameter is not set")
+	}
+	if inst.Seed == nil {
+		return errors.New("seed parameter is not set")
+	}
+	if inst.Owner == nil {
+		return errors.New("owner parameter is not set")
+	}
+	if inst.NewAuthority == nil {
+		return errors.New("new authority parameter is not set")
+	}
+	if inst.AuthorityType == nil {
+		return errors.New("authority type parameter is not set")
+	}
+
+	for accIndex, acc := range inst.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("ins.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+// Stake account account
+func (inst *AuthorizeWithSeed) SetStakeAccount(stakeAccount solana.PublicKey) *AuthorizeWithSeed {
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE()
+	return inst
+}
+
+// Base account
+func (inst *AuthorizeWithSeed) SetBaseAccount(baseAccount solana.PublicKey) *AuthorizeWithSeed {
+	inst.AccountMetaSlice[1] = solana.Meta(baseAccount)
+	return inst
+}
+
+// Clock sysvar account
+func (inst *AuthorizeWithSeed) SetClockSysvarAccount(clockSysvar solana.PublicKey) *AuthorizeWithSeed {
+	inst.AccountMetaSlice[2] = solana.Meta(clockSysvar)
+	return inst
+}
+
+func (inst *AuthorizeWithSeed) GetStakeAccount() *solana.AccountMeta { return inst.AccountMetaSlice[0] }
+func (inst *AuthorizeWithSeed) GetBaseAccount() *solana.AccountMeta  { return inst.AccountMetaSlice[1] }
+func (inst *AuthorizeWithSeed) GetClockSysvarAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice[2]
+}
+
+func (inst *AuthorizeWithSeed) SetBase(base solana.PublicKey) *AuthorizeWithSeed {
+	inst.Base = &base
+	return inst
+}
+
+func (inst *AuthorizeWithSeed) SetSeed(seed string) *AuthorizeWithSeed {
+	inst.Seed = &seed
+	return inst
+}
+
+func (inst *AuthorizeWithSeed) SetOwner(owner solana.PublicKey) *AuthorizeWithSeed {
+	inst.Owner = &owner
+	return inst
+}
+
+func (inst *AuthorizeWithSeed) SetNewAuthority(newAuthority solana.PublicKey) *AuthorizeWithSeed {
+	inst.NewAuthority = &newAuthority
+	return inst
+}
+
+func (inst *AuthorizeWithSeed) SetAuthorityType(authorityType AuthorityType) *AuthorizeWithSeed {
+	inst.AuthorityType = &authorityType
+	return inst
+}
+
+func (inst AuthorizeWithSeed) Build() *Instruction {
+	return &Instruction{BaseVariant: bin.BaseVariant{
+		Impl:   inst,
+		TypeID: bin.TypeIDFromUint32(Instruction_AuthorizeWithSeed, bin.LE),
+	}}
+}
+
+func (inst *AuthorizeWithSeed) EncodeToTree(parent treeout.Branches) {
+	parent.Child(format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch treeout.Branches) {
+			programBranch.Child(format.Instruction("AuthorizeWithSeed")).
+				//
+				ParentFunc(func(instructionBranch treeout.Branches) {
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
+						paramsBranch.Child(format.Account("Base", *inst.Base))
+						paramsBranch.Child(format.Param("Seed", *inst.Seed))
+						paramsBranch.Child(format.Account("Owner", *inst.Owner))
+						paramsBranch.Child(format.Account("NewAuthority", *inst.NewAuthority))
+						paramsBranch.Child(format.Param("AuthorityType", *inst.AuthorityType))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("BaseAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(2)))
+					})
+				})
+		})
+}
+
+// NewAuthorizeWithSeedInstructionBuilder creates a new `AuthorizeWithSeed` instruction builder.
+func NewAuthorizeWithSeedInstructionBuilder() *AuthorizeWithSeed {
+	nd := &AuthorizeWithSeed{
+		AccountMetaSlice: make(solana.AccountMetaSlice, 3),
+	}
+	return nd
+}
+
+// NewAuthorizeWithSeedInstruction declares a new AuthorizeWithSeed instruction with the provided parameters and accounts.
+func NewAuthorizeWithSeedInstruction(
+	// parameters:
+	base solana.PublicKey,
+	seed string,
+	owner solana.PublicKey,
+	newAuthority solana.PublicKey,
+	authorityType AuthorityType,
+	// Accounts:
+	stakeAccount solana.PublicKey,
+	baseAccount solana.PublicKey,
+	clockSysvar solana.PublicKey,
+) *AuthorizeWithSeed {
+	return NewAuthorizeWithSeedInstructionBuilder().
+		SetBase(base).
+		SetSeed(seed).
+		SetOwner(owner).
+		SetNewAuthority(newAuthority).
+		SetAuthorityType(authorityType).
+		SetStakeAccount(stakeAccount).
+		SetBaseAccount(baseAccount).
+		SetClockSysvarAccount(clockSysvar)
+}

--- a/programs/stake/Authorized.go
+++ b/programs/stake/Authorized.go
@@ -30,34 +30,30 @@ type Authorized struct {
 }
 
 func (inst *Authorized) UnmarshalWithDecoder(dec *bin.Decoder) error {
-	{
-		err := dec.Decode(&inst.Staker)
-		if err != nil {
-			return err
-		}
+	err := dec.Decode(&inst.Staker)
+	if err != nil {
+		return err
 	}
-	{
-		err := dec.Decode(&inst.Withdrawer)
-		if err != nil {
-			return err
-		}
+
+	err = dec.Decode(&inst.Withdrawer)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 
 func (inst *Authorized) MarshalWithEncoder(encoder *bin.Encoder) error {
-	{
-		err := encoder.Encode(*inst.Staker)
-		if err != nil {
-			return err
-		}
+	err := encoder.Encode(*inst.Staker)
+	if err != nil {
+		return err
 	}
-	{
-		err := encoder.Encode(*inst.Withdrawer)
-		if err != nil {
-			return err
-		}
+
+	err = encoder.Encode(*inst.Withdrawer)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 

--- a/programs/stake/Authorized.go
+++ b/programs/stake/Authorized.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	bin "github.com/gagliardetto/binary"
+
 	ag_solanago "github.com/gagliardetto/solana-go"
 )
 
@@ -28,31 +29,15 @@ type Authorized struct {
 	Withdrawer *ag_solanago.PublicKey
 }
 
-func (auth *Authorized) UnmarshalWithDecoder(dec *bin.Decoder) error {
+func (inst *Authorized) UnmarshalWithDecoder(dec *bin.Decoder) error {
 	{
-		err := dec.Decode(&auth.Staker)
+		err := dec.Decode(&inst.Staker)
 		if err != nil {
 			return err
 		}
 	}
 	{
-		err := dec.Decode(&auth.Withdrawer)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (auth *Authorized) MarshalWithEncoder(encoder *bin.Encoder) error {
-	{
-		err := encoder.Encode(*auth.Staker)
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := encoder.Encode(*auth.Withdrawer)
+		err := dec.Decode(&inst.Withdrawer)
 		if err != nil {
 			return err
 		}
@@ -60,11 +45,27 @@ func (auth *Authorized) MarshalWithEncoder(encoder *bin.Encoder) error {
 	return nil
 }
 
-func (auth *Authorized) Validate() error {
-	if auth.Staker == nil {
+func (inst *Authorized) MarshalWithEncoder(encoder *bin.Encoder) error {
+	{
+		err := encoder.Encode(*inst.Staker)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err := encoder.Encode(*inst.Withdrawer)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (inst *Authorized) Validate() error {
+	if inst.Staker == nil {
 		return errors.New("staker parameter is not set")
 	}
-	if auth.Withdrawer == nil {
+	if inst.Withdrawer == nil {
 		return errors.New("withdrawer parameter is not set")
 	}
 	return nil

--- a/programs/stake/Deactivate.go
+++ b/programs/stake/Deactivate.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/text/format"
-	"github.com/gagliardetto/treeout"
 )
 
 type Deactivate struct {
-
 	// [0] = [WRITE] Stake Account
 	// ··········· Delegated stake account to be deactivated
 	//
@@ -90,9 +90,9 @@ func (inst *Deactivate) EncodeToTree(parent treeout.Branches) {
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
-						accountsBranch.Child(format.Meta("            StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("             ClockSysvar", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("           StakeAuthoriy", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("StakeAuthoriy", inst.AccountMetaSlice.Get(2)))
 					})
 				})
 		})

--- a/programs/stake/DeactivateDelinquent.go
+++ b/programs/stake/DeactivateDelinquent.go
@@ -1,0 +1,159 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// DeactivateDelinquent instruction
+type DeactivateDelinquent struct {
+	// [0] = [WRITE] StakeAccount
+	// ··········· The stake account to deactivate.
+	//
+	// [1] = [] DelinquentVoteAccount
+	// ··········· The delinquent vote account.
+	//
+	// [2] = [] ReferenceVoteAccount
+	// ··········· The reference vote account.
+	//
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *DeactivateDelinquent) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.AccountMetaSlice = accounts
+	return nil
+}
+
+func (inst DeactivateDelinquent) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.AccountMetaSlice...)
+	return
+}
+
+// NewDeactivateDelinquentInstructionBuilder creates a new `DeactivateDelinquent` instruction builder.
+func NewDeactivateDelinquentInstructionBuilder() *DeactivateDelinquent {
+	nd := &DeactivateDelinquent{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 3),
+	}
+	return nd
+}
+
+// SetStakeAccount sets the "StakeAccount" account.
+// The stake account to deactivate.
+func (inst *DeactivateDelinquent) SetStakeAccount(stakeAccount ag_solanago.PublicKey) *DeactivateDelinquent {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(stakeAccount).WRITE()
+	return inst
+}
+
+// GetStakeAccount gets the "StakeAccount" account.
+// The stake account to deactivate.
+func (inst *DeactivateDelinquent) GetStakeAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+// SetDelinquentVoteAccount sets the "DelinquentVoteAccount" account.
+// The delinquent vote account.
+func (inst *DeactivateDelinquent) SetDelinquentVoteAccount(delinquentVoteAccount ag_solanago.PublicKey) *DeactivateDelinquent {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(delinquentVoteAccount)
+	return inst
+}
+
+// GetDelinquentVoteAccount gets the "DelinquentVoteAccount" account.
+// The delinquent vote account.
+func (inst *DeactivateDelinquent) GetDelinquentVoteAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+
+// SetReferenceVoteAccount sets the "ReferenceVoteAccount" account.
+// The reference vote account.
+func (inst *DeactivateDelinquent) SetReferenceVoteAccount(referenceVoteAccount ag_solanago.PublicKey) *DeactivateDelinquent {
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(referenceVoteAccount)
+	return inst
+}
+
+// GetReferenceVoteAccount gets the "ReferenceVoteAccount" account.
+// The reference vote account.
+func (inst *DeactivateDelinquent) GetReferenceVoteAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[2]
+}
+
+func (inst DeactivateDelinquent) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_DeactivateDelinquent, ag_binary.LE),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst DeactivateDelinquent) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *DeactivateDelinquent) Validate() error {
+	// Check whether all accounts are set:
+	for accIndex, acc := range inst.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("ins.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+func (inst *DeactivateDelinquent) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("DeactivateDelinquent")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(ag_format.Meta("DelinquentVoteAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(ag_format.Meta("ReferenceVoteAccount", inst.AccountMetaSlice.Get(2)))
+					})
+				})
+		})
+}
+
+func (inst DeactivateDelinquent) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (inst *DeactivateDelinquent) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewDeactivateDelinquentInstruction declares a new DeactivateDelinquent instruction with the provided accounts.
+func NewDeactivateDelinquentInstruction(
+	// Accounts:
+	stakeAccount ag_solanago.PublicKey,
+	delinquentVoteAccount ag_solanago.PublicKey,
+	referenceVoteAccount ag_solanago.PublicKey,
+) *DeactivateDelinquent {
+	return NewDeactivateDelinquentInstructionBuilder().
+		SetStakeAccount(stakeAccount).
+		SetDelinquentVoteAccount(delinquentVoteAccount).
+		SetReferenceVoteAccount(referenceVoteAccount)
+}

--- a/programs/stake/DeactivateDelinquent.go
+++ b/programs/stake/DeactivateDelinquent.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,9 +130,9 @@ func (inst *DeactivateDelinquent) EncodeToTree(parent ag_treeout.Branches) {
 				ParentFunc(func(instructionBranch ag_treeout.Branches) {
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(ag_format.Meta("         StakeAccount", inst.AccountMetaSlice.Get(0)))
 						accountsBranch.Child(ag_format.Meta("DelinquentVoteAccount", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(ag_format.Meta("ReferenceVoteAccount", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(ag_format.Meta(" ReferenceVoteAccount", inst.AccountMetaSlice.Get(2)))
 					})
 				})
 		})

--- a/programs/stake/DelegateStake.go
+++ b/programs/stake/DelegateStake.go
@@ -17,10 +17,11 @@ package stake
 import (
 	"fmt"
 
-	bin "github.com/gagliardetto/binary"
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/text/format"
-	"github.com/gagliardetto/treeout"
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
 )
 
 type DelegateStake struct {
@@ -42,7 +43,7 @@ type DelegateStake struct {
 	// [5] = [WRITE SIGNER] Stake Authoriy
 	// ··········· The Stake Authority
 	//
-	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 func (inst *DelegateStake) Validate() error {
@@ -54,65 +55,71 @@ func (inst *DelegateStake) Validate() error {
 	}
 	return nil
 }
-func (inst *DelegateStake) SetStakeAccount(stakeAccount solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE().SIGNER()
+func (inst *DelegateStake) SetStakeAccount(stakeAccount ag_solanago.PublicKey) *DelegateStake {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(stakeAccount).WRITE().SIGNER()
 	return inst
 }
-func (inst *DelegateStake) SetVoteAccount(voteAcc solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[1] = solana.Meta(voteAcc)
+func (inst *DelegateStake) SetVoteAccount(voteAcc ag_solanago.PublicKey) *DelegateStake {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(voteAcc)
 	return inst
 }
-func (inst *DelegateStake) SetClockSysvar(clockSysVarAcc solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[2] = solana.Meta(clockSysVarAcc)
+func (inst *DelegateStake) SetClockSysvar(clockSysVarAcc ag_solanago.PublicKey) *DelegateStake {
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(clockSysVarAcc)
 	return inst
 }
-func (inst *DelegateStake) SetStakeHistorySysvar(stakeHistorySysVarAcc solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[3] = solana.Meta(stakeHistorySysVarAcc)
+func (inst *DelegateStake) SetStakeHistorySysvar(stakeHistorySysVarAcc ag_solanago.PublicKey) *DelegateStake {
+	inst.AccountMetaSlice[3] = ag_solanago.Meta(stakeHistorySysVarAcc)
 	return inst
 }
-func (inst *DelegateStake) SetConfigAccount(stakeConfigAcc solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[4] = solana.Meta(stakeConfigAcc)
+func (inst *DelegateStake) SetConfigAccount(stakeConfigAcc ag_solanago.PublicKey) *DelegateStake {
+	inst.AccountMetaSlice[4] = ag_solanago.Meta(stakeConfigAcc)
 	return inst
 }
-func (inst *DelegateStake) SetStakeAuthority(stakeAuthority solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[5] = solana.Meta(stakeAuthority).WRITE().SIGNER()
+func (inst *DelegateStake) SetStakeAuthority(stakeAuthority ag_solanago.PublicKey) *DelegateStake {
+	inst.AccountMetaSlice[5] = ag_solanago.Meta(stakeAuthority).WRITE().SIGNER()
 	return inst
 }
-func (inst *DelegateStake) GetStakeAccount() *solana.AccountMeta { return inst.AccountMetaSlice[0] }
-func (inst *DelegateStake) GetVoteAccount() *solana.AccountMeta  { return inst.AccountMetaSlice[1] }
-func (inst *DelegateStake) GetClockSysvar() *solana.AccountMeta  { return inst.AccountMetaSlice[2] }
-func (inst *DelegateStake) GetStakeHistorySysvar() *solana.AccountMeta {
+func (inst *DelegateStake) GetStakeAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+func (inst *DelegateStake) GetVoteAccount() *ag_solanago.AccountMeta { return inst.AccountMetaSlice[1] }
+func (inst *DelegateStake) GetClockSysvar() *ag_solanago.AccountMeta { return inst.AccountMetaSlice[2] }
+func (inst *DelegateStake) GetStakeHistorySysvar() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice[3]
 }
-func (inst *DelegateStake) GetConfigAccount() *solana.AccountMeta  { return inst.AccountMetaSlice[4] }
-func (inst *DelegateStake) GetStakeAuthority() *solana.AccountMeta { return inst.AccountMetaSlice[5] }
+func (inst *DelegateStake) GetConfigAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[4]
+}
+func (inst *DelegateStake) GetStakeAuthority() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[5]
+}
 
 func (inst DelegateStake) Build() *Instruction {
-	return &Instruction{BaseVariant: bin.BaseVariant{
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
-		TypeID: bin.TypeIDFromUint32(Instruction_DelegateStake, bin.LE),
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_DelegateStake, ag_binary.LE),
 	}}
 }
 
-func (inst *DelegateStake) EncodeToTree(parent treeout.Branches) {
-	parent.Child(format.Program(ProgramName, ProgramID)).
+func (inst *DelegateStake) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
-		ParentFunc(func(programBranch treeout.Branches) {
-			programBranch.Child(format.Instruction("DelegateStake")).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("DelegateStake")).
 				//
-				ParentFunc(func(instructionBranch treeout.Branches) {
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
 					// Parameters of the instruction:
-					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
-						accountsBranch.Child(format.Meta("           StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("           VoteAccount", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("           ClockSysvar", inst.AccountMetaSlice.Get(2)))
-						accountsBranch.Child(format.Meta("           StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
-						accountsBranch.Child(format.Meta("           StakeConfigAccount", inst.AccountMetaSlice.Get(4)))
-						accountsBranch.Child(format.Meta("           StakeAuthoriy", inst.AccountMetaSlice.Get(5)))
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(ag_format.Meta("VoteAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(ag_format.Meta("StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
+						accountsBranch.Child(ag_format.Meta("StakeConfigAccount", inst.AccountMetaSlice.Get(4)))
+						accountsBranch.Child(ag_format.Meta("StakeAuthoriy", inst.AccountMetaSlice.Get(5)))
 					})
 				})
 		})
@@ -121,7 +128,7 @@ func (inst *DelegateStake) EncodeToTree(parent treeout.Branches) {
 // NewDelegateStakeInstructionBuilder creates a new `DelegateStake` instruction builder.
 func NewDelegateStakeInstructionBuilder() *DelegateStake {
 	nd := &DelegateStake{
-		AccountMetaSlice: make(solana.AccountMetaSlice, 6),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	return nd
 }
@@ -129,15 +136,15 @@ func NewDelegateStakeInstructionBuilder() *DelegateStake {
 // NewDelegateStakeInstruction declares a new DelegateStake instruction with the provided parameters and accounts.
 func NewDelegateStakeInstruction(
 	// Accounts:
-	validatorVoteAccount solana.PublicKey,
-	stakeAuthority solana.PublicKey,
-	stakeAccount solana.PublicKey,
+	validatorVoteAccount ag_solanago.PublicKey,
+	stakeAuthority ag_solanago.PublicKey,
+	stakeAccount ag_solanago.PublicKey,
 ) *DelegateStake {
 	return NewDelegateStakeInstructionBuilder().
 		SetStakeAccount(stakeAccount).
 		SetVoteAccount(validatorVoteAccount).
-		SetClockSysvar(solana.SysVarClockPubkey).
-		SetStakeHistorySysvar(solana.SysVarStakeHistoryPubkey).
-		SetConfigAccount(solana.SysVarStakeConfigPubkey).
+		SetClockSysvar(ag_solanago.SysVarClockPubkey).
+		SetStakeHistorySysvar(ag_solanago.SysVarStakeHistoryPubkey).
+		SetConfigAccount(ag_solanago.SysVarStakeConfigPubkey).
 		SetStakeAuthority(stakeAuthority)
 }

--- a/programs/stake/GetMinimumDelegation.go
+++ b/programs/stake/GetMinimumDelegation.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/stake/GetMinimumDelegation.go
+++ b/programs/stake/GetMinimumDelegation.go
@@ -1,0 +1,69 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// GetMinimumDelegation instruction
+type GetMinimumDelegation struct {
+}
+
+func (inst GetMinimumDelegation) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst GetMinimumDelegation) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_GetMinimumDelegation, ag_binary.LE),
+	}}
+}
+
+func (inst *GetMinimumDelegation) Validate() error {
+	return nil
+}
+
+func (inst *GetMinimumDelegation) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("GetMinimumDelegation")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+				})
+		})
+}
+
+func (inst GetMinimumDelegation) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (inst *GetMinimumDelegation) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewGetMinimumDelegationInstruction declares a new GetMinimumDelegation instruction with the provided accounts.
+func NewGetMinimumDelegationInstruction() *GetMinimumDelegation {
+	return &GetMinimumDelegation{}
+}

--- a/programs/stake/GetMinimumDelegation.go
+++ b/programs/stake/GetMinimumDelegation.go
@@ -23,8 +23,7 @@ import (
 )
 
 // GetMinimumDelegation instruction
-type GetMinimumDelegation struct {
-}
+type GetMinimumDelegation struct{}
 
 func (inst GetMinimumDelegation) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {

--- a/programs/stake/Initialize.go
+++ b/programs/stake/Initialize.go
@@ -19,18 +19,17 @@ import (
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/text/format"
-	"github.com/gagliardetto/treeout"
 )
 
 type Initialize struct {
 	// Authorization settings for stake account
 	Authorized *Authorized
-
 	// Lockup settings for stake account
 	Lockup *Lockup
-
 	// [0] = [WRITE SIGNER] StakeAccount
 	// ··········· Stake account getting initialized
 	//
@@ -41,56 +40,49 @@ type Initialize struct {
 }
 
 func (inst *Initialize) UnmarshalWithDecoder(dec *bin.Decoder) error {
-	{
-		err := dec.Decode(&inst.Authorized)
-		if err != nil {
-			return err
-		}
+	err := dec.Decode(&inst.Authorized)
+	if err != nil {
+		return err
 	}
-	{
-		err := dec.Decode(&inst.Lockup)
-		if err != nil {
-			return err
-		}
+
+	err = dec.Decode(&inst.Lockup)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 
 func (inst *Initialize) MarshalWithEncoder(encoder *bin.Encoder) error {
-	{
-		err := encoder.Encode(*inst.Authorized)
-		if err != nil {
-			return err
-		}
+	err := encoder.Encode(*inst.Authorized)
+	if err != nil {
+		return err
 	}
-	{
-		err := encoder.Encode(*inst.Lockup)
-		if err != nil {
-			return err
-		}
+
+	err = encoder.Encode(*inst.Lockup)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 
 func (inst *Initialize) Validate() error {
 	// Check whether all (required) parameters are set:
-	{
-		if inst.Authorized == nil {
-			return errors.New("authorized parameter is not set")
-		}
-		err := inst.Authorized.Validate()
-		if err != nil {
-			return err
-		}
+	if inst.Authorized == nil {
+		return errors.New("authorized parameter is not set")
 	}
-	{
-		if inst.Lockup == nil {
-			return errors.New("lockup parameter is not set")
-		}
-		err := inst.Lockup.Validate()
-		if err != nil {
-			return err
-		}
+	err := inst.Authorized.Validate()
+	if err != nil {
+		return err
+	}
+
+	if inst.Lockup == nil {
+		return errors.New("lockup parameter is not set")
+	}
+	err = inst.Lockup.Validate()
+	if err != nil {
+		return err
 	}
 
 	// Check whether all accounts are set:
@@ -158,20 +150,20 @@ func (inst *Initialize) EncodeToTree(parent treeout.Branches) {
 					// Parameters of the instruction:
 					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
 						paramsBranch.Child("Authorized").ParentFunc(func(authBranch treeout.Branches) {
-							authBranch.Child(format.Account("    Staker", *inst.Authorized.Staker))
+							authBranch.Child(format.Account("Staker", *inst.Authorized.Staker))
 							authBranch.Child(format.Account("Withdrawer", *inst.Authorized.Withdrawer))
 						})
 						paramsBranch.Child("Lockup").ParentFunc(func(authBranch treeout.Branches) {
 							authBranch.Child(format.Param("UnixTimestamp", inst.Lockup.UnixTimestamp))
-							authBranch.Child(format.Param("        Epoch", inst.Lockup.Epoch))
-							authBranch.Child(format.Account("    Custodian", *inst.Lockup.Custodian))
+							authBranch.Child(format.Param("Epoch", inst.Lockup.Epoch))
+							authBranch.Child(format.Account("Custodian", *inst.Lockup.Custodian))
 						})
 					})
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
-						accountsBranch.Child(format.Meta("           StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("           RentSysvar", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("RentSysvar", inst.AccountMetaSlice.Get(1)))
 					})
 				})
 		})

--- a/programs/stake/InitializeChecked.go
+++ b/programs/stake/InitializeChecked.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/stake/InitializeChecked.go
+++ b/programs/stake/InitializeChecked.go
@@ -49,56 +49,49 @@ type InitializeChecked struct {
 }
 
 func (inst *InitializeChecked) UnmarshalWithDecoder(dec *bin.Decoder) error {
-	{
-		err := dec.Decode(&inst.Authorized)
-		if err != nil {
-			return err
-		}
+	err := dec.Decode(&inst.Authorized)
+	if err != nil {
+		return err
 	}
-	{
-		err := dec.Decode(&inst.Lockup)
-		if err != nil {
-			return err
-		}
+
+	err = dec.Decode(&inst.Lockup)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 
 func (inst *InitializeChecked) MarshalWithEncoder(encoder *bin.Encoder) error {
-	{
-		err := encoder.Encode(*inst.Authorized)
-		if err != nil {
-			return err
-		}
+	err := encoder.Encode(*inst.Authorized)
+	if err != nil {
+		return err
 	}
-	{
-		err := encoder.Encode(*inst.Lockup)
-		if err != nil {
-			return err
-		}
+
+	err = encoder.Encode(*inst.Lockup)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 
 func (inst *InitializeChecked) Validate() error {
 	// Check whether all (required) parameters are set:
-	{
-		if inst.Authorized == nil {
-			return errors.New("authorized parameter is not set")
-		}
-		err := inst.Authorized.Validate()
-		if err != nil {
-			return err
-		}
+	if inst.Authorized == nil {
+		return errors.New("authorized parameter is not set")
 	}
-	{
-		if inst.Lockup == nil {
-			return errors.New("lockup parameter is not set")
-		}
-		err := inst.Lockup.Validate()
-		if err != nil {
-			return err
-		}
+	err := inst.Authorized.Validate()
+	if err != nil {
+		return err
+	}
+
+	if inst.Lockup == nil {
+		return errors.New("lockup parameter is not set")
+	}
+	err = inst.Lockup.Validate()
+	if err != nil {
+		return err
 	}
 
 	// Check whether all accounts are set:
@@ -191,17 +184,17 @@ func (inst *InitializeChecked) EncodeToTree(parent treeout.Branches) {
 							authBranch.Child(format.Account("Withdrawer", *inst.Authorized.Withdrawer))
 						})
 						paramsBranch.Child("Lockup").ParentFunc(func(authBranch treeout.Branches) {
-							authBranch.Child(format.Param("UnixTimestamp", inst.Lockup.UnixTimestamp))
-							authBranch.Child(format.Param("        Epoch", inst.Lockup.Epoch))
+							authBranch.Child(format.Param("  UnixTimestamp", inst.Lockup.UnixTimestamp))
+							authBranch.Child(format.Param("          Epoch", inst.Lockup.Epoch))
 							authBranch.Child(format.Account("    Custodian", *inst.Lockup.Custodian))
 						})
 					})
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
-						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("RentSysvar", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("StakeAuthority", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("     StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("       RentSysvar", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("   StakeAuthority", inst.AccountMetaSlice.Get(2)))
 						accountsBranch.Child(format.Meta("WithdrawAuthority", inst.AccountMetaSlice.Get(3)))
 					})
 				})

--- a/programs/stake/InitializeChecked.go
+++ b/programs/stake/InitializeChecked.go
@@ -1,0 +1,238 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/text/format"
+)
+
+type InitializeChecked struct {
+	// Authorization settings for stake account
+	Authorized *Authorized
+
+	// Lockup settings for stake account
+	Lockup *Lockup
+
+	// [0] = [WRITE SIGNER] StakeAccount
+	// ··········· Stake account getting initialized
+	//
+	// [1] = [] RentSysvar
+	// ··········· RentSysvar account
+	//
+	// [2] = [] StakeAuthority
+	// ··········· Stake authority account
+	//
+	// [3] = [] WithdrawAuthority
+	// ··········· Withdraw authority account
+	//
+	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *InitializeChecked) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	{
+		err := dec.Decode(&inst.Authorized)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err := dec.Decode(&inst.Lockup)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeChecked) MarshalWithEncoder(encoder *bin.Encoder) error {
+	{
+		err := encoder.Encode(*inst.Authorized)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err := encoder.Encode(*inst.Lockup)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeChecked) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Authorized == nil {
+			return errors.New("authorized parameter is not set")
+		}
+		err := inst.Authorized.Validate()
+		if err != nil {
+			return err
+		}
+	}
+	{
+		if inst.Lockup == nil {
+			return errors.New("lockup parameter is not set")
+		}
+		err := inst.Lockup.Validate()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check whether all accounts are set:
+	for accIndex, acc := range inst.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("ins.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+// Stake account account
+func (inst *InitializeChecked) SetStakeAccount(stakeAccount solana.PublicKey) *InitializeChecked {
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE().SIGNER()
+	return inst
+}
+
+// Rent sysvar account
+func (inst *InitializeChecked) SetRentSysvarAccount(rentSysvar solana.PublicKey) *InitializeChecked {
+	inst.AccountMetaSlice[1] = solana.Meta(rentSysvar)
+	return inst
+}
+
+// Stake authority account
+func (inst *InitializeChecked) SetStakeAuthorityAccount(stakeAuthority solana.PublicKey) *InitializeChecked {
+	inst.AccountMetaSlice[2] = solana.Meta(stakeAuthority)
+	return inst
+}
+
+// Withdraw authority account
+func (inst *InitializeChecked) SetWithdrawAuthorityAccount(withdrawAuthority solana.PublicKey) *InitializeChecked {
+	inst.AccountMetaSlice[3] = solana.Meta(withdrawAuthority)
+	return inst
+}
+
+func (inst *InitializeChecked) GetStakeAccount() *solana.AccountMeta { return inst.AccountMetaSlice[0] }
+func (inst *InitializeChecked) GetRentSysvarAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+func (inst *InitializeChecked) GetStakeAuthorityAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice[2]
+}
+func (inst *InitializeChecked) GetWithdrawAuthorityAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice[3]
+}
+
+func (inst *InitializeChecked) SetStaker(staker solana.PublicKey) *InitializeChecked {
+	inst.Authorized.Staker = &staker
+	return inst
+}
+
+func (inst *InitializeChecked) SetWithdrawer(withdrawer solana.PublicKey) *InitializeChecked {
+	inst.Authorized.Withdrawer = &withdrawer
+	return inst
+}
+
+func (inst *InitializeChecked) SetLockupTimestamp(unixTimestamp int64) *InitializeChecked {
+	inst.Lockup.UnixTimestamp = &unixTimestamp
+	return inst
+}
+
+func (inst *InitializeChecked) SetLockupEpoch(epoch uint64) *InitializeChecked {
+	inst.Lockup.Epoch = &epoch
+	return inst
+}
+
+func (inst *InitializeChecked) SetCustodian(custodian solana.PublicKey) *InitializeChecked {
+	inst.Lockup.Custodian = &custodian
+	return inst
+}
+
+func (inst InitializeChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: bin.BaseVariant{
+		Impl:   inst,
+		TypeID: bin.TypeIDFromUint32(Instruction_InitializeChecked, bin.LE),
+	}}
+}
+
+func (inst *InitializeChecked) EncodeToTree(parent treeout.Branches) {
+	parent.Child(format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch treeout.Branches) {
+			programBranch.Child(format.Instruction("InitializeChecked")).
+				//
+				ParentFunc(func(instructionBranch treeout.Branches) {
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
+						paramsBranch.Child("Authorized").ParentFunc(func(authBranch treeout.Branches) {
+							authBranch.Child(format.Account("    Staker", *inst.Authorized.Staker))
+							authBranch.Child(format.Account("Withdrawer", *inst.Authorized.Withdrawer))
+						})
+						paramsBranch.Child("Lockup").ParentFunc(func(authBranch treeout.Branches) {
+							authBranch.Child(format.Param("UnixTimestamp", inst.Lockup.UnixTimestamp))
+							authBranch.Child(format.Param("        Epoch", inst.Lockup.Epoch))
+							authBranch.Child(format.Account("    Custodian", *inst.Lockup.Custodian))
+						})
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("RentSysvar", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("StakeAuthority", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("WithdrawAuthority", inst.AccountMetaSlice.Get(3)))
+					})
+				})
+		})
+}
+
+// NewInitializeCheckedInstructionBuilder creates a new `InitializeChecked` instruction builder.
+func NewInitializeCheckedInstructionBuilder() *InitializeChecked {
+	nd := &InitializeChecked{
+		AccountMetaSlice: make(solana.AccountMetaSlice, 4),
+		Authorized:       &Authorized{},
+		Lockup:           &Lockup{},
+	}
+	return nd
+}
+
+// NewInitializeCheckedInstruction declares a new InitializeChecked instruction with the provided parameters and accounts.
+func NewInitializeCheckedInstruction(
+	// parameters:
+	staker solana.PublicKey,
+	withdrawer solana.PublicKey,
+	// Accounts:
+	stakeAccount solana.PublicKey,
+) *InitializeChecked {
+	return NewInitializeCheckedInstructionBuilder().
+		SetStakeAccount(stakeAccount).
+		SetRentSysvarAccount(solana.SysVarRentPubkey).
+		SetStakeAuthorityAccount(staker).
+		SetWithdrawAuthorityAccount(withdrawer).
+		SetStaker(staker).
+		SetWithdrawer(withdrawer).
+		SetLockupEpoch(0).
+		SetLockupTimestamp(0).
+		SetCustodian(solana.SystemProgramID)
+}

--- a/programs/stake/Lockup.go
+++ b/programs/stake/Lockup.go
@@ -17,72 +17,79 @@ package stake
 import (
 	"errors"
 
-	bin "github.com/gagliardetto/binary"
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
 	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
 )
 
 type Lockup struct {
-	// UnixTimestamp at which this stake will allow withdrawal, unless the transaction is signed by the custodian
 	UnixTimestamp *int64
-	// Epoch height at which this stake will allow withdrawal, unless the transaction is signed by the custodian
-	Epoch *uint64
-	// Custodian signature on a transaction exempts the operation from lockup constraints
-	Custodian *ag_solanago.PublicKey
+	Epoch         *uint64
+	Custodian     *ag_solanago.PublicKey
 }
 
-func (lockup *Lockup) UnmarshalWithDecoder(dec *bin.Decoder) error {
-	{
-		err := dec.Decode(&lockup.UnixTimestamp)
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := dec.Decode(&lockup.Epoch)
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := dec.Decode(&lockup.Custodian)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func (obj *Lockup) SetUnixTimestamp(unixTimestamp int64) *Lockup {
+	obj.UnixTimestamp = &unixTimestamp
+	return obj
 }
 
-func (lockup *Lockup) MarshalWithEncoder(encoder *bin.Encoder) error {
-	{
-		err := encoder.Encode(*lockup.UnixTimestamp)
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := encoder.Encode(*lockup.Epoch)
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := encoder.Encode(*lockup.Custodian)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func (obj *Lockup) SetEpoch(epoch uint64) *Lockup {
+	obj.Epoch = &epoch
+	return obj
 }
 
-func (lockup *Lockup) Validate() error {
-	if lockup.Custodian == nil {
-		return errors.New("custodian parameter is not set")
+func (obj *Lockup) SetCustodian(custodian ag_solanago.PublicKey) *Lockup {
+	obj.Custodian = &custodian
+	return obj
+}
+
+func (obj *Lockup) Validate() error {
+	if obj.UnixTimestamp == nil {
+		return errors.New("UnixTimestamp parameter is not set")
 	}
-	if lockup.Epoch == nil {
+	if obj.Epoch == nil {
 		return errors.New("epoch parameter is not set")
 	}
-	if lockup.UnixTimestamp == nil {
-		return errors.New("unix timestamp parameter is not set")
+	if obj.Custodian == nil {
+		return errors.New("custodian parameter is not set")
 	}
 	return nil
+}
+
+func (obj *Lockup) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
+	if err := encoder.Encode(obj.UnixTimestamp); err != nil {
+		return err
+	}
+	if err := encoder.Encode(obj.Epoch); err != nil {
+		return err
+	}
+	if err := encoder.Encode(obj.Custodian); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (obj *Lockup) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
+	if err := decoder.Decode(&obj.UnixTimestamp); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&obj.Epoch); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&obj.Custodian); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (obj *Lockup) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Param("UnixTimestamp", obj.UnixTimestamp))
+	parent.Child(ag_format.Param("Epoch", obj.Epoch))
+	parent.Child(ag_format.Account("Custodian", *obj.Custodian))
+}
+
+func NewLockup() *Lockup {
+	return &Lockup{}
 }

--- a/programs/stake/Merge.go
+++ b/programs/stake/Merge.go
@@ -1,0 +1,179 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// Merge instruction
+type Merge struct {
+	// [0] = [WRITE] DestinationStakeAccount
+	// ··········· The destination stake account.
+	//
+	// [1] = [WRITE] SourceStakeAccount
+	// ··········· The source stake account.
+	//
+	// [2] = [] ClockSysvar
+	// ··········· Clock sysvar account.
+	//
+	// [3] = [] StakeHistorySysvar
+	// ··········· Stake history sysvar account.
+	//
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *Merge) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.AccountMetaSlice = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+func (inst Merge) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.AccountMetaSlice...)
+	return
+}
+
+// NewMergeInstructionBuilder creates a new `Merge` instruction builder.
+func NewMergeInstructionBuilder() *Merge {
+	nd := &Merge{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 4),
+	}
+	return nd
+}
+
+// SetDestinationStakeAccount sets the "destination" account.
+// The destination stake account.
+func (inst *Merge) SetDestinationStakeAccount(destination ag_solanago.PublicKey) *Merge {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationStakeAccount gets the "destination" account.
+// The destination stake account.
+func (inst *Merge) GetDestinationStakeAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+// SetSourceStakeAccount sets the "source" account.
+// The source stake account.
+func (inst *Merge) SetSourceStakeAccount(source ag_solanago.PublicKey) *Merge {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceStakeAccount gets the "source" account.
+// The source stake account.
+func (inst *Merge) GetSourceStakeAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+
+// SetClockSysvarAccount sets the "clock" account.
+// The clock sysvar account.
+func (inst *Merge) SetClockSysvarAccount(clock ag_solanago.PublicKey) *Merge {
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(clock)
+	return inst
+}
+
+// GetClockSysvarAccount gets the "clock" account.
+// The clock sysvar account.
+func (inst *Merge) GetClockSysvarAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[2]
+}
+
+// SetStakeHistorySysvarAccount sets the "stake history" account.
+// The stake history sysvar account.
+func (inst *Merge) SetStakeHistorySysvarAccount(stakeHistory ag_solanago.PublicKey) *Merge {
+	inst.AccountMetaSlice[3] = ag_solanago.Meta(stakeHistory)
+	return inst
+}
+
+// GetStakeHistorySysvarAccount gets the "stake history" account.
+// The stake history sysvar account.
+func (inst *Merge) GetStakeHistorySysvarAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[3]
+}
+
+func (inst Merge) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_Merge, ag_binary.LE),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst Merge) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *Merge) Validate() error {
+	// Check whether all accounts are set:
+	for accIndex, acc := range inst.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("ins.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+func (inst *Merge) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("Merge")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(ag_format.Meta("SourceStakeAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(ag_format.Meta("StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
+					})
+				})
+		})
+}
+
+func (inst Merge) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (inst *Merge) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewMergeInstruction declares a new Merge instruction with the provided accounts.
+func NewMergeInstruction(
+	// Accounts:
+	destination ag_solanago.PublicKey,
+	source ag_solanago.PublicKey,
+	clock ag_solanago.PublicKey,
+	stakeHistory ag_solanago.PublicKey,
+) *Merge {
+	return NewMergeInstructionBuilder().
+		SetDestinationStakeAccount(destination).
+		SetSourceStakeAccount(source).
+		SetClockSysvarAccount(clock).
+		SetStakeHistorySysvarAccount(stakeHistory)
+}

--- a/programs/stake/Merge.go
+++ b/programs/stake/Merge.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -147,9 +148,9 @@ func (inst *Merge) EncodeToTree(parent ag_treeout.Branches) {
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(ag_format.Meta("SourceStakeAccount", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(ag_format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(2)))
-						accountsBranch.Child(ag_format.Meta("StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
+						accountsBranch.Child(ag_format.Meta("     SourceStakeAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(ag_format.Meta("            ClockSysvar", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(ag_format.Meta("     StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
 					})
 				})
 		})

--- a/programs/stake/Merge.go
+++ b/programs/stake/Merge.go
@@ -43,7 +43,7 @@ type Merge struct {
 }
 
 func (inst *Merge) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
-	inst.AccountMetaSlice = ag_solanago.AccountMetaSlice(accounts)
+	inst.AccountMetaSlice = accounts
 	return nil
 }
 

--- a/programs/stake/MoveLamports.go
+++ b/programs/stake/MoveLamports.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,7 +156,7 @@ func (inst *MoveLamports) EncodeToTree(parent ag_treeout.Branches) {
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("SourceStakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("     SourceStakeAccount", inst.Accounts[0]))
 						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.Accounts[1]))
 						accountsBranch.Child(ag_format.Meta("StakeAuthority", inst.Accounts[2]))
 					})

--- a/programs/stake/MoveLamports.go
+++ b/programs/stake/MoveLamports.go
@@ -1,0 +1,198 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// MoveLamports instruction
+type MoveLamports struct {
+	// The amount of lamports to move.
+	Amount *uint64
+
+	// [0] = [WRITE] SourceStakeAccount
+	// ··········· The source stake account.
+	//
+	// [1] = [WRITE] DestinationStakeAccount
+	// ··········· The destination stake account.
+	//
+	// [2] = [SIGNER] StakeAuthority
+	// ··········· The stake authority.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *MoveLamports) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	if len(accounts) != 3 {
+		return errors.New("incorrect number of accounts")
+	}
+
+	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+func (inst MoveLamports) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	return inst.Accounts
+}
+
+// NewMoveLamportsInstructionBuilder creates a new `MoveLamports` instruction builder.
+func NewMoveLamportsInstructionBuilder() *MoveLamports {
+	nd := &MoveLamports{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of lamports to move.
+func (inst *MoveLamports) SetAmount(amount uint64) *MoveLamports {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetSourceStakeAccount sets the "source" account.
+// The source stake account.
+func (inst *MoveLamports) SetSourceStakeAccount(source ag_solanago.PublicKey) *MoveLamports {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceStakeAccount gets the "source" account.
+// The source stake account.
+func (inst *MoveLamports) GetSourceStakeAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDestinationStakeAccount sets the "destination" account.
+// The destination stake account.
+func (inst *MoveLamports) SetDestinationStakeAccount(destination ag_solanago.PublicKey) *MoveLamports {
+	inst.Accounts[1] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationStakeAccount gets the "destination" account.
+// The destination stake account.
+func (inst *MoveLamports) GetDestinationStakeAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetStakeAuthorityAccount sets the "stake authority" account.
+// The stake authority.
+func (inst *MoveLamports) SetStakeAuthorityAccount(stakeAuthority ag_solanago.PublicKey) *MoveLamports {
+	inst.Accounts[2] = ag_solanago.Meta(stakeAuthority).SIGNER()
+	return inst
+}
+
+// GetStakeAuthorityAccount gets the "stake authority" account.
+// The stake authority.
+func (inst *MoveLamports) GetStakeAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst MoveLamports) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_MoveLamports, ag_binary.LE),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst MoveLamports) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *MoveLamports) Validate() error {
+	if inst.Amount == nil {
+		return errors.New("Amount parameter is not set")
+	}
+	if inst.Accounts[0] == nil {
+		return errors.New("accounts.SourceStakeAccount is not set")
+	}
+	if inst.Accounts[1] == nil {
+		return errors.New("accounts.DestinationStakeAccount is not set")
+	}
+	if inst.Accounts[2] == nil {
+		return errors.New("accounts.StakeAuthority is not set")
+	}
+	return nil
+}
+
+func (inst *MoveLamports) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("MoveLamports")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Amount", *inst.Amount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("SourceStakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("StakeAuthority", inst.Accounts[2]))
+					})
+				})
+		})
+}
+
+func (inst MoveLamports) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(inst.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *MoveLamports) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&inst.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewMoveLamportsInstruction declares a new MoveLamports instruction with the provided parameters and accounts.
+func NewMoveLamportsInstruction(
+	// Parameters:
+	amount uint64,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	stakeAuthority ag_solanago.PublicKey,
+) *MoveLamports {
+	return NewMoveLamportsInstructionBuilder().
+		SetAmount(amount).
+		SetSourceStakeAccount(source).
+		SetDestinationStakeAccount(destination).
+		SetStakeAuthorityAccount(stakeAuthority)
+}

--- a/programs/stake/MoveLamports.go
+++ b/programs/stake/MoveLamports.go
@@ -127,7 +127,7 @@ func (inst MoveLamports) ValidateAndBuild() (*Instruction, error) {
 
 func (inst *MoveLamports) Validate() error {
 	if inst.Amount == nil {
-		return errors.New("Amount parameter is not set")
+		return errors.New("amount parameter is not set")
 	}
 	if inst.Accounts[0] == nil {
 		return errors.New("accounts.SourceStakeAccount is not set")
@@ -158,7 +158,7 @@ func (inst *MoveLamports) EncodeToTree(parent ag_treeout.Branches) {
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("     SourceStakeAccount", inst.Accounts[0]))
 						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.Accounts[1]))
-						accountsBranch.Child(ag_format.Meta("StakeAuthority", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("         StakeAuthority", inst.Accounts[2]))
 					})
 				})
 		})

--- a/programs/stake/MoveStake.go
+++ b/programs/stake/MoveStake.go
@@ -1,0 +1,195 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// MoveStake moves stake from one account to another.
+type MoveStake struct {
+	// The amount of lamports to move.
+	Lamports *uint64
+
+	// [0] = [WRITE] SourceStakeAccount
+	// ··········· The source stake account.
+	//
+	// [1] = [WRITE] DestinationStakeAccount
+	// ··········· The destination stake account.
+	//
+	// [2] = [SIGNER] StakeAuthority
+	// ··········· The stake authority.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *MoveStake) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+// NewMoveStakeInstructionBuilder creates a new `MoveStake` instruction builder.
+func NewMoveStakeInstructionBuilder() *MoveStake {
+	nd := &MoveStake{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+	}
+	return nd
+}
+
+// SetLamports sets the "lamports" parameter.
+// The amount of lamports to move.
+func (inst *MoveStake) SetLamports(lamports uint64) *MoveStake {
+	inst.Lamports = &lamports
+	return inst
+}
+
+// SetSourceStakeAccount sets the "source" account.
+// The source stake account.
+func (inst *MoveStake) SetSourceStakeAccount(source ag_solanago.PublicKey) *MoveStake {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceStakeAccount gets the "source" account.
+// The source stake account.
+func (inst *MoveStake) GetSourceStakeAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDestinationStakeAccount sets the "destination" account.
+// The destination stake account.
+func (inst *MoveStake) SetDestinationStakeAccount(destination ag_solanago.PublicKey) *MoveStake {
+	inst.Accounts[1] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationStakeAccount gets the "destination" account.
+// The destination stake account.
+func (inst *MoveStake) GetDestinationStakeAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetStakeAuthority sets the "stake authority" account.
+// The stake authority.
+func (inst *MoveStake) SetStakeAuthority(stakeAuthority ag_solanago.PublicKey) *MoveStake {
+	inst.Accounts[2] = ag_solanago.Meta(stakeAuthority).SIGNER()
+	return inst
+}
+
+// GetStakeAuthority gets the "stake authority" account.
+// The stake authority.
+func (inst *MoveStake) GetStakeAuthority() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst MoveStake) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_MoveStake, ag_binary.LE),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst MoveStake) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *MoveStake) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Lamports == nil {
+			return errors.New("Lamports parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.SourceStakeAccount is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.DestinationStakeAccount is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.StakeAuthority is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *MoveStake) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("MoveStake")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Lamports", *inst.Lamports))
+					})
+
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("SourceStakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("StakeAuthority", inst.Accounts[2]))
+					})
+				})
+		})
+}
+
+func (inst MoveStake) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Lamports` param:
+	err = encoder.Encode(inst.Lamports)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *MoveStake) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Lamports`:
+	err = decoder.Decode(&inst.Lamports)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewMoveStakeInstruction declares a new MoveStake instruction with the provided parameters and accounts.
+func NewMoveStakeInstruction(
+	// Parameters:
+	lamports uint64,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	stakeAuthority ag_solanago.PublicKey,
+) *MoveStake {
+	return NewMoveStakeInstructionBuilder().
+		SetLamports(lamports).
+		SetSourceStakeAccount(source).
+		SetDestinationStakeAccount(destination).
+		SetStakeAuthority(stakeAuthority)
+}

--- a/programs/stake/MoveStake.go
+++ b/programs/stake/MoveStake.go
@@ -42,7 +42,7 @@ type MoveStake struct {
 }
 
 func (inst *MoveStake) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
-	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	inst.Accounts = accounts
 	return nil
 }
 
@@ -121,7 +121,7 @@ func (inst *MoveStake) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Lamports == nil {
-			return errors.New("Lamports parameter is not set")
+			return errors.New("lamports parameter is not set")
 		}
 	}
 

--- a/programs/stake/MoveStake.go
+++ b/programs/stake/MoveStake.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +19,10 @@ import (
 	"errors"
 
 	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
 	ag_solanago "github.com/gagliardetto/solana-go"
 	ag_format "github.com/gagliardetto/solana-go/text/format"
-	ag_treeout "github.com/gagliardetto/treeout"
 )
 
 // MoveStake moves stake from one account to another.
@@ -152,9 +154,9 @@ func (inst *MoveStake) EncodeToTree(parent ag_treeout.Branches) {
 					})
 
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("SourceStakeAccount", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("     SourceStakeAccount", inst.Accounts[0]))
 						accountsBranch.Child(ag_format.Meta("DestinationStakeAccount", inst.Accounts[1]))
-						accountsBranch.Child(ag_format.Meta("StakeAuthority", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("         StakeAuthority", inst.Accounts[2]))
 					})
 				})
 		})

--- a/programs/stake/SetLockup.go
+++ b/programs/stake/SetLockup.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/stake/SetLockup.go
+++ b/programs/stake/SetLockup.go
@@ -1,0 +1,152 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/text/format"
+)
+
+type SetLockup struct {
+	// Lockup settings for stake account
+	Lockup *Lockup
+
+	// [0] = [WRITE] StakeAccount
+	// ··········· Stake account to set lockup for
+	//
+	// [1] = [] ClockSysvar
+	// ··········· ClockSysvar account
+	//
+	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *SetLockup) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	return dec.Decode(&inst.Lockup)
+}
+
+func (inst *SetLockup) MarshalWithEncoder(encoder *bin.Encoder) error {
+	return encoder.Encode(*inst.Lockup)
+}
+
+func (inst *SetLockup) Validate() error {
+	// Check whether all (required) parameters are set:
+	if inst.Lockup == nil {
+		return errors.New("lockup parameter is not set")
+	}
+	err := inst.Lockup.Validate()
+	if err != nil {
+		return err
+	}
+
+	// Check whether all accounts are set:
+	for accIndex, acc := range inst.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("ins.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+func (inst *SetLockup) SetStakeAccount(stakeAccount solana.PublicKey) *SetLockup {
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE()
+	return inst
+}
+
+func (inst *SetLockup) SetClockSysvarAccount(clockSysvar solana.PublicKey) *SetLockup {
+	inst.AccountMetaSlice[1] = solana.Meta(clockSysvar)
+	return inst
+}
+
+func (inst *SetLockup) GetStakeAccount() *solana.AccountMeta       { return inst.AccountMetaSlice[0] }
+func (inst *SetLockup) GetClockSysvarAccount() *solana.AccountMeta { return inst.AccountMetaSlice[1] }
+
+func (inst *SetLockup) SetLockupTimestamp(unixTimestamp int64) *SetLockup {
+	inst.Lockup.UnixTimestamp = &unixTimestamp
+	return inst
+}
+
+func (inst *SetLockup) SetLockupEpoch(epoch uint64) *SetLockup {
+	inst.Lockup.Epoch = &epoch
+	return inst
+}
+
+func (inst *SetLockup) SetCustodian(custodian solana.PublicKey) *SetLockup {
+	inst.Lockup.Custodian = &custodian
+	return inst
+}
+
+func (inst SetLockup) Build() *Instruction {
+	return &Instruction{BaseVariant: bin.BaseVariant{
+		Impl:   inst,
+		TypeID: bin.TypeIDFromUint32(Instruction_SetLockup, bin.LE),
+	}}
+}
+
+func (inst *SetLockup) EncodeToTree(parent treeout.Branches) {
+	parent.Child(format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch treeout.Branches) {
+			programBranch.Child(format.Instruction("SetLockup")).
+				//
+				ParentFunc(func(instructionBranch treeout.Branches) {
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
+						paramsBranch.Child("Lockup").ParentFunc(func(authBranch treeout.Branches) {
+							authBranch.Child(format.Param("UnixTimestamp", inst.Lockup.UnixTimestamp))
+							authBranch.Child(format.Param("        Epoch", inst.Lockup.Epoch))
+							authBranch.Child(format.Account("    Custodian", *inst.Lockup.Custodian))
+						})
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(1)))
+					})
+				})
+		})
+}
+
+// NewSetLockupInstructionBuilder creates a new `SetLockup` instruction builder.
+func NewSetLockupInstructionBuilder() *SetLockup {
+	nd := &SetLockup{
+		AccountMetaSlice: make(solana.AccountMetaSlice, 2),
+		Lockup:           &Lockup{},
+	}
+	return nd
+}
+
+// NewSetLockupInstruction declares a new SetLockup instruction with the provided parameters and accounts.
+func NewSetLockupInstruction(
+	// parameters:
+	unixTimestamp int64,
+	epoch uint64,
+	custodian solana.PublicKey,
+	// Accounts:
+	stakeAccount solana.PublicKey,
+) *SetLockup {
+	return NewSetLockupInstructionBuilder().
+		SetStakeAccount(stakeAccount).
+		SetClockSysvarAccount(solana.SysVarClockPubkey).
+		SetLockupTimestamp(unixTimestamp).
+		SetLockupEpoch(epoch).
+		SetCustodian(custodian)
+}

--- a/programs/stake/SetLockupChecked.go
+++ b/programs/stake/SetLockupChecked.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,8 +135,8 @@ func (inst *SetLockupChecked) EncodeToTree(parent treeout.Branches) {
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
 						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("Custodian", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta(" ClockSysvar", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("   Custodian", inst.AccountMetaSlice.Get(2)))
 					})
 				})
 		})

--- a/programs/stake/SetLockupChecked.go
+++ b/programs/stake/SetLockupChecked.go
@@ -1,0 +1,167 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stake
+
+import (
+	"errors"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/text/format"
+)
+
+type SetLockupChecked struct {
+	// Lockup settings for stake account
+	Lockup *Lockup
+
+	// [0] = [WRITE] StakeAccount
+	// ··········· Stake account to set lockup
+	//
+	// [1] = [] ClockSysvar
+	// ··········· ClockSysvar account
+	//
+	// [2] = [] Custodian
+	// ··········· Optional: Lockup custodian
+	//
+	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *SetLockupChecked) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	err := dec.Decode(&inst.Lockup)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (inst *SetLockupChecked) MarshalWithEncoder(encoder *bin.Encoder) error {
+	err := encoder.Encode(*inst.Lockup)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (inst *SetLockupChecked) Validate() error {
+	// Check whether all (required) parameters are set:
+	if inst.Lockup == nil {
+		return errors.New("lockup parameter is not set")
+	}
+	err := inst.Lockup.Validate()
+	if err != nil {
+		return err
+	}
+
+	// Check whether all accounts are set:
+	for accIndex, acc := range inst.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("ins.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+// Stake account account
+func (inst *SetLockupChecked) SetStakeAccount(stakeAccount solana.PublicKey) *SetLockupChecked {
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE()
+	return inst
+}
+
+// Clock sysvar account
+func (inst *SetLockupChecked) SetClockSysvarAccount(clockSysvar solana.PublicKey) *SetLockupChecked {
+	inst.AccountMetaSlice[1] = solana.Meta(clockSysvar)
+	return inst
+}
+
+// Optional: Lockup custodian
+func (inst *SetLockupChecked) SetCustodian(custodian solana.PublicKey) *SetLockupChecked {
+	inst.AccountMetaSlice[2] = solana.Meta(custodian)
+	return inst
+}
+
+// Lockup settings for stake account
+func (inst *SetLockupChecked) SetLockup(lockup Lockup) *SetLockupChecked {
+	inst.Lockup = &lockup
+	return inst
+}
+
+func (inst *SetLockupChecked) GetStakeAccount() *solana.AccountMeta { return inst.AccountMetaSlice[0] }
+func (inst *SetLockupChecked) GetClockSysvarAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+func (inst *SetLockupChecked) GetCustodian() *solana.AccountMeta { return inst.AccountMetaSlice[2] }
+
+func (inst SetLockupChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: bin.BaseVariant{
+		Impl:   inst,
+		TypeID: bin.TypeIDFromUint32(Instruction_SetLockupChecked, bin.LE),
+	}}
+}
+
+func (inst *SetLockupChecked) EncodeToTree(parent treeout.Branches) {
+	parent.Child(format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch treeout.Branches) {
+			programBranch.Child(format.Instruction("SetLockupChecked")).
+				//
+				ParentFunc(func(instructionBranch treeout.Branches) {
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
+						paramsBranch.Child("Lockup").ParentFunc(func(authBranch treeout.Branches) {
+							authBranch.Child(format.Param("UnixTimestamp", inst.Lockup.UnixTimestamp))
+							authBranch.Child(format.Param("        Epoch", inst.Lockup.Epoch))
+							authBranch.Child(format.Account("    Custodian", *inst.Lockup.Custodian))
+						})
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("Custodian", inst.AccountMetaSlice.Get(2)))
+					})
+				})
+		})
+}
+
+// NewSetLockupCheckedInstructionBuilder creates a new `SetLockupChecked` instruction builder.
+func NewSetLockupCheckedInstructionBuilder() *SetLockupChecked {
+	nd := &SetLockupChecked{
+		AccountMetaSlice: make(solana.AccountMetaSlice, 3),
+		Lockup:           &Lockup{},
+	}
+	return nd
+}
+
+// NewSetLockupCheckedInstruction declares a new SetLockupChecked instruction with the provided parameters and accounts.
+func NewSetLockupCheckedInstruction(
+	// parameters:
+	lockup Lockup,
+	// Accounts:
+	stakeAccount solana.PublicKey,
+	clockSysvar solana.PublicKey,
+	custodian solana.PublicKey,
+) *SetLockupChecked {
+	return NewSetLockupCheckedInstructionBuilder().
+		SetStakeAccount(stakeAccount).
+		SetClockSysvarAccount(clockSysvar).
+		SetCustodian(custodian).
+		SetLockup(lockup)
+}

--- a/programs/stake/SetLockupChecked.go
+++ b/programs/stake/SetLockupChecked.go
@@ -126,8 +126,8 @@ func (inst *SetLockupChecked) EncodeToTree(parent treeout.Branches) {
 					// Parameters of the instruction:
 					instructionBranch.Child("Params").ParentFunc(func(paramsBranch treeout.Branches) {
 						paramsBranch.Child("Lockup").ParentFunc(func(authBranch treeout.Branches) {
-							authBranch.Child(format.Param("UnixTimestamp", inst.Lockup.UnixTimestamp))
-							authBranch.Child(format.Param("        Epoch", inst.Lockup.Epoch))
+							authBranch.Child(format.Param("  UnixTimestamp", inst.Lockup.UnixTimestamp))
+							authBranch.Child(format.Param("          Epoch", inst.Lockup.Epoch))
 							authBranch.Child(format.Account("    Custodian", *inst.Lockup.Custodian))
 						})
 					})

--- a/programs/stake/Split.go
+++ b/programs/stake/Split.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/text/format"
-	"github.com/gagliardetto/treeout"
 )
 
 type Split struct {
@@ -117,9 +118,9 @@ func (inst *Split) EncodeToTree(parent treeout.Branches) {
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
-						accountsBranch.Child(format.Meta("              StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("           NewStakeAccount", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("             StakeAuthoriy", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("NewStakeAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("StakeAuthoriy", inst.AccountMetaSlice.Get(2)))
 					})
 				})
 		})

--- a/programs/stake/Withdraw.go
+++ b/programs/stake/Withdraw.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/text/format"
-	"github.com/gagliardetto/treeout"
 )
 
 type Withdraw struct {
@@ -136,11 +137,11 @@ func (inst *Withdraw) EncodeToTree(parent treeout.Branches) {
 
 					// Accounts of the instruction:
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
-						accountsBranch.Child(format.Meta("                   StakeAccount", inst.AccountMetaSlice.Get(0)))
-						accountsBranch.Child(format.Meta("               RecipientAccount", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("                    ClockSysvar", inst.AccountMetaSlice.Get(2)))
-						accountsBranch.Child(format.Meta("             StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
-						accountsBranch.Child(format.Meta("              WithdrawAuthority", inst.AccountMetaSlice.Get(4)))
+						accountsBranch.Child(format.Meta("StakeAccount", inst.AccountMetaSlice.Get(0)))
+						accountsBranch.Child(format.Meta("RecipientAccount", inst.AccountMetaSlice.Get(1)))
+						accountsBranch.Child(format.Meta("ClockSysvar", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
+						accountsBranch.Child(format.Meta("WithdrawAuthority", inst.AccountMetaSlice.Get(4)))
 					})
 				})
 		})

--- a/programs/stake/instructions.go
+++ b/programs/stake/instructions.go
@@ -22,9 +22,10 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/treeout"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/text"
-	"github.com/gagliardetto/treeout"
 )
 
 var ProgramID solana.PublicKey = solana.StakeProgramID
@@ -53,6 +54,28 @@ const (
 	Instruction_Withdraw
 	// Deactivates the stake in the account
 	Instruction_Deactivate
+	// Sets the lockup for the stake account
+	Instruction_SetLockup
+	// Merges two stake accounts
+	Instruction_Merge
+	// Authorize a key to manage stake or withdrawal with seed
+	Instruction_AuthorizeWithSeed
+	// Initializes a new stake account with checked authorities
+	Instruction_InitializeChecked
+	// Authorize a key to manage stake or withdrawal with checked authorities
+	Instruction_AuthorizeChecked
+	// Authorize a key to manage stake or withdrawal with checked authorities and seed
+	Instruction_AuthorizeCheckedWithSeed
+	// Sets the lockup for the stake account with checked authorities
+	Instruction_SetLockupChecked
+	// Gets the minimum delegation for the stake account
+	Instruction_GetMinimumDelegation
+	// Deactivates delinquent stake accounts
+	Instruction_DeactivateDelinquent
+	// Moves stake from one account to another
+	Instruction_MoveStake
+	// Moves lamports from one account to another
+	Instruction_MoveLamports
 )
 
 type Instruction struct {
@@ -74,7 +97,7 @@ var InstructionImplDef = bin.NewVariantDefinition(
 			"Initialize", (*Initialize)(nil),
 		},
 		{
-			"Authorize", nil,
+			"Authorize", (*Authorize)(nil),
 		},
 		{
 			"DelegateStake", (*DelegateStake)(nil),
@@ -87,6 +110,39 @@ var InstructionImplDef = bin.NewVariantDefinition(
 		},
 		{
 			"Deactivate", (*Deactivate)(nil),
+		},
+		{
+			"SetLockup", (*SetLockup)(nil),
+		},
+		{
+			"Merge", (*Merge)(nil),
+		},
+		{
+			"AuthorizeWithSeed", (*AuthorizeWithSeed)(nil),
+		},
+		{
+			"InitializeChecked", (*InitializeChecked)(nil),
+		},
+		{
+			"AuthorizeChecked", (*AuthorizeChecked)(nil),
+		},
+		{
+			"AuthorizeCheckedWithSeed", (*AuthorizeCheckedWithSeed)(nil),
+		},
+		{
+			"SetLockupChecked", (*SetLockupChecked)(nil),
+		},
+		{
+			"GetMinimumDelegation", (*GetMinimumDelegation)(nil),
+		},
+		{
+			"DeactivateDelinquent", (*DeactivateDelinquent)(nil),
+		},
+		{
+			"MoveStake", (*MoveStake)(nil),
+		},
+		{
+			"MoveLamports", (*MoveLamports)(nil),
 		},
 	},
 )

--- a/programs/stake/types.go
+++ b/programs/stake/types.go
@@ -1,0 +1,32 @@
+package stake
+
+import (
+	ag_binary "github.com/gagliardetto/binary"
+)
+
+// StakeAuthorize represents the different types of authorities in the stake program.
+type StakeAuthorize ag_binary.BorshEnum
+
+const (
+	// Authority to stake
+	StakeAuthorizeStaker StakeAuthorize = iota
+
+	// Authority to withdraw
+	StakeAuthorizeWithdrawer
+)
+
+type AuthorityType ag_binary.BorshEnum
+
+const (
+	// Authority to mint new tokens
+	AuthorityMintTokens AuthorityType = iota
+
+	// Authority to freeze any account associated with the Mint
+	AuthorityFreezeAccount
+
+	// Owner of a given token account
+	AuthorityAccountOwner
+
+	// Authority to close a token account
+	AuthorityCloseAccount
+)


### PR DESCRIPTION
This pull request introduces new instructions in the `programs/stake` package:
- SetLockup
- Merge
- AuthorizeWithSeed
- InitializeChecked
- AuthorizeChecked
- AuthorizeCheckedWithSeed
- SetLockupChecked
- GetMinimumDelegation
- DeactivateDelinquent
- MoveStake
- MoveLamports