### PR TITLE
feat: add SetLoadedAccountsDataSizeLimitInstruction

### DIFF
--- a/programs/compute-budget/SetLoadedAccountsDataSizeLimit.go
+++ b/programs/compute-budget/SetLoadedAccountsDataSizeLimit.go
@@ -1,0 +1,115 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package computebudget
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+type SetLoadedAccountsDataSizeLimit struct {
+	Bytes uint32
+}
+
+func (obj *SetLoadedAccountsDataSizeLimit) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	return nil
+}
+
+func (slice SetLoadedAccountsDataSizeLimit) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	return
+}
+
+// NewSetLoadedAccountsDataSizeLimitInstructionBuilder creates a new `SetLoadedAccountsDataSizeLimit` instruction builder.
+func NewSetLoadedAccountsDataSizeLimitInstructionBuilder() *SetLoadedAccountsDataSizeLimit {
+	nd := &SetLoadedAccountsDataSizeLimit{}
+	return nd
+}
+
+// Byytes limit
+func (inst *SetLoadedAccountsDataSizeLimit) SetBytes(bytes uint32) *SetLoadedAccountsDataSizeLimit {
+	inst.Bytes = bytes
+	return inst
+}
+
+func (inst SetLoadedAccountsDataSizeLimit) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_SetLoadedAccountsDataSizeLimit),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst SetLoadedAccountsDataSizeLimit) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *SetLoadedAccountsDataSizeLimit) Validate() error {
+	// Check whether all (required) parameters are set:
+	if inst.Bytes == 0 {
+		return errors.New("Bytes parameter is not set")
+	}
+
+	return nil
+}
+
+func (inst *SetLoadedAccountsDataSizeLimit) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("SetLoadedAccountsDataSizeLimit")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Bytes", inst.Bytes))
+					})
+				})
+		})
+}
+
+func (obj SetLoadedAccountsDataSizeLimit) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Bytes` param:
+	err = encoder.Encode(obj.Bytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *SetLoadedAccountsDataSizeLimit) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Bytes`:
+	err = decoder.Decode(&obj.Bytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewSetLoadedAccountsDataSizeLimitInstruction declares a new SetLoadedAccountsDataSizeLimit instruction with the provided parameters and accounts.
+func NewSetLoadedAccountsDataSizeLimitInstruction(
+	// Parameters:
+	bytes uint32,
+) *SetLoadedAccountsDataSizeLimit {
+	return NewSetLoadedAccountsDataSizeLimitInstructionBuilder().SetBytes(bytes)
+}

--- a/programs/compute-budget/SetLoadedAccountsDataSizeLimit_test.go
+++ b/programs/compute-budget/SetLoadedAccountsDataSizeLimit_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package computebudget
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetLoadedAccountsDataSizeLimitInstruction(t *testing.T) {
+	ix, err := NewSetLoadedAccountsDataSizeLimitInstruction(32 * 1024).ValidateAndBuild()
+	require.Nil(t, err)
+
+	require.Equal(t, ProgramID, ix.ProgramID())
+	require.Equal(t, 0, len(ix.Accounts()))
+
+	data, err := ix.Data()
+	require.Nil(t, err)
+	require.Equal(t, []byte{0x4, 0x0, 0x80, 0x0, 0x0}, data)
+}

--- a/programs/compute-budget/instruction.go
+++ b/programs/compute-budget/instruction.go
@@ -57,6 +57,9 @@ const (
 	// Set a compute unit price in "micro-lamports" to pay a higher transaction
 	// fee for higher transaction prioritization.
 	Instruction_SetComputeUnitPrice
+
+	// Set a specific transaction-wide account data size limit, in bytes, is allowed to load.
+	Instruction_SetLoadedAccountsDataSizeLimit
 )
 
 // InstructionIDToName returns the name of the instruction given its ID.
@@ -70,6 +73,8 @@ func InstructionIDToName(id uint8) string {
 		return "SetComputeUnitLimit"
 	case Instruction_SetComputeUnitPrice:
 		return "SetComputeUnitPrice"
+	case Instruction_SetLoadedAccountsDataSizeLimit:
+		return "SetLoadedAccountsDataSizeLimit"
 	default:
 		return ""
 	}
@@ -101,6 +106,9 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 		},
 		{
 			"SetComputeUnitPrice", (*SetComputeUnitPrice)(nil),
+		},
+		{
+			"SetLoadedAccountsDataSizeLimit", (*SetLoadedAccountsDataSizeLimit)(nil),
 		},
 	},
 )

--- a/programs/compute-budget/instruction_test.go
+++ b/programs/compute-budget/instruction_test.go
@@ -79,6 +79,18 @@ func TestEncodingInstruction(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "SetLoadedAccountsDataSizeLimit",
+			hexData: "0400800000",
+			expectInstruction: &Instruction{
+				BaseVariant: bin.BaseVariant{
+					TypeID: bin.TypeIDFromUint8(4),
+					Impl: &SetLoadedAccountsDataSizeLimit{
+						Bytes: 32 * 1024,
+					},
+				},
+			},
+		},
 	}
 
 	t.Run("should encode", func(t *testing.T) {


### PR DESCRIPTION
### Problem
 SDK doesn't support the `ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit` instruction that was added to the validator codebase more than [2 years ago](https://github.com/solana-labs/solana/pull/30377)
 
 ### Summary of Changes
 - extend `compute-budget` program, add support of the forgotten instruction