### PR TITLE
add stackHeight for instruction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -140,7 +140,7 @@ type CompiledInstruction struct {
 
 	// Invocation stack height of this instruction. Instruction stack height
 	// starts at 1 for transaction instructions.
-	StackHeight uint8 `json:"stackHeight,omitempty"`
+	StackHeight uint16 `json:"stackHeight,omitempty"`
 }
 
 func (ci *CompiledInstruction) ResolveInstructionAccounts(message *Message) ([]*AccountMeta, error) {

--- a/transaction.go
+++ b/transaction.go
@@ -137,6 +137,10 @@ type CompiledInstruction struct {
 
 	// The program input data encoded in a base-58 string.
 	Data Base58 `json:"data"`
+
+	// Invocation stack height of this instruction. Instruction stack height
+	// starts at 1 for transaction instructions.
+	StackHeight uint8 `json:"stackHeight,omitempty"`
 }
 
 func (ci *CompiledInstruction) ResolveInstructionAccounts(message *Message) ([]*AccountMeta, error) {

--- a/transaction.go
+++ b/transaction.go
@@ -140,7 +140,7 @@ type CompiledInstruction struct {
 
 	// Invocation stack height of this instruction. Instruction stack height
 	// starts at 1 for transaction instructions.
-	StackHeight uint16 `json:"stackHeight,omitempty"`
+	StackHeight *uint16 `json:"stackHeight,omitempty"`
 }
 
 func (ci *CompiledInstruction) ResolveInstructionAccounts(message *Message) ([]*AccountMeta, error) {


### PR DESCRIPTION
The original `CompiledInstruction` struct is missing the field `stackHeight`
Without this field, parse inner instruction would miss part of the stack height data.
