### PR TITLE
associated token account program add missing instructions

### DIFF
--- a/programs/associated-token-account/CreateIdempotent.go
+++ b/programs/associated-token-account/CreateIdempotent.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/associated-token-account/CreateIdempotent.go
+++ b/programs/associated-token-account/CreateIdempotent.go
@@ -1,0 +1,219 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package associatedtokenaccount
+
+import (
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+type CreateIdempotent struct {
+	// [0] = [WRITE, SIGNER] Funding account (must be a system account)
+	// ··········· Funding account
+	//
+	// [1] = [WRITE] Associated token account address to be created
+	// ··········· Associated token account address to be created
+	//
+	// [2] = [] Wallet address for the new associated token account
+	// ··········· Wallet address for the new associated token account
+	//
+	// [3] = [] The token mint for the new associated token account
+	// ··········· The token mint for the new associated token account
+	//
+	// ··········· System program ID
+	//
+	// [5] = [] SPL token program ID
+	// ··········· SPL token program ID
+	//
+	// [6] = [] SysVarRentPubkey
+	// ··········· SysVarRentPubkey
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *CreateIdempotent) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	if len(accounts) != 7 {
+		return fmt.Errorf("expected 7 accounts, got %v", len(accounts))
+	}
+	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+func (inst CreateIdempotent) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	return
+}
+
+// NewCreateIdempotentInstructionBuilder creates a new `CreateIdempotent` instruction builder.
+func NewCreateIdempotentInstructionBuilder() *CreateIdempotent {
+	return &CreateIdempotent{
+		Accounts: make(ag_solanago.AccountMetaSlice, 7),
+	}
+}
+
+// SetFundingAccount sets the "funding" account.
+func (inst *CreateIdempotent) SetFundingAccount(funding ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[0] = ag_solanago.Meta(funding).WRITE().SIGNER()
+	return inst
+}
+
+// GetFundingAccount gets the "funding" account.
+func (inst *CreateIdempotent) GetFundingAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetAssociatedTokenAccount sets the "associated token" account.
+func (inst *CreateIdempotent) SetAssociatedTokenAccount(associatedToken ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[1] = ag_solanago.Meta(associatedToken).WRITE()
+	return inst
+}
+
+// GetAssociatedTokenAccount gets the "associated token" account.
+func (inst *CreateIdempotent) GetAssociatedTokenAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetWalletAccount sets the "wallet" account.
+func (inst *CreateIdempotent) SetWalletAccount(wallet ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[2] = ag_solanago.Meta(wallet)
+	return inst
+}
+
+// GetWalletAccount gets the "wallet" account.
+func (inst *CreateIdempotent) GetWalletAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+// SetTokenMintAccount sets the "token mint" account.
+func (inst *CreateIdempotent) SetTokenMintAccount(tokenMint ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[3] = ag_solanago.Meta(tokenMint)
+	return inst
+}
+
+// GetTokenMintAccount gets the "token mint" account.
+func (inst *CreateIdempotent) GetTokenMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[3]
+}
+
+// SetSystemProgramAccount sets the "system program" account.
+func (inst *CreateIdempotent) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[4] = ag_solanago.Meta(systemProgram)
+	return inst
+}
+
+// GetSystemProgramAccount gets the "system program" account.
+func (inst *CreateIdempotent) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[4]
+}
+
+// SetTokenProgramAccount sets the "token program" account.
+func (inst *CreateIdempotent) SetTokenProgramAccount(tokenProgram ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[5] = ag_solanago.Meta(tokenProgram)
+	return inst
+}
+
+// GetTokenProgramAccount gets the "token program" account.
+func (inst *CreateIdempotent) GetTokenProgramAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[5]
+}
+
+// SetSysVarRentAccount sets the "sys var rent" account.
+func (inst *CreateIdempotent) SetSysVarRentAccount(sysVarRent ag_solanago.PublicKey) *CreateIdempotent {
+	inst.Accounts[6] = ag_solanago.Meta(sysVarRent)
+	return inst
+}
+
+// GetSysVarRentAccount gets the "sys var rent" account.
+func (inst *CreateIdempotent) GetSysVarRentAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[6]
+}
+
+func (inst CreateIdempotent) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_CreateIdempotent),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst CreateIdempotent) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *CreateIdempotent) Validate() error {
+	// Check whether all accounts are set:
+	for i, acc := range inst.Accounts {
+		if acc == nil {
+			return fmt.Errorf("inst.Accounts[%v] is not set", i)
+		}
+	}
+	return nil
+}
+
+func (inst *CreateIdempotent) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("CreateIdempotent")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("        funding", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("associatedToken", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("         wallet", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("      tokenMint", inst.Accounts[3]))
+						accountsBranch.Child(ag_format.Meta("  systemProgram", inst.Accounts[4]))
+						accountsBranch.Child(ag_format.Meta("   tokenProgram", inst.Accounts[5]))
+						accountsBranch.Child(ag_format.Meta("     sysVarRent", inst.Accounts[6]))
+					})
+				})
+		})
+}
+
+func (inst CreateIdempotent) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (inst *CreateIdempotent) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewCreateIdempotentInstruction declares a new CreateIdempotent instruction with the provided parameters and accounts.
+func NewCreateIdempotentInstruction(
+	// Accounts:
+	funding ag_solanago.PublicKey,
+	associatedToken ag_solanago.PublicKey,
+	wallet ag_solanago.PublicKey,
+	tokenMint ag_solanago.PublicKey,
+	systemProgram ag_solanago.PublicKey,
+	tokenProgram ag_solanago.PublicKey,
+	sysVarRent ag_solanago.PublicKey,
+) *CreateIdempotent {
+	return NewCreateIdempotentInstructionBuilder().
+		SetFundingAccount(funding).
+		SetAssociatedTokenAccount(associatedToken).
+		SetWalletAccount(wallet).
+		SetTokenMintAccount(tokenMint).
+		SetSystemProgramAccount(systemProgram).
+		SetTokenProgramAccount(tokenProgram).
+		SetSysVarRentAccount(sysVarRent)
+}

--- a/programs/associated-token-account/RecoverNested.go
+++ b/programs/associated-token-account/RecoverNested.go
@@ -1,4 +1,5 @@
 // Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/programs/associated-token-account/RecoverNested.go
+++ b/programs/associated-token-account/RecoverNested.go
@@ -1,0 +1,219 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package associatedtokenaccount
+
+import (
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+type RecoverNested struct {
+	// [0] = [WRITE] Nested associated token account, must be owned by `3`
+	// ··········· The nested associated token account.
+	//
+	// [1] = [] Token mint for the nested associated token account
+	// ··········· Token mint for the nested associated token account.
+	//
+	// [2] = [WRITE] Wallet's associated token account
+	// ··········· Wallet's associated token account.
+	//
+	// [3] = [] Owner associated token account address, must be owned by `5`
+	// ··········· Owner associated token account address.
+	//
+	// ··········· Token mint for the owner associated token account.
+	//
+	// [5] = [WRITE, SIGNER] Wallet address for the owner associated token account
+	// ··········· Wallet address for the owner associated token account.
+	//
+	// [6] = [] SPL Token program
+	// ··········· SPL Token program.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *RecoverNested) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	if len(accounts) != 7 {
+		return fmt.Errorf("expected 7 accounts, got %v", len(accounts))
+	}
+	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+func (inst RecoverNested) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	return
+}
+
+// NewRecoverNestedInstructionBuilder creates a new `RecoverNested` instruction builder.
+func NewRecoverNestedInstructionBuilder() *RecoverNested {
+	return &RecoverNested{
+		Accounts: make(ag_solanago.AccountMetaSlice, 7),
+	}
+}
+
+// SetNestedAccount sets the "nested" account.
+func (inst *RecoverNested) SetNestedAccount(nested ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[0] = ag_solanago.Meta(nested).WRITE()
+	return inst
+}
+
+// GetNestedAccount gets the "nested" account.
+func (inst *RecoverNested) GetNestedAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetTokenMintForNestedAccount sets the "token mint for nested" account.
+func (inst *RecoverNested) SetTokenMintForNestedAccount(tokenMint ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[1] = ag_solanago.Meta(tokenMint)
+	return inst
+}
+
+// GetTokenMintForNestedAccount gets the "token mint for nested" account.
+func (inst *RecoverNested) GetTokenMintForNestedAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetWalletAssociatedTokenAccount sets the "wallet's associated token" account.
+func (inst *RecoverNested) SetWalletAssociatedTokenAccount(walletAssociatedToken ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[2] = ag_solanago.Meta(walletAssociatedToken).WRITE()
+	return inst
+}
+
+// GetWalletAssociatedTokenAccount gets the "wallet's associated token" account.
+func (inst *RecoverNested) GetWalletAssociatedTokenAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+// SetOwnerAssociatedTokenAccount sets the "owner associated token" account.
+func (inst *RecoverNested) SetOwnerAssociatedTokenAccount(ownerAssociatedToken ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[3] = ag_solanago.Meta(ownerAssociatedToken)
+	return inst
+}
+
+// GetOwnerAssociatedTokenAccount gets the "owner associated token" account.
+func (inst *RecoverNested) GetOwnerAssociatedTokenAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[3]
+}
+
+// SetTokenMintForOwnerAccount sets the "token mint for owner" account.
+func (inst *RecoverNested) SetTokenMintForOwnerAccount(tokenMint ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[4] = ag_solanago.Meta(tokenMint)
+	return inst
+}
+
+// GetTokenMintForOwnerAccount gets the "token mint for owner" account.
+func (inst *RecoverNested) GetTokenMintForOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[4]
+}
+
+// SetWalletAccount sets the "wallet" account.
+func (inst *RecoverNested) SetWalletAccount(wallet ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[5] = ag_solanago.Meta(wallet).WRITE().SIGNER()
+	return inst
+}
+
+// GetWalletAccount gets the "wallet" account.
+func (inst *RecoverNested) GetWalletAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[5]
+}
+
+// SetTokenProgramAccount sets the "token program" account.
+func (inst *RecoverNested) SetTokenProgramAccount(tokenProgram ag_solanago.PublicKey) *RecoverNested {
+	inst.Accounts[6] = ag_solanago.Meta(tokenProgram)
+	return inst
+}
+
+// GetTokenProgramAccount gets the "token program" account.
+func (inst *RecoverNested) GetTokenProgramAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[6]
+}
+
+func (inst RecoverNested) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_RecoverNested),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst RecoverNested) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *RecoverNested) Validate() error {
+	// Check whether all accounts are set:
+	for i, acc := range inst.Accounts {
+		if acc == nil {
+			return fmt.Errorf("accounts[%v] is not set", i)
+		}
+	}
+	return nil
+}
+
+func (inst *RecoverNested) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("RecoverNested")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("                   nested", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("    token mint for nested", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("wallet's associated token", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("   owner associated token", inst.Accounts[3]))
+						accountsBranch.Child(ag_format.Meta("     token mint for owner", inst.Accounts[4]))
+						accountsBranch.Child(ag_format.Meta("                   wallet", inst.Accounts[5]))
+						accountsBranch.Child(ag_format.Meta("            token program", inst.Accounts[6]))
+					})
+				})
+		})
+}
+
+func (inst RecoverNested) MarshalWithEncoder(_ *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (inst *RecoverNested) UnmarshalWithDecoder(_ *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewRecoverNestedInstruction declares a new RecoverNested instruction with the provided parameters and accounts.
+func NewRecoverNestedInstruction(
+	// Accounts:
+	nested ag_solanago.PublicKey,
+	tokenMintForNested ag_solanago.PublicKey,
+	walletAssociatedToken ag_solanago.PublicKey,
+	ownerAssociatedToken ag_solanago.PublicKey,
+	tokenMintForOwner ag_solanago.PublicKey,
+	wallet ag_solanago.PublicKey,
+	tokenProgram ag_solanago.PublicKey,
+) *RecoverNested {
+	return NewRecoverNestedInstructionBuilder().
+		SetNestedAccount(nested).
+		SetTokenMintForNestedAccount(tokenMintForNested).
+		SetWalletAssociatedTokenAccount(walletAssociatedToken).
+		SetOwnerAssociatedTokenAccount(ownerAssociatedToken).
+		SetTokenMintForOwnerAccount(tokenMintForOwner).
+		SetWalletAccount(wallet).
+		SetTokenProgramAccount(tokenProgram)
+}

--- a/programs/associated-token-account/RecoverNested.go
+++ b/programs/associated-token-account/RecoverNested.go
@@ -52,7 +52,7 @@ func (inst *RecoverNested) SetAccounts(accounts []*ag_solanago.AccountMeta) erro
 	if len(accounts) != 7 {
 		return fmt.Errorf("expected 7 accounts, got %v", len(accounts))
 	}
-	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	inst.Accounts = accounts
 	return nil
 }
 

--- a/programs/associated-token-account/instructions.go
+++ b/programs/associated-token-account/instructions.go
@@ -17,72 +17,108 @@ package associatedtokenaccount
 import (
 	"fmt"
 
-	spew "github.com/davecgh/go-spew/spew"
-	bin "github.com/gagliardetto/binary"
-	solana "github.com/gagliardetto/solana-go"
-	text "github.com/gagliardetto/solana-go/text"
-	treeout "github.com/gagliardetto/treeout"
+	ag_spew "github.com/davecgh/go-spew/spew"
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_text "github.com/gagliardetto/solana-go/text"
 )
 
-var ProgramID solana.PublicKey = solana.SPLAssociatedTokenAccountProgramID
+var ProgramID ag_solanago.PublicKey = ag_solanago.SPLAssociatedTokenAccountProgramID
 
-func SetProgramID(pubkey solana.PublicKey) {
+func SetProgramID(pubkey ag_solanago.PublicKey) {
 	ProgramID = pubkey
-	solana.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
+	ag_solanago.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
 }
 
 const ProgramName = "AssociatedTokenAccount"
 
 func init() {
-	solana.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
+	ag_solanago.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
 }
 
-type Instruction struct {
-	bin.BaseVariant
-}
+const (
+	// Creates an associated token account for the given wallet address and
+	// token mint Returns an error if the account exists.
+	Instruction_Create uint8 = iota
 
-func (inst *Instruction) EncodeToTree(parent treeout.Branches) {
-	if enToTree, ok := inst.Impl.(text.EncodableToTree); ok {
-		enToTree.EncodeToTree(parent)
-	} else {
-		parent.Child(spew.Sdump(inst))
+	// Creates an associated token account for the given wallet address and
+	// token mint, if it doesn't already exist.  Returns an error if the
+	// account exists, but with a different owner.
+	Instruction_CreateIdempotent
+
+	// Transfers from and closes a nested associated token account: an
+	// associated token account owned by an associated token account.
+	Instruction_RecoverNested
+)
+
+// InstructionIDToName returns the name of the instruction given its ID.
+func InstructionIDToName(id uint8) string {
+	switch id {
+	case Instruction_Create:
+		return "Create"
+	case Instruction_CreateIdempotent:
+		return "CreateIdempotent"
+	case Instruction_RecoverNested:
+		return "RecoverNested"
+	default:
+		return ""
 	}
 }
 
-var InstructionImplDef = bin.NewVariantDefinition(
-	bin.NoTypeIDEncoding, // NOTE: the associated-token-account program has no ID encoding.
-	[]bin.VariantType{
+type Instruction struct {
+	ag_binary.BaseVariant
+}
+
+func (inst *Instruction) EncodeToTree(parent ag_treeout.Branches) {
+	if enToTree, ok := inst.Impl.(ag_text.EncodableToTree); ok {
+		enToTree.EncodeToTree(parent)
+	} else {
+		parent.Child(ag_spew.Sdump(inst))
+	}
+}
+
+var InstructionImplDef = ag_binary.NewVariantDefinition(
+	ag_binary.Uint8TypeIDEncoding,
+	[]ag_binary.VariantType{
 		{
 			"Create", (*Create)(nil),
+		},
+		{
+			"CreateIdempotent", (*CreateIdempotent)(nil),
+		},
+		{
+			"RecoverNested", (*RecoverNested)(nil),
 		},
 	},
 )
 
-func (inst *Instruction) ProgramID() solana.PublicKey {
+func (inst *Instruction) ProgramID() ag_solanago.PublicKey {
 	return ProgramID
 }
 
-func (inst *Instruction) Accounts() (out []*solana.AccountMeta) {
-	return inst.Impl.(solana.AccountsGettable).GetAccounts()
+func (inst *Instruction) Accounts() (out []*ag_solanago.AccountMeta) {
+	return inst.Impl.(ag_solanago.AccountsGettable).GetAccounts()
 }
 
 func (inst *Instruction) Data() ([]byte, error) {
 	return []byte{}, nil
 }
 
-func (inst *Instruction) TextEncode(encoder *text.Encoder, option *text.Option) error {
+func (inst *Instruction) TextEncode(encoder *ag_text.Encoder, option *ag_text.Option) error {
 	return encoder.Encode(inst.Impl, option)
 }
 
-func (inst *Instruction) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+func (inst *Instruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
 	return inst.BaseVariant.UnmarshalBinaryVariant(decoder, InstructionImplDef)
 }
 
-func (inst Instruction) MarshalWithEncoder(encoder *bin.Encoder) error {
+func (inst Instruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err
@@ -90,12 +126,12 @@ func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (int
 	return inst, nil
 }
 
-func DecodeInstruction(accounts []*solana.AccountMeta, data []byte) (*Instruction, error) {
+func DecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (*Instruction, error) {
 	inst := new(Instruction)
-	if err := bin.NewBinDecoder(data).Decode(inst); err != nil {
+	if err := ag_binary.NewBinDecoder(data).Decode(inst); err != nil {
 		return nil, fmt.Errorf("unable to decode instruction: %w", err)
 	}
-	if v, ok := inst.Impl.(solana.AccountsSettable); ok {
+	if v, ok := inst.Impl.(ag_solanago.AccountsSettable); ok {
 		err := v.SetAccounts(accounts)
 		if err != nil {
 			return nil, fmt.Errorf("unable to set accounts for instruction: %w", err)


### PR DESCRIPTION
This pull request introduces new functionality in the `programs/associated-token-account` package by adding two new instructions: `CreateIdempotent` and `RecoverNested`. Additionally, it refactors existing code to use prefixed import aliases for better readability and consistency.

### New Instructions:
* **CreateIdempotent**:
  - Adds a new instruction `CreateIdempotent` for creating an associated token account idempotently. This includes methods for setting and getting accounts, validation, and building the instruction.

* **RecoverNested**:
  - Adds a new instruction `RecoverNested` for recovering nested associated token accounts. This includes methods for setting and getting accounts, validation, and building the instruction.

### Refactoring:
* **Import Aliases**:
  - Updates import statements to use prefixed aliases (`ag_*`) for all imported packages to improve code readability and consistency.
* **Instruction Handling**:
  - Adds constants for the new instruction types and updates the `InstructionIDToName` function to handle these new types.
  - Updates the `Instruction` struct and related functions to use the new prefixed import aliases.