### PR TITLE
Add SetAccounts implementation to be able to access accounts for Create instruction after decoding

### DIFF
--- a/message.go
+++ b/message.go
@@ -815,6 +815,29 @@ func (m Message) isWritableInLookups(idx int) bool {
 	return idx-m.numStaticAccounts() < m.AddressTableLookups.NumWritableLookups()
 }
 
+// IsWritableStatic checks if the account is a writable account in the static accounts list, ignoring the accounts in the address table lookups.
+func (m *Message) IsWritableStatic(account PublicKey) bool {
+	// check only the static accounts (i.e. not the ones in the address table lookups); no check preconditions needed.
+	accountKeys := m.getStaticKeys()
+	index := 0
+	found := false
+	for idx, acc := range accountKeys {
+		if acc.Equals(account) {
+			found = true
+			index = idx
+		}
+	}
+	if !found {
+		return false
+	}
+	h := m.Header
+	if index >= int(h.NumRequiredSignatures) {
+		// unsignedAccountIndex < numWritableUnsignedAccounts
+		return index-int(h.NumRequiredSignatures) < (m.numStaticAccounts()-int(h.NumRequiredSignatures))-int(h.NumReadonlyUnsignedAccounts)
+	}
+	return index < int(h.NumRequiredSignatures-h.NumReadonlySignedAccounts)
+}
+
 func (m Message) IsWritable(account PublicKey) (bool, error) {
 	err := m.checkPreconditions()
 	if err != nil {
@@ -834,7 +857,7 @@ func (m Message) IsWritable(account PublicKey) (bool, error) {
 		}
 	}
 	if !found {
-		return false, err
+		return false, nil
 	}
 	h := m.Header
 

--- a/message.go
+++ b/message.go
@@ -460,6 +460,19 @@ func (mx *Message) ResolveLookups() (err error) {
 	return nil
 }
 
+var ErrAlreadyResolved = fmt.Errorf("lookups already resolved")
+
+// ResolveLookupsWith resolves the address table lookups with the provided writable and readonly accounts,
+// assuming that the order of the accounts is correct.
+func (mx *Message) ResolveLookupsWith(writable, readonly PublicKeySlice) (err error) {
+	if mx.resolved {
+		return ErrAlreadyResolved
+	}
+	mx.AccountKeys = append(mx.AccountKeys, append(writable, readonly...)...)
+	mx.resolved = true
+	return nil
+}
+
 func (mx Message) IsResolved() bool {
 	return mx.resolved
 }

--- a/programs/associated-token-account/Create.go
+++ b/programs/associated-token-account/Create.go
@@ -73,8 +73,18 @@ func (inst *Create) SetMint(mint solana.PublicKey) *Create {
 	return inst
 }
 
-func (inst Create) Build() *Instruction {
+func (inst *Create) SetAccounts(accounts []*solana.AccountMeta) error {
+	inst.AccountMetaSlice = accounts
+	if len(accounts) < 7 {
+		return fmt.Errorf("insufficient accounts, Create requires at-least 7 accounts not %d", len(accounts))
+	}
+	inst.Payer = accounts[0].PublicKey
+	inst.Wallet = accounts[2].PublicKey
+	inst.Mint = accounts[3].PublicKey
+	return nil
+}
 
+func (inst Create) Build() *Instruction {
 	// Find the associatedTokenAddress;
 	associatedTokenAddress, _, _ := solana.FindAssociatedTokenAddress(
 		inst.Wallet,
@@ -164,7 +174,6 @@ func (inst *Create) EncodeToTree(parent treeout.Branches) {
 			programBranch.Child(format.Instruction("Create")).
 				//
 				ParentFunc(func(instructionBranch treeout.Branches) {
-
 					// Parameters of the instruction:
 					instructionBranch.Child("Params[len=0]").ParentFunc(func(paramsBranch treeout.Branches) {})
 
@@ -199,4 +208,20 @@ func NewCreateInstruction(
 		SetPayer(payer).
 		SetWallet(walletAddress).
 		SetMint(splTokenMintAddress)
+}
+
+func (inst *Create) GetPayerAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice.Get(0)
+}
+
+func (inst *Create) GetAssociatedTokenAddressAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice.Get(1)
+}
+
+func (inst *Create) GetWalletAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice.Get(2)
+}
+
+func (inst *Create) GetMintAccount() *solana.AccountMeta {
+	return inst.AccountMetaSlice.Get(3)
 }

--- a/programs/associated-token-account/instruction_test.go
+++ b/programs/associated-token-account/instruction_test.go
@@ -1,0 +1,132 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package associatedtokenaccount
+
+import (
+	"encoding/hex"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodingInstruction(t *testing.T) {
+	t.Run("should encode", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			// Build an instruction and ensure current encoding matches implementation
+			payer := solana.NewWallet().PublicKey()
+			wallet := solana.NewWallet().PublicKey()
+			mint := solana.NewWallet().PublicKey()
+			ix := NewCreateInstructionBuilder().
+				SetPayer(payer).
+				SetWallet(wallet).
+				SetMint(mint).
+				Build()
+			data, err := ix.Data()
+			require.NoError(t, err)
+			encodedHex := hex.EncodeToString(data)
+			// Current ATA Create encodes no payload bytes
+			require.Equal(t, "", encodedHex)
+		})
+	})
+
+	tests := []struct {
+		name              string
+		hexData           string
+		expectInstruction *Instruction
+	}{
+		{
+			name:    "Create",
+			hexData: "",
+			expectInstruction: &Instruction{
+				BaseVariant: bin.BaseVariant{
+					TypeID: bin.TypeIDFromUint8(0),
+					Impl:   &Create{},
+				},
+			},
+		},
+	}
+
+	t.Run("should encode", func(t *testing.T) {
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				data, err := test.expectInstruction.Data()
+				require.NoError(t, err)
+				encodedHex := hex.EncodeToString(data)
+				require.Equal(t, test.hexData, encodedHex)
+			})
+		}
+	})
+
+	t.Run("should decode", func(t *testing.T) {
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				data, err := hex.DecodeString(test.hexData)
+				require.NoError(t, err)
+				var instruction *Instruction
+				err = bin.NewBinDecoder(data).Decode(&instruction)
+				require.NoError(t, err)
+				assert.Equal(t, test.expectInstruction, instruction)
+			})
+		}
+	})
+}
+
+func TestDecodeSetsAccountsAndGetters(t *testing.T) {
+	payer := solana.NewWallet().PublicKey()
+	wallet := solana.NewWallet().PublicKey()
+	mint := solana.NewWallet().PublicKey()
+
+	// Build an instruction to obtain correctly ordered accounts and data
+	ix := NewCreateInstructionBuilder().
+		SetPayer(payer).
+		SetWallet(wallet).
+		SetMint(mint).
+		Build()
+
+	accounts := ix.Accounts()
+	data, err := ix.Data()
+	require.NoError(t, err)
+
+	decoded, err := DecodeInstruction(accounts, data)
+	require.NoError(t, err)
+
+	create, ok := decoded.Impl.(*Create)
+	require.True(t, ok)
+
+	// Check decoded fields populated via SetAccounts
+	assert.Equal(t, payer, create.Payer)
+	assert.Equal(t, wallet, create.Wallet)
+	assert.Equal(t, mint, create.Mint)
+
+	// Check getters return expected account metas
+	require.NotNil(t, create.GetPayerAccount())
+	require.NotNil(t, create.GetAssociatedTokenAddressAccount())
+	require.NotNil(t, create.GetWalletAccount())
+	require.NotNil(t, create.GetMintAccount())
+
+	assert.True(t, create.GetPayerAccount().IsSigner)
+	assert.True(t, create.GetPayerAccount().IsWritable)
+	assert.Equal(t, payer, create.GetPayerAccount().PublicKey)
+	assert.Equal(t, wallet, create.GetWalletAccount().PublicKey)
+	assert.Equal(t, mint, create.GetMintAccount().PublicKey)
+
+	// Verify associated token address is correctly derived and placed at index 1
+	ata, _, err := solana.FindAssociatedTokenAddress(wallet, mint)
+	require.NoError(t, err)
+	assert.Equal(t, ata, create.GetAssociatedTokenAddressAccount().PublicKey)
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 type testTransactionInstructions struct {
@@ -313,6 +314,54 @@ func TestTransactionVerifySignatures(t *testing.T) {
 		require.NoError(t, tx.VerifySignatures())
 		require.Equal(t, len(tx.Signatures), len(tx.Message.Signers()))
 	}
+}
+
+func TestTransactionSerializeExisting(t *testing.T) {
+	// random pump amm swap transaction (3HWKcTbnAMXt3TZDi8LitZCAT5ht7tYqXCroQgNkEnRuvjWCAhmx4UAFnKTWzxS2JXxhbfTiKEdXeU3VHWKzEkNY)
+	trueEncoded := "AXJEirR5ePYXWIemCsSrRB3kTOxBQvJ8pZ4Of+vs75/Lw4NgNf0jr+eyI+2CAZZcwEQ54v/tcIh0p5qisd6ZfQWAAQAHDuIP6DQ7XgVvZzx4ZyZS5BjxS0s5JIGa893M/2foLj/N9tJulKNTEJ+CcURWZpXddGLJc0niyvBs8fADaZXWBStZSYulGfGwKCcEVhAem2vYiJnZnDQHW8EbXuli2pgFPcs4OJAtX+MJFvqNDoxBApNOXVmhOPi+s+Xj5G6dipCzZIG9Det/kYMpmklt7LaKvckpmIhAC+cygPT/H7L6uDUm47unlLqsWvR0JhT3lhSFUnSWfDsT92IHGjplDB07Bwa4Mppngp8gB0rx3o6jx3q5zZqJ7jaF//YA5f9pM0rWAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAACMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkMFN78gl7GdpQlCBi7ZUBl9CmNMVbVcbTU+AkMGOmoY2CQL4wWkL0iw2m16tD4VGZ2ZSCn9Rr5uDY8UTDVNj2KSwXRBHtnMBytk20Zd1LAlKbsLUEcQ8RupHeXS0aTLV9S0zqFMcANe7dmXMUOgO/qYKWak7hGKVjQNpnUxyaEPQgHAAUCkHwBAAcACQNkjocBAAAAAAgGAAEAEAkKAQELEQwADg0QAgEDBBEPCgoJCBILGDPmhaQBf4OtOLwvMTcAAABscskIAAAAAAoDAQAAAQkKAwIAAAEJCQIABQwCAAAAQEtMAAAAAAAJAgAGDAIAAABAQg8AAAAAAAEcQpjY9205kUMXxtRgI8+U286AVT/u2xYmbclxYfAs+QJDZQMS0kc="
+
+	tx, err := TransactionFromBase64(trueEncoded)
+	require.NoError(t, err)
+
+	encoded, err := tx.ToBase64()
+	require.NoError(t, err)
+	require.Equal(t, trueEncoded, encoded)
+}
+
+func TestTransactionSerializePumpFunSwap(t *testing.T) {
+	expectedEncoded := "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAcMC8/60geEHarnEMtcmE3t7lADNe2/gxa7NAhBe5Ufe5mtEeak/ClEpPqCUb74FUJuG/soxrZkZndgfGrZ9WamRvj7gB4Ax7akKlldX2HW0ZpscDlcG0xgSGrm4qPYLjpXha3ZyoEhdb0urZWzhcxyIVTkHNfJDlRkaaaZumtUuJid6LnvUOa256MT0Ym0MG/y6Uqt2PX3ijrL9vC9eTaGKzqGXmnuD1SAyrz2Y1fk3C8Y1Y1Fwep0ifs3I9l5PHKm6c4nvkyiO9V3lgShoznE+kfvld5CoS4qMMKpnUOErY8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpBqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAACs8TbrAfwcTog9I8i1hEq1mjf2at1XxemsO1PgWdNcZAFW4PaTZlrPRNsVaL8XW6pRicuX9dL/O2VdK7b9bRiw0WlzNBoKArNIcmjqJI0o+XoQGnMjSEA/HZqyYrSJgLkBCwwFAQYCAwQABwgJCgsYZgY9EgHa6+pMR9bEaRkAAHg1HjQAAAAA"
+	instruction := &testTransactionInstructions{
+		programID: MPK("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"),
+		accounts: []*AccountMeta{
+			{PublicKey: MPK("4wTV1YmiEkRvAtNtsSGPtUrqRYQMe5SKy2uB4Jjaxnjf"), IsSigner: false, IsWritable: false},
+			{PublicKey: MPK("CebN5WGQ4jvEPvsVU4EoHEpgzq1VV7AbicfhtW4xC9iM"), IsSigner: false, IsWritable: true},
+			{PublicKey: MPK("GjgKTqtzDei5E3uZyA2CN29KQgugF564K1hoc1jHpump"), IsSigner: false, IsWritable: false},
+			{PublicKey: MPK("HkvYAZV1Mg6kt5KMaA5YBQazZECg21zaZdQEMUiLrjKc"), IsSigner: false, IsWritable: true},
+			{PublicKey: MPK("9zpyjwrYdRWNMyqicoiuL3gUcrbvrkd5Kq9nxui1znw1"), IsSigner: false, IsWritable: true},
+			{PublicKey: MPK("BdQqJnuqqFhNZUNYGEEsuhBidpf8qHqfjDQvcjDN3nti"), IsSigner: false, IsWritable: true},
+			{PublicKey: MPK("o7RY6P2vQMuGSu1TrLM81weuzgDjaCRTXYRaXJwWcvc"), IsSigner: true, IsWritable: true},
+			{PublicKey: MPK("11111111111111111111111111111111"), IsSigner: false, IsWritable: false},
+			{PublicKey: MPK("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"), IsSigner: false, IsWritable: false},
+			{PublicKey: MPK("SysvarRent111111111111111111111111111111111"), IsSigner: false, IsWritable: false},
+			{PublicKey: MPK("Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1"), IsSigner: false, IsWritable: false},
+			{PublicKey: MPK("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"), IsSigner: false, IsWritable: false},
+		},
+		data: []byte{102, 6, 61, 18, 1, 218, 235, 234, 76, 71, 214, 196, 105, 25, 0, 0, 120, 53, 30, 52, 0, 0, 0, 0},
+	}
+
+	tx, err := NewTransactionBuilder().
+		AddInstruction(instruction).
+		SetFeePayer(MPK("o7RY6P2vQMuGSu1TrLM81weuzgDjaCRTXYRaXJwWcvc")).
+		SetRecentBlockHash(MustHashFromBase58("F6TUDvYPMwDLP1MW4BUWTNm6S94XR1UZ2nGVyubqo6oi")).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	encoded, err := tx.ToBase64()
+	require.NoError(t, err)
+
+	zlog.Debug("encoded", zap.String("encoded", encoded))
+	require.Equal(t, expectedEncoded, encoded)
 }
 
 func BenchmarkTransactionFromDecoder(b *testing.B) {


### PR DESCRIPTION
Adding some logic to be able to retrieve the accounts from the ATA instruction after decoding.

I also removed the `SysVarRentPubkey` in the account list for Create. According to the Rust implementation, Create only expects 6 accounts, not 7.
[source.](https://docs.rs/spl-associated-token-account/latest/src/spl_associated_token_account/instruction.rs.html#12-17)

This PR also includes changes from #308 