### PR TITLE
Fix race condition that leads to panic

### DIFF
--- a/rpc/ws/client.go
+++ b/rpc/ws/client.go
@@ -254,10 +254,11 @@ func (c *Client) handleSubscriptionMessage(subID uint64, message []byte) {
 		return
 	}
 
+	sub.mutex.Lock()
+	defer sub.mutex.Unlock()
 	if !sub.closed {
 		sub.stream <- result
 	}
-	return
 }
 
 func (c *Client) closeAllSubscription(err error) {

--- a/rpc/ws/subscription.go
+++ b/rpc/ws/subscription.go
@@ -17,7 +17,10 @@
 
 package ws
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type Subscription struct {
 	req               *request
@@ -25,6 +28,7 @@ type Subscription struct {
 	stream            chan result
 	err               chan error
 	closeFunc         func(err error)
+	mutex             sync.Mutex
 	closed            bool
 	unsubscribeMethod string
 	decoderFunc       decoderFunc
@@ -65,6 +69,8 @@ func (s *Subscription) Unsubscribe() {
 }
 
 func (s *Subscription) unsubscribe(err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.closeFunc(err)
 	s.closed = true
 	close(s.stream)


### PR DESCRIPTION
Frequent resubscriptions may prevent synchronized closed channel checks, potentially leading to panic:
```golang
panic: send on closed channel

goroutine 1688260 [running]:
github.com/gagliardetto/solana-go/rpc/ws.(*Client).handleSubscriptionMessage(0xc001250720, 0x2, {0xc0002e6800, 0x95, 0x200})
	/vendor/github.com/gagliardetto/solana-go/rpc/ws/client.go:258 +0x34b
github.com/gagliardetto/solana-go/rpc/ws.(*Client).handleMessage(0xc001250720, {0xc0002e6800, 0x95, 0x200})
	/vendor/github.com/gagliardetto/solana-go/rpc/ws/client.go:191 +0x10b
github.com/gagliardetto/solana-go/rpc/ws.(*Client).receiveMessages(0xc001250720)
	/vendor/github.com/gagliardetto/solana-go/rpc/ws/client.go:153 +0x1f
created by github.com/gagliardetto/solana-go/rpc/ws.ConnectWithOptions in goroutine 6
	/vendor/github.com/gagliardetto/solana-go/rpc/ws/client.go:121 +0x356
```