### PR TITLE
Don't write memo string length to instruction data

### DIFF
--- a/programs/memo/Create.go
+++ b/programs/memo/Create.go
@@ -111,7 +111,7 @@ func (inst *Create) EncodeToTree(parent ag_treeout.Branches) {
 func (inst Create) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
 	// Serialize `Message` param:
 	{
-		err := encoder.Encode(inst.Message)
+		err := encoder.WriteBytes(inst.Message, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Creating a memo instruction with a given message should use that message's bytes as-is, not prepend it with the byte length.