### PR TITLE
refactor: replace deprecated patterns

### DIFF
--- a/cmd/slnc/cmd/decoding.go
+++ b/cmd/slnc/cmd/decoding.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gagliardetto/solana-go/programs/token"
 )
 
-func decode(owner solana.PublicKey, data []byte) (interface{}, error) {
+func decode(owner solana.PublicKey, data []byte) (any, error) {
 	bdx, _ := solana.PublicKeyFromBase58("BdxDnkFufu8tjAE5gdPkWdjGfQ3Lz2v6ozfiBDMKxDFW")
 	tkn, _ := solana.PublicKeyFromBase58("TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o")
 	switch owner {
@@ -33,7 +33,7 @@ func decode(owner solana.PublicKey, data []byte) (interface{}, error) {
 	return nil, nil
 }
 
-func decodeAsToken(data []byte) (out interface{}, err error) {
+func decodeAsToken(data []byte) (out any, err error) {
 
 	switch len(data) {
 	case 120:

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Diffeable interface {
-	Diff(right interface{}, options ...Option)
+	Diff(right any, options ...Option)
 }
 
 type Option interface {
@@ -192,7 +192,7 @@ func reflectValueCanIsNil(value reflect.Value) bool {
 	}
 }
 
-func Diff(left interface{}, right interface{}, opts ...Option) {
+func Diff(left any, right any, opts ...Option) {
 	options := options{}
 	for _, opt := range opts {
 		opt.apply(&options)

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestDiff(t *testing.T) {
 	type pair struct {
-		left  interface{}
-		right interface{}
+		left  any
+		right any
 	}
 
 	tests := []struct {
@@ -159,8 +159,8 @@ func eventToString(event *Event) string {
 func TestDiff_EventMatch(t *testing.T) {
 	tests := []struct {
 		name           string
-		left           interface{}
-		right          interface{}
+		left           any
+		right          any
 		pattern        string
 		expectedMatch  bool
 		expectedGroups []string
@@ -195,14 +195,14 @@ func TestDiff_EventMatch(t *testing.T) {
 // results. I assume it's a Golang thing related to slice and struct as value versus pointers. It works
 // only single event but starts to act weirdly when there > 1, like the Event's Path is all wrong. It's
 // better to try to avoid it when possible.
-func accumulateDiff(left, right interface{}) (out []Event) {
+func accumulateDiff(left, right any) (out []Event) {
 	Diff(left, right, OnEvent(func(event Event) {
 		out = append(out, event)
 	}))
 	return
 }
 
-func accumulateDiffStrings(left, right interface{}) (out []string) {
+func accumulateDiffStrings(left, right any) (out []string) {
 	Diff(left, right, OnEvent(func(event Event) {
 		out = append(out, eventToString(&event))
 	}))

--- a/diff/logging.go
+++ b/diff/logging.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 type reflectType struct {
-	in interface{}
+	in any
 }
 
 func (r reflectType) String() string {

--- a/nativetype_test.go
+++ b/nativetype_test.go
@@ -135,7 +135,7 @@ func TestData_base64(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			val,
 			"base64",
 		},
@@ -162,7 +162,7 @@ func TestData_base64_empty(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			val,
 			"base64",
 		},
@@ -189,7 +189,7 @@ func TestData_base64_zstd(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			val,
 			"base64+zstd",
 		},
@@ -215,7 +215,7 @@ func TestData_base64_zstd_empty(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			"",
 			"base64+zstd",
 		},
@@ -242,7 +242,7 @@ func TestData_base58(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			val,
 			"base58",
 		},
@@ -269,7 +269,7 @@ func TestData_base58_empty(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			val,
 			"base58",
 		},
@@ -279,7 +279,7 @@ func TestData_base58_empty(t *testing.T) {
 
 // mustAnyToJSON marshals the provided variable
 // to JSON bytes.
-func mustAnyToJSON(raw interface{}) []byte {
+func mustAnyToJSON(raw any) []byte {
 	out, err := json.Marshal(raw)
 	if err != nil {
 		panic(err)
@@ -289,8 +289,8 @@ func mustAnyToJSON(raw interface{}) []byte {
 
 // mustJSONToInterface unmarshals the provided JSON bytes
 // into an `interface{}` type variable, and returns it.
-func mustJSONToInterface(rawJSON []byte) interface{} {
-	var out interface{}
+func mustJSONToInterface(rawJSON []byte) any {
+	var out any
 	err := json.Unmarshal(rawJSON, &out)
 	if err != nil {
 		panic(err)

--- a/nativetypes.go
+++ b/nativetypes.go
@@ -257,7 +257,7 @@ type Data struct {
 
 func (t Data) MarshalJSON() ([]byte, error) {
 	return json.Marshal(
-		[]interface{}{
+		[]any{
 			t.String(),
 			t.Encoding,
 		})

--- a/programs/address-lookup-table/instructions.go
+++ b/programs/address-lookup-table/instructions.go
@@ -115,7 +115,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *bin.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/associated-token-account/instructions.go
+++ b/programs/associated-token-account/instructions.go
@@ -120,7 +120,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *bin.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/compute-budget/instruction.go
+++ b/programs/compute-budget/instruction.go
@@ -145,7 +145,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/memo/instructions.go
+++ b/programs/memo/instructions.go
@@ -84,7 +84,7 @@ func (inst MemoInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/stake/instructions.go
+++ b/programs/stake/instructions.go
@@ -147,7 +147,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *bin.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/system/instructions.go
+++ b/programs/system/instructions.go
@@ -207,7 +207,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/system/testing_utils.go
+++ b/programs/system/testing_utils.go
@@ -21,13 +21,13 @@ import (
 	ag_binary "github.com/gagliardetto/binary"
 )
 
-func encodeT(data interface{}, buf *bytes.Buffer) error {
+func encodeT(data any, buf *bytes.Buffer) error {
 	if err := ag_binary.NewBinEncoder(buf).Encode(data); err != nil {
 		return fmt.Errorf("unable to encode instruction: %w", err)
 	}
 	return nil
 }
 
-func decodeT(dst interface{}, data []byte) error {
+func decodeT(dst any, data []byte) error {
 	return ag_binary.NewBinDecoder(data).Decode(dst)
 }

--- a/programs/token-2022/instructions.go
+++ b/programs/token-2022/instructions.go
@@ -324,7 +324,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/token-2022/testing_utils.go
+++ b/programs/token-2022/testing_utils.go
@@ -7,13 +7,13 @@ import (
 	ag_binary "github.com/gagliardetto/binary"
 )
 
-func encodeT(data interface{}, buf *bytes.Buffer) error {
+func encodeT(data any, buf *bytes.Buffer) error {
 	if err := ag_binary.NewBinEncoder(buf).Encode(data); err != nil {
 		return fmt.Errorf("unable to encode instruction: %w", err)
 	}
 	return nil
 }
 
-func decodeT(dst interface{}, data []byte) error {
+func decodeT(dst any, data []byte) error {
 	return ag_binary.NewBinDecoder(data).Decode(dst)
 }

--- a/programs/token/instructions.go
+++ b/programs/token/instructions.go
@@ -338,7 +338,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/token/testing_utils.go
+++ b/programs/token/testing_utils.go
@@ -20,13 +20,13 @@ import (
 	ag_binary "github.com/gagliardetto/binary"
 )
 
-func encodeT(data interface{}, buf *bytes.Buffer) error {
+func encodeT(data any, buf *bytes.Buffer) error {
 	if err := ag_binary.NewBinEncoder(buf).Encode(data); err != nil {
 		return fmt.Errorf("unable to encode instruction: %w", err)
 	}
 	return nil
 }
 
-func decodeT(dst interface{}, data []byte) error {
+func decodeT(dst any, data []byte) error {
 	return ag_binary.NewBinDecoder(data).Decode(dst)
 }

--- a/programs/tokenregistry/instruction.go
+++ b/programs/tokenregistry/instruction.go
@@ -32,7 +32,7 @@ func init() {
 	solana.MustRegisterInstructionDecoder(ProgramID(), registryDecodeInstruction)
 }
 
-func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/programs/vote/instructions.go
+++ b/programs/vote/instructions.go
@@ -101,7 +101,7 @@ func (inst Instruction) MarshalWithEncoder(encoder *bin.Encoder) error {
 	return encoder.Encode(inst.Impl)
 }
 
-func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (interface{}, error) {
+func registryDecodeInstruction(accounts []*solana.AccountMeta, data []byte) (any, error) {
 	inst, err := DecodeInstruction(accounts, data)
 	if err != nil {
 		return nil, err

--- a/registry.go
+++ b/registry.go
@@ -29,7 +29,7 @@ var ErrInstructionDecoderNotFound = errors.New("instruction decoder not found")
 // InstructionDecoder receives the AccountMeta FOR THAT INSTRUCTION,
 // and not the accounts of the *Message object. Resolve with
 // CompiledInstruction.ResolveInstructionAccounts(message) beforehand.
-type InstructionDecoder func(instructionAccounts []*AccountMeta, data []byte) (interface{}, error)
+type InstructionDecoder func(instructionAccounts []*AccountMeta, data []byte) (any, error)
 
 var instructionDecoderRegistry = newInstructionDecoderRegistry()
 
@@ -109,7 +109,7 @@ func isSameFunction(f1 any, f2 any) bool {
 	return reflect.ValueOf(f1).Pointer() == reflect.ValueOf(f2).Pointer()
 }
 
-func DecodeInstruction(programID PublicKey, accounts []*AccountMeta, data []byte) (interface{}, error) {
+func DecodeInstruction(programID PublicKey, accounts []*AccountMeta, data []byte) (any, error) {
 	decoder, found := instructionDecoderRegistry.Get(programID)
 	if !found {
 		return nil, ErrInstructionDecoderNotFound

--- a/rpc/client-with-ratelimit.go
+++ b/rpc/client-with-ratelimit.go
@@ -33,7 +33,7 @@ func NewWithRateLimit(
 	}
 }
 
-func (wr *clientWithRateLimiting) CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error {
+func (wr *clientWithRateLimiting) CallForInto(ctx context.Context, out any, method string, params []any) error {
 	wr.rateLimiter.Take()
 	return wr.rpcClient.CallForInto(ctx, &out, method, params)
 }
@@ -41,7 +41,7 @@ func (wr *clientWithRateLimiting) CallForInto(ctx context.Context, out interface
 func (wr *clientWithRateLimiting) CallWithCallback(
 	ctx context.Context,
 	method string,
-	params []interface{},
+	params []any,
 	callback func(*http.Request, *http.Response) error,
 ) error {
 	wr.rateLimiter.Take()

--- a/rpc/client-with-ratelimit2.go
+++ b/rpc/client-with-ratelimit2.go
@@ -36,7 +36,7 @@ func NewWithLimiter(
 	}
 }
 
-func (wr *clientWithLimiter) CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error {
+func (wr *clientWithLimiter) CallForInto(ctx context.Context, out any, method string, params []any) error {
 	err := wr.limiter.Wait(ctx)
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func (wr *clientWithLimiter) CallForInto(ctx context.Context, out interface{}, m
 func (wr *clientWithLimiter) CallWithCallback(
 	ctx context.Context,
 	method string,
-	params []interface{},
+	params []any,
 	callback func(*http.Request, *http.Response) error,
 ) error {
 	err := wr.limiter.Wait(ctx)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -40,8 +40,8 @@ type Client struct {
 }
 
 type JSONRPCClient interface {
-	CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error
-	CallWithCallback(ctx context.Context, method string, params []interface{}, callback func(*http.Request, *http.Response) error) error
+	CallForInto(ctx context.Context, out any, method string, params []any) error
+	CallWithCallback(ctx context.Context, method string, params []any, callback func(*http.Request, *http.Response) error) error
 	CallBatch(ctx context.Context, requests jsonrpc.RPCRequests) (jsonrpc.RPCResponses, error)
 }
 
@@ -122,14 +122,14 @@ func newHTTP() *http.Client {
 }
 
 // RPCCallForInto allows to access the raw RPC client and send custom requests.
-func (cl *Client) RPCCallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error {
+func (cl *Client) RPCCallForInto(ctx context.Context, out any, method string, params []any) error {
 	return cl.rpcClient.CallForInto(ctx, out, method, params)
 }
 
 func (cl *Client) RPCCallWithCallback(
 	ctx context.Context,
 	method string,
-	params []interface{},
+	params []any,
 	callback func(*http.Request, *http.Response) error,
 ) error {
 	return cl.rpcClient.CallWithCallback(ctx, method, params, callback)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -51,13 +51,13 @@ func TestClient_GetAccountInfo(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getAccountInfo",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"encoding": "base64",
 				},
 			},
@@ -122,16 +122,16 @@ func TestClient_GetAccountInfoWithOpts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getAccountInfo",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"encoding":   string(solana.EncodingJSON),
 					"commitment": string(CommitmentFinalized),
-					"dataSlice": map[string]interface{}{
+					"dataSlice": map[string]any{
 						"offset": float64(offset),
 						"length": float64(length),
 					},
@@ -143,10 +143,9 @@ func TestClient_GetAccountInfoWithOpts(t *testing.T) {
 	)
 }
 
-
 // mustAnyToJSON marshals the provided variable
 // to JSON bytes.
-func mustAnyToJSON(raw interface{}) []byte {
+func mustAnyToJSON(raw any) []byte {
 	out, err := json.Marshal(raw)
 	if err != nil {
 		panic(err)
@@ -156,8 +155,8 @@ func mustAnyToJSON(raw interface{}) []byte {
 
 // mustJSONToInterface unmarshals the provided JSON bytes
 // into an `interface{}` type variable, and returns it.
-func mustJSONToInterface(rawJSON []byte) interface{} {
-	var out interface{}
+func mustJSONToInterface(rawJSON []byte) any {
+	var out any
 	err := json.Unmarshal(rawJSON, &out)
 	if err != nil {
 		panic(err)
@@ -168,8 +167,8 @@ func mustJSONToInterface(rawJSON []byte) interface{} {
 // mustJSONToInterfaceWithUseNumber unmarshals the provided JSON bytes
 // into an `interface{}` type variable, and returns it.
 // The decoder is configured with `UseNumber()`.
-func mustJSONToInterfaceWithUseNumber(rawJSON []byte) interface{} {
-	var out interface{}
+func mustJSONToInterfaceWithUseNumber(rawJSON []byte) any {
+	var out any
 	dec := json.NewDecoder(bytes.NewReader(rawJSON))
 	dec.UseNumber()
 	err := dec.Decode(&out)
@@ -206,13 +205,13 @@ func TestClient_GetBalance(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBalance",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -249,13 +248,13 @@ func TestClient_GetBlock(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlock",
-			"params": []interface{}{
+			"params": []any{
 				float64(block),
-				map[string]interface{}{
+				map[string]any{
 					"encoding": string(solana.EncodingBase64),
 				},
 			},
@@ -421,13 +420,13 @@ func TestClient_GetBlockWithOpts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlock",
-			"params": []interface{}{
+			"params": []any{
 				float64(block),
-				map[string]interface{}{
+				map[string]any{
 					"encoding":                       string(solana.EncodingBase64),
 					"transactionDetails":             string(TransactionDetailsSignatures),
 					"rewards":                        rewards,
@@ -461,12 +460,12 @@ func TestClient_GetBlockHeight(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlockHeight",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -498,11 +497,11 @@ func TestClient_GetBlockProduction(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlockProduction",
-			"params":  []interface{}{},
+			"params":  []any{},
 		},
 		reqBody,
 	)
@@ -544,14 +543,14 @@ func TestClient_GetBlockProductionWithOpts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlockProduction",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
-					"range": map[string]interface{}{
+					"range": map[string]any{
 						"firstSlot": float64(firstSlot),
 						"lastSlot":  float64(lastSlot),
 					},
@@ -583,19 +582,19 @@ func TestClient_GetBlockCommitment(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlockCommitment",
-			"params": []interface{}{
+			"params": []any{
 				float64(block),
 			},
 		},
 		reqBody,
 	)
 
-	expected := map[string]interface{}{
-		"commitment": []interface{}{
+	expected := map[string]any{
+		"commitment": []any{
 			stdjson.Number("0"),
 			stdjson.Number("0"),
 			stdjson.Number("0"),
@@ -659,14 +658,14 @@ func TestClient_GetBlocks(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlocks",
-			"params": []interface{}{
+			"params": []any{
 				float64(startSlot),
 				float64(endSlot),
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -703,14 +702,14 @@ func TestClient_GetBlocksWithLimit(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlocksWithLimit",
-			"params": []interface{}{
+			"params": []any{
 				float64(startSlot),
 				float64(limit),
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -744,11 +743,11 @@ func TestClient_GetBlockTime(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getBlockTime",
-			"params": []interface{}{
+			"params": []any{
 				float64(block),
 			},
 		},
@@ -779,7 +778,7 @@ func TestClient_GetClusterNodes(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getClusterNodes",
@@ -812,12 +811,12 @@ func TestClient_GetEpochInfo(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getEpochInfo",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -825,7 +824,7 @@ func TestClient_GetEpochInfo(t *testing.T) {
 		reqBody,
 	)
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"absoluteSlot":     8.3994151e+07,
 		"blockHeight":      6.9218302e+07,
 		"epoch":            207.0,
@@ -856,7 +855,7 @@ func TestClient_GetEpochSchedule(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getEpochSchedule",
@@ -888,7 +887,7 @@ func TestClient_GetFirstAvailableBlock(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getFirstAvailableBlock",
@@ -920,7 +919,7 @@ func TestClient_GetGenesisHash(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getGenesisHash",
@@ -952,7 +951,7 @@ func TestClient_GetHealth(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getHealth",
@@ -984,7 +983,7 @@ func TestClient_GetIdentity(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getIdentity",
@@ -1017,12 +1016,12 @@ func TestClient_GetInflationGovernor(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getInflationGovernor",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -1054,7 +1053,7 @@ func TestClient_GetInflationRate(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getInflationRate",
@@ -1100,15 +1099,15 @@ func TestClient_GetInflationReward(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getInflationReward",
-			"params": []interface{}{
-				[]interface{}{
+			"params": []any{
+				[]any{
 					pubkeyString,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 					"epoch":      float64(epoch),
 				},
@@ -1144,12 +1143,12 @@ func TestClient_GetLargestAccounts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getLargestAccounts",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 					"filter":     string(filter),
 				},
@@ -1278,13 +1277,13 @@ func TestClient_GetLeaderSchedule(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getLeaderSchedule",
-			"params": []interface{}{
+			"params": []any{
 				float64(epoch),
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 					"identity":   string(identity.String()),
 				},
@@ -1317,7 +1316,7 @@ func TestClient_GetMaxRetransmitSlot(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getMaxRetransmitSlot",
@@ -1349,7 +1348,7 @@ func TestClient_GetMaxShredInsertSlot(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getMaxShredInsertSlot",
@@ -1384,13 +1383,13 @@ func TestClient_GetMinimumBalanceForRentExemption(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getMinimumBalanceForRentExemption",
-			"params": []interface{}{
+			"params": []any{
 				float64(dataSize),
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -1425,12 +1424,12 @@ func TestClient_GetMultipleAccounts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getMultipleAccounts",
-			"params": []interface{}{
-				[]interface{}{pubkeyString},
+			"params": []any{
+				[]any{pubkeyString},
 			},
 		},
 		reqBody,
@@ -1503,22 +1502,22 @@ func TestClient_GetProgramAccounts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getProgramAccounts",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"encoding":   string(solana.EncodingBase58),
 					"commitment": string(CommitmentFinalized),
-					"dataSlice": map[string]interface{}{
+					"dataSlice": map[string]any{
 						"offset": float64(offset),
 						"length": float64(length),
 					},
-					"filters": []interface{}{
-						map[string]interface{}{
-							"memcmp": map[string]interface{}{
+					"filters": []any{
+						map[string]any{
+							"memcmp": map[string]any{
 								"bytes":  "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932",
 								"offset": float64(offset),
 							},
@@ -1571,11 +1570,11 @@ func TestClient_GetRecentPerformanceSamples(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getRecentPerformanceSamples",
-			"params": []interface{}{
+			"params": []any{
 				float64(limit),
 			},
 		},
@@ -1623,13 +1622,13 @@ func TestClient_GetSignaturesForAddress(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSignaturesForAddress",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"commitment":     string(CommitmentFinalized),
 					"before":         before.String(),
 					"until":          until.String(),
@@ -1670,16 +1669,16 @@ func TestClient_GetSignatureStatuses(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSignatureStatuses",
-			"params": []interface{}{
-				[]interface{}{
+			"params": []any{
+				[]any{
 					sig1.String(),
 					sig2.String(),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"searchTransactionHistory": true,
 				},
 			},
@@ -1712,12 +1711,12 @@ func TestClient_GetSlot(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSlot",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -1750,12 +1749,12 @@ func TestClient_GetSlotLeader(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSlotLeader",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -1791,11 +1790,11 @@ func TestClient_GetSlotLeaders(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSlotLeaders",
-			"params": []interface{}{
+			"params": []any{
 				float64(start),
 				float64(limit),
 			},
@@ -1825,12 +1824,12 @@ func TestClient_GetSupply(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSupply",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment":                        string(CommitmentFinalized),
 					"excludeNonCirculatingAccountsList": false,
 				},
@@ -1867,12 +1866,12 @@ func TestClient_GetSupply_WithOpts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSupply",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment":                        string(CommitmentFinalized),
 					"excludeNonCirculatingAccountsList": false,
 				},
@@ -1910,12 +1909,12 @@ func TestClient_GetSupply_ExcludeNonCirculatingAccounts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getSupply",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment":                        string(CommitmentConfirmed),
 					"excludeNonCirculatingAccountsList": true,
 				},
@@ -1953,13 +1952,13 @@ func TestClient_GetTokenLargestAccounts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTokenLargestAccounts",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -1996,13 +1995,13 @@ func TestClient_GetTokenSupply(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTokenSupply",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -2044,13 +2043,13 @@ func TestClient_GetTransaction(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTransaction",
-			"params": []interface{}{
+			"params": []any{
 				tx,
-				map[string]interface{}{
+				map[string]any{
 					"encoding":                       string(solana.EncodingBase64),
 					"commitment":                     string(CommitmentFinalized),
 					"maxSupportedTransactionVersion": float64(maxSupportedTransactionVersion),
@@ -2157,13 +2156,13 @@ func TestClient_GetParsedTransaction(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTransaction",
-			"params": []interface{}{
+			"params": []any{
 				tx,
-				map[string]interface{}{
+				map[string]any{
 					"encoding":   string(solana.EncodingJSONParsed),
 					"commitment": string(CommitmentFinalized),
 				},
@@ -2174,7 +2173,7 @@ func TestClient_GetParsedTransaction(t *testing.T) {
 
 	assert.Equal(t, uint64(2), out.Meta.InnerInstructions[0].Index)
 	assert.Equal(t, &InstructionInfo{
-		Info: map[string]interface{}{
+		Info: map[string]any{
 			"account":   "BMnsyyG6S6zkaE3K5X3nbRMKdvBS5dT6HhcMozBVL7Ly",
 			"amount":    "47444666",
 			"authority": "7oPa2PHQdZmjSPqvpZN7MQxnC7Dcf3uL4oLqknGLk2S3",
@@ -2183,7 +2182,7 @@ func TestClient_GetParsedTransaction(t *testing.T) {
 		InstructionType: "burn",
 	}, out.Meta.InnerInstructions[0].Instructions[0].Parsed.asInstructionInfo)
 	assert.Equal(t, &InstructionInfo{
-		Info: map[string]interface{}{
+		Info: map[string]any{
 			"destination": "9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxeintHy",
 			"lamports":    float64(100),
 			"source":      "G7Hf2J55BAkHtbbXPh94UTGRCQioKPpnb5oKQMBteXo",
@@ -2210,12 +2209,12 @@ func TestClient_GetTransactionCount(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTransactionCount",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -2247,7 +2246,7 @@ func TestClient_GetVersion(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getVersion",
@@ -2284,12 +2283,12 @@ func TestClient_GetVoteAccounts(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getVoteAccounts",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"votePubkey": opts.VotePubkey.String(),
 					"commitment": string(CommitmentFinalized),
 				},
@@ -2322,7 +2321,7 @@ func TestClient_MinimumLedgerSlot(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "minimumLedgerSlot",
@@ -2361,14 +2360,14 @@ func TestClient_RequestAirdrop(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "requestAirdrop",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
 				float64(lamports),
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -2405,13 +2404,13 @@ func TestClient_GetTokenAccountBalance(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTokenAccountBalance",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -2457,16 +2456,16 @@ func TestClient_GetTokenAccountsByDelegate(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTokenAccountsByDelegate",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"programId": string(programIDString),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 					"encoding":   string(solana.EncodingJSONParsed),
 				},
@@ -2513,16 +2512,16 @@ func TestClient_GetTokenAccountsByOwner(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getTokenAccountsByOwner",
-			"params": []interface{}{
+			"params": []any{
 				pubkeyString,
-				map[string]interface{}{
+				map[string]any{
 					"programId": string(programIDString),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 					"encoding":   string(solana.EncodingJSONParsed),
 				},
@@ -2625,13 +2624,13 @@ func TestClient_IsBlockhashValid(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "isBlockhashValid",
-			"params": []interface{}{
+			"params": []any{
 				blockhashString,
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentFinalized),
 				},
 			},
@@ -2671,13 +2670,13 @@ func TestClient_GetFeeForMessage(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getFeeForMessage",
-			"params": []interface{}{
+			"params": []any{
 				"AQABAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAA",
-				map[string]interface{}{
+				map[string]any{
 					"commitment": string(CommitmentProcessed),
 				},
 			},
@@ -2709,7 +2708,7 @@ func TestClient_GetHighestSnapshotSlot(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getHighestSnapshotSlot",
@@ -2742,12 +2741,12 @@ func TestClient_GetLatestBlockhash(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getLatestBlockhash",
-			"params": []interface{}{
-				map[string]interface{}{
+			"params": []any{
+				map[string]any{
 					"commitment": string(CommitmentProcessed),
 				},
 			},
@@ -2786,12 +2785,12 @@ func TestClient_GetRecentPrioritizationFees(t *testing.T) {
 	reqBody["id"] = any(nil)
 
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"id":      any(nil),
 			"jsonrpc": "2.0",
 			"method":  "getRecentPrioritizationFees",
-			"params": []interface{}{
-				[]interface{}{
+			"params": []any{
+				[]any{
 					accounts[0].String(),
 					accounts[1].String(),
 				},

--- a/rpc/getAccountInfo.go
+++ b/rpc/getAccountInfo.go
@@ -38,7 +38,7 @@ func (cl *Client) GetAccountInfo(ctx context.Context, account solana.PublicKey) 
 
 // GetAccountDataInto decodes the binary data and populates
 // the provided `inVar` parameter with all data associated with the account of provided publicKey.
-func (cl *Client) GetAccountDataInto(ctx context.Context, account solana.PublicKey, inVar interface{}) (err error) {
+func (cl *Client) GetAccountDataInto(ctx context.Context, account solana.PublicKey, inVar any) (err error) {
 	resp, err := cl.GetAccountInfo(ctx, account)
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (cl *Client) GetAccountDataInto(ctx context.Context, account solana.PublicK
 
 // GetAccountDataBorshInto decodes the borsh binary data and populates
 // the provided `inVar` parameter with all data associated with the account of provided publicKey.
-func (cl *Client) GetAccountDataBorshInto(ctx context.Context, account solana.PublicKey, inVar interface{}) (err error) {
+func (cl *Client) GetAccountDataBorshInto(ctx context.Context, account solana.PublicKey, inVar any) (err error) {
 	resp, err := cl.GetAccountInfo(ctx, account)
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ func (cl *Client) getAccountInfoWithOpts(
 		}
 	}
 
-	params := []interface{}{account}
+	params := []any{account}
 	if len(obj) > 0 {
 		params = append(params, obj)
 	}

--- a/rpc/getBalance.go
+++ b/rpc/getBalance.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ func (cl *Client) GetBalance(
 	// Commitment requirement. Optional.
 	commitment CommitmentType,
 ) (out *GetBalanceResult, err error) {
-	params := []interface{}{publicKey}
+	params := []any{publicKey}
 	if commitment != "" {
 		params = append(params, M{"commitment": string(commitment)})
 	}

--- a/rpc/getBlock.go
+++ b/rpc/getBlock.go
@@ -120,7 +120,7 @@ func (cl *Client) GetBlockWithOpts(
 		}
 	}
 
-	params := []interface{}{slot, obj}
+	params := []any{slot, obj}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getBlock", params)
 	if err != nil {
@@ -191,7 +191,7 @@ func (cl *Client) GetParsedBlockWithOpts(
 		}
 	}
 
-	params := []interface{}{slot, obj}
+	params := []any{slot, obj}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getBlock", params)
 	if err != nil {

--- a/rpc/getBlockCommitment.go
+++ b/rpc/getBlockCommitment.go
@@ -23,7 +23,7 @@ func (cl *Client) GetBlockCommitment(
 	ctx context.Context,
 	block uint64, // block, identified by Slot
 ) (out *GetBlockCommitmentResult, err error) {
-	params := []interface{}{block}
+	params := []any{block}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getBlockCommitment", params)
 	return
 }

--- a/rpc/getBlockHeight.go
+++ b/rpc/getBlockHeight.go
@@ -23,7 +23,7 @@ func (cl *Client) GetBlockHeight(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out uint64, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getBlockProduction.go
+++ b/rpc/getBlockProduction.go
@@ -68,7 +68,7 @@ func (cl *Client) GetBlockProductionWithOpts(
 	ctx context.Context,
 	opts *GetBlockProductionOpts,
 ) (out *GetBlockProductionResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 
 	if opts != nil {
 		obj := M{}

--- a/rpc/getBlockTime.go
+++ b/rpc/getBlockTime.go
@@ -35,7 +35,7 @@ func (cl *Client) GetBlockTime(
 	ctx context.Context,
 	block uint64, // block, identified by Slot
 ) (out *solana.UnixTimeSeconds, err error) {
-	params := []interface{}{block}
+	params := []any{block}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getBlockTime", params)
 	return
 }

--- a/rpc/getBlocks.go
+++ b/rpc/getBlocks.go
@@ -28,7 +28,7 @@ func (cl *Client) GetBlocks(
 	endSlot *uint64, // optional
 	commitment CommitmentType, // optional
 ) (out BlocksResult, err error) {
-	params := []interface{}{startSlot}
+	params := []any{startSlot}
 	if endSlot != nil {
 		params = append(params, endSlot)
 	}

--- a/rpc/getBlocksWithLimit.go
+++ b/rpc/getBlocksWithLimit.go
@@ -27,7 +27,7 @@ func (cl *Client) GetBlocksWithLimit(
 	limit uint64,
 	commitment CommitmentType, // optional; "processed" is not supported. If parameter not provided, the default is "finalized".
 ) (out *BlocksResult, err error) {
-	params := []interface{}{startSlot, limit}
+	params := []any{startSlot, limit}
 	if commitment != "" {
 		params = append(params,
 			// TODO: provide commitment as string instead of object?

--- a/rpc/getEpochInfo.go
+++ b/rpc/getEpochInfo.go
@@ -23,7 +23,7 @@ func (cl *Client) GetEpochInfo(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out *GetEpochInfoResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getFeeForMessage.go
+++ b/rpc/getFeeForMessage.go
@@ -24,7 +24,7 @@ func (cl *Client) GetFeeForMessage(
 	message string, // Base-64 encoded Message
 	commitment CommitmentType, // optional
 ) (out *GetFeeForMessageResult, err error) {
-	params := []interface{}{message}
+	params := []any{message}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getInflationGovernor.go
+++ b/rpc/getInflationGovernor.go
@@ -23,7 +23,7 @@ func (cl *Client) GetInflationGovernor(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out *GetInflationGovernorResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params,
 			M{"commitment": commitment},

--- a/rpc/getInflationReward.go
+++ b/rpc/getInflationReward.go
@@ -38,7 +38,7 @@ func (cl *Client) GetInflationReward(
 	opts *GetInflationRewardOpts,
 
 ) (out []*GetInflationRewardResult, err error) {
-	params := []interface{}{addresses}
+	params := []any{addresses}
 	if opts != nil {
 		obj := M{}
 		if opts.Commitment != "" {

--- a/rpc/getLargestAccounts.go
+++ b/rpc/getLargestAccounts.go
@@ -34,7 +34,7 @@ func (cl *Client) GetLargestAccounts(
 	commitment CommitmentType,
 	filter LargestAccountsFilterType, // filter results by account type; currently supported: circulating|nonCirculating
 ) (out *GetLargestAccountsResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	obj := M{}
 	if commitment != "" {
 		obj["commitment"] = commitment

--- a/rpc/getLatestBlockhash.go
+++ b/rpc/getLatestBlockhash.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ func (cl *Client) GetLatestBlockhash(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out *GetLatestBlockhashResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getLeaderSchedule.go
+++ b/rpc/getLeaderSchedule.go
@@ -47,7 +47,7 @@ func (cl *Client) GetLeaderScheduleWithOpts(
 	ctx context.Context,
 	opts *GetLeaderScheduleOpts,
 ) (out GetLeaderScheduleResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if opts != nil {
 		if opts.Epoch != nil {
 			params = append(params, opts.Epoch)

--- a/rpc/getMinimumBalanceForRentExemption.go
+++ b/rpc/getMinimumBalanceForRentExemption.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ func (cl *Client) GetMinimumBalanceForRentExemption(
 	dataSize uint64,
 	commitment CommitmentType, // optional
 ) (lamport uint64, err error) {
-	params := []interface{}{dataSize}
+	params := []any{dataSize}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getMultipleAccounts.go
+++ b/rpc/getMultipleAccounts.go
@@ -46,7 +46,7 @@ func (cl *Client) GetMultipleAccountsWithOpts(
 	accounts []solana.PublicKey,
 	opts *GetMultipleAccountsOpts,
 ) (out *GetMultipleAccountsResult, err error) {
-	params := []interface{}{accounts}
+	params := []any{accounts}
 
 	if opts != nil {
 		obj := M{}

--- a/rpc/getParsedTransaction.go
+++ b/rpc/getParsedTransaction.go
@@ -30,7 +30,7 @@ func (cl *Client) GetParsedTransaction(
 	txSig solana.Signature,
 	opts *GetParsedTransactionOpts,
 ) (out *GetParsedTransactionResult, err error) {
-	params := []interface{}{txSig}
+	params := []any{txSig}
 	obj := M{}
 	if opts != nil {
 		if opts.Commitment != "" {

--- a/rpc/getProgramAccounts.go
+++ b/rpc/getProgramAccounts.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -61,7 +61,7 @@ func (cl *Client) GetProgramAccountsWithOpts(
 		}
 	}
 
-	params := []interface{}{publicKey, obj}
+	params := []any{publicKey, obj}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getProgramAccounts", params)
 	return

--- a/rpc/getRecentPerformanceSamples.go
+++ b/rpc/getRecentPerformanceSamples.go
@@ -25,7 +25,7 @@ func (cl *Client) GetRecentPerformanceSamples(
 	ctx context.Context,
 	limit *uint,
 ) (out []*GetRecentPerformanceSamplesResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if limit != nil {
 		params = append(params, limit)
 	}

--- a/rpc/getRecentPrioritizationFees.go
+++ b/rpc/getRecentPrioritizationFees.go
@@ -26,7 +26,7 @@ func (cl *Client) GetRecentPrioritizationFees(
 	ctx context.Context,
 	accounts solana.PublicKeySlice, // optional
 ) (out []PriorizationFeeResult, err error) {
-	params := []interface{}{accounts}
+	params := []any{accounts}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getRecentPrioritizationFees", params)
 
 	return

--- a/rpc/getSignatureStatuses.go
+++ b/rpc/getSignatureStatuses.go
@@ -35,7 +35,7 @@ func (cl *Client) GetSignatureStatuses(
 	// Transaction signatures to confirm.
 	transactionSignatures ...solana.Signature,
 ) (out *GetSignatureStatusesResult, err error) {
-	params := []interface{}{transactionSignatures}
+	params := []any{transactionSignatures}
 	if searchTransactionHistory {
 		params = append(params, M{"searchTransactionHistory": searchTransactionHistory})
 	}
@@ -65,7 +65,7 @@ type SignatureStatusesResult struct {
 	Confirmations *uint64 `json:"confirmations"`
 
 	// Error if transaction failed, null if transaction succeeded.
-	Err interface{} `json:"err"`
+	Err any `json:"err"`
 
 	// The transaction's cluster confirmation status; either processed, confirmed, or finalized.
 	ConfirmationStatus ConfirmationStatusType `json:"confirmationStatus"`

--- a/rpc/getSignaturesForAddress.go
+++ b/rpc/getSignaturesForAddress.go
@@ -62,7 +62,7 @@ func (cl *Client) GetSignaturesForAddressWithOpts(
 	account solana.PublicKey,
 	opts *GetSignaturesForAddressOpts,
 ) (out []*TransactionSignature, err error) {
-	params := []interface{}{account}
+	params := []any{account}
 	if opts != nil {
 		obj := M{}
 		if opts.Limit != nil {

--- a/rpc/getSlot.go
+++ b/rpc/getSlot.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ func (cl *Client) GetSlot(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out uint64, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getSlotLeader.go
+++ b/rpc/getSlotLeader.go
@@ -25,7 +25,7 @@ func (cl *Client) GetSlotLeader(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out solana.PublicKey, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params, M{"commitment": commitment})
 	}

--- a/rpc/getSlotLeaders.go
+++ b/rpc/getSlotLeaders.go
@@ -26,7 +26,7 @@ func (cl *Client) GetSlotLeaders(
 	start uint64,
 	limit uint64,
 ) (out []solana.PublicKey, err error) {
-	params := []interface{}{start, limit}
+	params := []any{start, limit}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getSlotLeaders", params)
 	return
 }

--- a/rpc/getSupply.go
+++ b/rpc/getSupply.go
@@ -40,7 +40,7 @@ func (cl *Client) GetSupplyWithOpts(
 		obj["excludeNonCirculatingAccountsList"] = opts.ExcludeNonCirculatingAccountsList
 	}
 
-	err = cl.rpcClient.CallForInto(ctx, &out, "getSupply", []interface{}{obj})
+	err = cl.rpcClient.CallForInto(ctx, &out, "getSupply", []any{obj})
 	return
 }
 

--- a/rpc/getTokenAccountBalance.go
+++ b/rpc/getTokenAccountBalance.go
@@ -26,7 +26,7 @@ func (cl *Client) GetTokenAccountBalance(
 	account solana.PublicKey,
 	commitment CommitmentType, // optional
 ) (out *GetTokenAccountBalanceResult, err error) {
-	params := []interface{}{account}
+	params := []any{account}
 	if commitment != "" {
 		params = append(params,
 			M{"commitment": commitment},

--- a/rpc/getTokenAccountsByDelegate.go
+++ b/rpc/getTokenAccountsByDelegate.go
@@ -46,7 +46,7 @@ func (cl *Client) GetTokenAccountsByDelegate(
 	conf *GetTokenAccountsConfig,
 	opts *GetTokenAccountsOpts,
 ) (out *GetTokenAccountsResult, err error) {
-	params := []interface{}{account}
+	params := []any{account}
 	if conf == nil {
 		return nil, errors.New("conf is nil")
 	}

--- a/rpc/getTokenAccountsByOwner.go
+++ b/rpc/getTokenAccountsByOwner.go
@@ -28,7 +28,7 @@ func (cl *Client) GetTokenAccountsByOwner(
 	conf *GetTokenAccountsConfig,
 	opts *GetTokenAccountsOpts,
 ) (out *GetTokenAccountsResult, err error) {
-	params := []interface{}{owner}
+	params := []any{owner}
 	if conf == nil {
 		return nil, errors.New("conf is nil")
 	}

--- a/rpc/getTokenLargestAccounts.go
+++ b/rpc/getTokenLargestAccounts.go
@@ -26,7 +26,7 @@ func (cl *Client) GetTokenLargestAccounts(
 	tokenMint solana.PublicKey, // Pubkey of token Mint to query
 	commitment CommitmentType, // optional
 ) (out *GetTokenLargestAccountsResult, err error) {
-	params := []interface{}{tokenMint}
+	params := []any{tokenMint}
 	if commitment != "" {
 		params = append(params,
 			M{"commitment": commitment},

--- a/rpc/getTokenSupply.go
+++ b/rpc/getTokenSupply.go
@@ -26,7 +26,7 @@ func (cl *Client) GetTokenSupply(
 	tokenMint solana.PublicKey, // Pubkey of token Mint to query
 	commitment CommitmentType, // optional
 ) (out *GetTokenSupplyResult, err error) {
-	params := []interface{}{tokenMint}
+	params := []any{tokenMint}
 	if commitment != "" {
 		params = append(params,
 			M{"commitment": commitment},

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -39,7 +39,7 @@ func (cl *Client) GetTransaction(
 	txSig solana.Signature, // transaction signature
 	opts *GetTransactionOpts,
 ) (out *GetTransactionResult, err error) {
-	params := []interface{}{txSig}
+	params := []any{txSig}
 	if opts != nil {
 		obj := M{}
 		if opts.Encoding != "" {

--- a/rpc/getTransactionCount.go
+++ b/rpc/getTransactionCount.go
@@ -23,7 +23,7 @@ func (cl *Client) GetTransactionCount(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out uint64, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if commitment != "" {
 		params = append(params,
 			M{"commitment": commitment},

--- a/rpc/getVoteAccounts.go
+++ b/rpc/getVoteAccounts.go
@@ -42,7 +42,7 @@ func (cl *Client) GetVoteAccounts(
 	ctx context.Context,
 	opts *GetVoteAccountsOpts,
 ) (out *GetVoteAccountsResult, err error) {
-	params := []interface{}{}
+	params := []any{}
 	if opts != nil {
 		obj := M{}
 		if opts.Commitment != "" {

--- a/rpc/isBlockhashValid.go
+++ b/rpc/isBlockhashValid.go
@@ -15,7 +15,7 @@ func (cl *Client) IsBlockhashValid(
 	// Commitment requirement. Optional.
 	commitment CommitmentType,
 ) (out *IsValidBlockhashResult, err error) {
-	params := []interface{}{blockHash}
+	params := []any{blockHash}
 	if commitment != "" {
 		params = append(params, M{"commitment": string(commitment)})
 	}

--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -50,7 +50,7 @@ type RPCClient interface {
 	//   Call("setPersonDetails", "Alex", 35, "Germany") -> {"method": "setPersonDetails", "params": ["Alex", 35, "Germany"}}
 	//
 	// for more information, see the examples or the unit tests
-	Call(ctx context.Context, method string, params ...interface{}) (*RPCResponse, error)
+	Call(ctx context.Context, method string, params ...any) (*RPCResponse, error)
 
 	// CallRaw is like Call() but without magic in the requests.Params field.
 	// The RPCRequest object is sent exactly as you provide it.
@@ -72,7 +72,7 @@ type RPCClient interface {
 	// an error is returned. if it was an JSON-RPC error it can be casted
 	// to *RPCError.
 	//
-	CallFor(ctx context.Context, out interface{}, method string, params ...interface{}) error
+	CallFor(ctx context.Context, out any, method string, params ...any) error
 
 	// CallBatch invokes a list of RPCRequests in a single batch request.
 	//
@@ -120,8 +120,8 @@ type RPCClient interface {
 	// - RPCPersponses is enriched with helper functions e.g.: responses.HasError() returns  true if one of the responses holds an RPCError
 	CallBatchRaw(ctx context.Context, requests RPCRequests) (RPCResponses, error)
 
-	CallForInto(ctx context.Context, out interface{}, method string, params []interface{}) error
-	CallWithCallback(ctx context.Context, method string, params []interface{}, callback func(*http.Request, *http.Response) error) error
+	CallForInto(ctx context.Context, out any, method string, params []any) error
+	CallWithCallback(ctx context.Context, method string, params []any, callback func(*http.Request, *http.Response) error) error
 	Close() error
 }
 
@@ -165,16 +165,16 @@ type RPCClient interface {
 //	  Params: []int{2}, <-- invalid since a single primitive value must be wrapped in an array
 //	}
 type RPCRequest struct {
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params,omitempty"`
-	ID      any         `json:"id"`
-	JSONRPC string      `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+	ID      any    `json:"id"`
+	JSONRPC string `json:"jsonrpc"`
 }
 
 // NewRequest returns a new RPCRequest that can be created using the same convenient parameter syntax as Call()
 //
 // e.g. NewRequest("myMethod", "Alex", 35, true)
-func NewRequest(method string, params ...interface{}) *RPCRequest {
+func NewRequest(method string, params ...any) *RPCRequest {
 	request := &RPCRequest{
 		Method:  method,
 		Params:  Params(params...),
@@ -212,9 +212,9 @@ type RPCResponse struct {
 //
 // See: http://www.jsonrpc.org/specification#error_object
 type RPCError struct {
-	Code    int         `json:"code"`
-	Message string      `json:"message"`
-	Data    interface{} `json:"data,omitempty"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
 }
 
 var spewConf = spew.ConfigState{
@@ -358,7 +358,7 @@ func NewClientWithOpts(endpoint string, opts *RPCClientOpts) RPCClient {
 	return rpcClient
 }
 
-func (client *rpcClient) Call(ctx context.Context, method string, params ...interface{}) (*RPCResponse, error) {
+func (client *rpcClient) Call(ctx context.Context, method string, params ...any) (*RPCResponse, error) {
 	request := &RPCRequest{
 		Method:  method,
 		Params:  Params(params...),
@@ -377,9 +377,9 @@ func (client *rpcClient) Close() error {
 
 func (client *rpcClient) CallForInto(
 	ctx context.Context,
-	out interface{},
+	out any,
 	method string,
-	params []interface{},
+	params []any,
 ) error {
 	request := &RPCRequest{
 		Method:  method,
@@ -405,7 +405,7 @@ func (client *rpcClient) CallForInto(
 func (client *rpcClient) CallWithCallback(
 	ctx context.Context,
 	method string,
-	params []interface{},
+	params []any,
 	callback func(*http.Request, *http.Response) error,
 ) error {
 	request := &RPCRequest{
@@ -428,7 +428,7 @@ func (client *rpcClient) CallRaw(ctx context.Context, request *RPCRequest) (*RPC
 	return client.doCall(ctx, request)
 }
 
-func (client *rpcClient) CallFor(ctx context.Context, out interface{}, method string, params ...interface{}) error {
+func (client *rpcClient) CallFor(ctx context.Context, out any, method string, params ...any) error {
 	rpcResponse, err := client.Call(ctx, method, params...)
 	if err != nil {
 		return err
@@ -462,7 +462,7 @@ func (client *rpcClient) CallBatchRaw(ctx context.Context, requests RPCRequests)
 	return client.doBatchCall(ctx, requests)
 }
 
-func (client *rpcClient) newRequest(ctx context.Context, req interface{}) (*http.Request, error) {
+func (client *rpcClient) newRequest(ctx context.Context, req any) (*http.Request, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
@@ -644,8 +644,8 @@ func (client *rpcClient) doBatchCall(ctx context.Context, rpcRequest []*RPCReque
 //	  Method: "myMethod",
 //	  Params: []int{2}, <-- invalid since a single primitive value must be wrapped in an array
 //	}
-func Params(params ...interface{}) interface{} {
-	var finalParams interface{}
+func Params(params ...any) any {
+	var finalParams any
 
 	// if params was nil skip this and p stays nil
 	if params != nil {
@@ -691,7 +691,7 @@ func Params(params ...interface{}) interface{} {
 // GetObject converts the rpc response to an arbitrary type.
 //
 // The function works as you would expect it from json.Unmarshal()
-func (RPCResponse *RPCResponse) GetObject(toType interface{}) error {
+func (RPCResponse *RPCResponse) GetObject(toType any) error {
 	if RPCResponse == nil {
 		return errors.New("rpc response is nil")
 	}

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	stdjson "encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,7 +32,7 @@ var httpServer *httptest.Server
 // start the testhttp server and stop it when tests are finished
 func TestMain(m *testing.M) {
 	httpServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		defer r.Body.Close()
 		// put request and body to channel for the client to investigate them
 		requestChan <- &RequestData{r, string(data)}
@@ -84,7 +84,7 @@ func TestRpcClient_Call(t *testing.T) {
 	rpcClient.Call(context.Background(), "nullParams", nil, nil)
 	Expect((<-requestChan).body).To(Equal(`{"method":"nullParams","params":[null,null],"id":1,"jsonrpc":"2.0"}`))
 
-	rpcClient.Call(context.Background(), "emptyParams", []interface{}{})
+	rpcClient.Call(context.Background(), "emptyParams", []any{})
 	Expect((<-requestChan).body).To(Equal(`{"method":"emptyParams","params":[],"id":1,"jsonrpc":"2.0"}`))
 
 	rpcClient.Call(context.Background(), "emptyAnyParams", []string{})
@@ -139,10 +139,10 @@ func TestRpcClient_Call(t *testing.T) {
 	rpcClient.Call(context.Background(), "multipleStructs", person, &drink)
 	Expect((<-requestChan).body).To(Equal(`{"method":"multipleStructs","params":[{"name":"Alex","age":35,"country":"Germany"},{"name":"Cuba Libre","ingredients":["rum","cola"]}],"id":1,"jsonrpc":"2.0"}`))
 
-	rpcClient.Call(context.Background(), "singleStructInArray", []interface{}{person})
+	rpcClient.Call(context.Background(), "singleStructInArray", []any{person})
 	Expect((<-requestChan).body).To(Equal(`{"method":"singleStructInArray","params":[{"name":"Alex","age":35,"country":"Germany"}],"id":1,"jsonrpc":"2.0"}`))
 
-	rpcClient.Call(context.Background(), "namedParameters", map[string]interface{}{
+	rpcClient.Call(context.Background(), "namedParameters", map[string]any{
 		"name": "Alex",
 		"age":  35,
 	})
@@ -212,7 +212,7 @@ func TestRpcClient_CallBatch(t *testing.T) {
 	requests := RPCRequests{
 		NewRequest("nullParam", nil),
 		NewRequest("nullParams", nil, nil),
-		NewRequest("emptyParams", []interface{}{}),
+		NewRequest("emptyParams", []any{}),
 		NewRequest("emptyAnyParams", []string{}),
 		NewRequest("emptyObject", struct{}{}),
 		NewRequest("emptyObjectList", []struct{}{{}, {}}),
@@ -229,8 +229,8 @@ func TestRpcClient_CallBatch(t *testing.T) {
 		NewRequest("singleStruct", person),
 		NewRequest("singlePointerToStruct", &person),
 		NewRequest("multipleStructs", person, &drink),
-		NewRequest("singleStructInArray", []interface{}{person}),
-		NewRequest("namedParameters", map[string]interface{}{
+		NewRequest("singleStructInArray", []any{person}),
+		NewRequest("namedParameters", map[string]any{
 			"name": "Alex",
 			"age":  35,
 		}),

--- a/rpc/requestAirdrop.go
+++ b/rpc/requestAirdrop.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ func (cl *Client) RequestAirdrop(
 	lamports uint64,
 	commitment CommitmentType, // optional; used for retrieving blockhash and verifying airdrop success.
 ) (signature solana.Signature, err error) {
-	params := []interface{}{
+	params := []any{
 		account,
 		lamports,
 	}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -19,7 +19,7 @@ package rpc
 
 import (
 	stdjson "encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,11 +32,11 @@ type mockJSONRPCServer struct {
 	body []byte
 }
 
-func mockJSONRPC(t *testing.T, response interface{}) (mock *mockJSONRPCServer, close func()) {
+func mockJSONRPC(t *testing.T, response any) (mock *mockJSONRPCServer, close func()) {
 	mock = &mockJSONRPCServer{
 		Server: httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			var err error
-			mock.body, err = ioutil.ReadAll(req.Body)
+			mock.body, err = io.ReadAll(req.Body)
 			require.NoError(t, err)
 
 			var responseBody []byte
@@ -58,7 +58,7 @@ func (s *mockJSONRPCServer) RequestBodyAsJSON(t *testing.T) (out string) {
 	return string(s.body)
 }
 
-func (s *mockJSONRPCServer) RequestBody(t *testing.T) (out map[string]interface{}) {
+func (s *mockJSONRPCServer) RequestBody(t *testing.T) (out map[string]any) {
 	err := json.Unmarshal(s.body, &out)
 	require.NoError(t, err)
 

--- a/rpc/sendEncodedTransaction.go
+++ b/rpc/sendEncodedTransaction.go
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,7 +47,7 @@ func (cl *Client) SendEncodedTransactionWithOpts(
 	opts TransactionOpts,
 ) (signature solana.Signature, err error) {
 	obj := opts.ToMap()
-	params := []interface{}{
+	params := []any{
 		encodedTx,
 		obj,
 	}

--- a/rpc/simulateTransaction.go
+++ b/rpc/simulateTransaction.go
@@ -31,7 +31,7 @@ type SimulateTransactionResponse struct {
 
 type SimulateTransactionResult struct {
 	// Error if transaction failed, null if transaction succeeded.
-	Err interface{} `json:"err,omitempty"`
+	Err any `json:"err,omitempty"`
 
 	// Array of log messages the transaction instructions output during execution,
 	// null if simulation failed before the transaction was able to execute
@@ -127,7 +127,7 @@ func (cl *Client) SimulateRawTransactionWithOpts(
 	}
 
 	b64Data := base64.StdEncoding.EncodeToString(txData)
-	params := []interface{}{
+	params := []any{
 		b64Data,
 		obj,
 	}

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -161,7 +161,7 @@ type LoadedAddresses struct {
 type TransactionMeta struct {
 	// Error if transaction failed, null if transaction succeeded.
 	// https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24
-	Err interface{} `json:"err"`
+	Err any `json:"err"`
 
 	// Fee this transaction was charged
 	Fee uint64 `json:"fee"`
@@ -237,7 +237,7 @@ type DeprecatedTransactionMetaStatus M
 
 type TransactionSignature struct {
 	// Error if transaction failed, nil if transaction succeeded.
-	Err interface{} `json:"err"`
+	Err any `json:"err"`
 
 	// Memo associated with the transaction, nil if no memo is present.
 	Memo *string `json:"memo"`
@@ -446,7 +446,7 @@ type ParsedTransaction struct {
 type ParsedTransactionMeta struct {
 	// Error if transaction failed, null if transaction succeeded.
 	// https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24
-	Err interface{} `json:"err"`
+	Err any `json:"err"`
 
 	// Fee this transaction was charged
 	Fee uint64 `json:"fee"`
@@ -506,8 +506,8 @@ type InstructionInfoEnvelope struct {
 }
 
 type InstructionInfo struct {
-	Info            map[string]interface{} `json:"info"`
-	InstructionType string                 `json:"type"`
+	Info            map[string]any `json:"info"`
+	InstructionType string         `json:"type"`
 }
 
 type TransactionOpts struct {
@@ -545,4 +545,4 @@ func (opts *TransactionOpts) ToMap() M {
 	return obj
 }
 
-type M map[string]interface{}
+type M map[string]any

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -39,7 +39,7 @@ func TestData_base64_zstd(t *testing.T) {
 		data.asDecodedBinary.Encoding,
 	)
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			val,
 			"base64+zstd",
 		},
@@ -63,7 +63,7 @@ func TestData_base64_zstd_empty(t *testing.T) {
 		data.asDecodedBinary.Encoding,
 	)
 	assert.Equal(t,
-		[]interface{}{
+		[]any{
 			"",
 			"base64+zstd",
 		},
@@ -83,7 +83,7 @@ func TestData_jsonParsed(t *testing.T) {
 		data.GetRawJSON(),
 	)
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"hello": "world",
 		},
 		mustJSONToInterface(mustAnyToJSON(data)),
@@ -102,7 +102,7 @@ func TestData_jsonParsed_empty(t *testing.T) {
 		data.GetRawJSON(),
 	)
 	assert.Equal(t,
-		map[string]interface{}{},
+		map[string]any{},
 		mustJSONToInterface(mustAnyToJSON(data)),
 	)
 }

--- a/rpc/ws/accountSubscribe.go
+++ b/rpc/ws/accountSubscribe.go
@@ -49,8 +49,8 @@ func (cl *Client) AccountSubscribeWithOpts(
 	encoding solana.EncodingType,
 ) (*AccountSubscription, error) {
 
-	params := []interface{}{account.String()}
-	conf := map[string]interface{}{
+	params := []any{account.String()}
+	conf := map[string]any{
 		"encoding": "base64",
 	}
 	if commitment != "" {
@@ -65,7 +65,7 @@ func (cl *Client) AccountSubscribeWithOpts(
 		conf,
 		"accountSubscribe",
 		"accountUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res AccountResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/blockSubscribe.go
+++ b/rpc/ws/blockSubscribe.go
@@ -28,7 +28,7 @@ type BlockResult struct {
 	} `json:"context"`
 	Value struct {
 		Slot  uint64              `json:"slot"`
-		Err   interface{}         `json:"err,omitempty"`
+		Err   any                 `json:"err,omitempty"`
 		Block *rpc.GetBlockResult `json:"block,omitempty"`
 	} `json:"value"`
 }
@@ -85,7 +85,7 @@ func (cl *Client) BlockSubscribe(
 	filter BlockSubscribeFilter,
 	opts *BlockSubscribeOpts,
 ) (*BlockSubscription, error) {
-	var params []interface{}
+	var params []any
 	if filter != nil {
 		switch v := filter.(type) {
 		case BlockSubscribeFilterAll:
@@ -131,7 +131,7 @@ func (cl *Client) BlockSubscribe(
 		nil,
 		"blockSubscribe",
 		"blockUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res BlockResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/client.go
+++ b/rpc/ws/client.go
@@ -35,7 +35,7 @@ import (
 
 var ErrSubscriptionClosed = errors.New("subscription closed")
 
-type result interface{}
+type result any
 
 type Client struct {
 	rpcURL                  string
@@ -296,7 +296,7 @@ func (c *Client) closeSubscription(reqID uint64, err error) {
 }
 
 func (c *Client) unsubscribe(subID uint64, method string) error {
-	req := newRequest([]interface{}{subID}, method, nil, c.shortID)
+	req := newRequest([]any{subID}, method, nil, c.shortID)
 	data, err := req.encode()
 	if err != nil {
 		return fmt.Errorf("unable to encode unsubscription message for subID %d and method %s", subID, method)
@@ -311,8 +311,8 @@ func (c *Client) unsubscribe(subID uint64, method string) error {
 }
 
 func (c *Client) subscribe(
-	params []interface{},
-	conf map[string]interface{},
+	params []any,
+	conf map[string]any,
 	subscriptionMethod string,
 	unsubscribeMethod string,
 	decoderFunc decoderFunc,
@@ -349,7 +349,7 @@ func (c *Client) subscribe(
 	return sub, nil
 }
 
-func decodeResponseFromReader(r io.Reader, reply interface{}) (err error) {
+func decodeResponseFromReader(r io.Reader, reply any) (err error) {
 	var c *response
 	if err := json.NewDecoder(r).Decode(&c); err != nil {
 		return err
@@ -373,7 +373,7 @@ func decodeResponseFromReader(r io.Reader, reply interface{}) (err error) {
 	return json.Unmarshal(*c.Params.Result, &reply)
 }
 
-func decodeResponseFromMessage(r []byte, reply interface{}) (err error) {
+func decodeResponseFromMessage(r []byte, reply any) (err error) {
 	var c *response
 	if err := json.Unmarshal(r, &c); err != nil {
 		return err

--- a/rpc/ws/logsSubscribe.go
+++ b/rpc/ws/logsSubscribe.go
@@ -29,7 +29,7 @@ type LogResult struct {
 		// The transaction signature.
 		Signature solana.Signature `json:"signature"`
 		// Error if transaction failed, null if transaction succeeded.
-		Err interface{} `json:"err"`
+		Err any `json:"err"`
 		// Array of log messages the transaction instructions output
 		// during execution, null if simulation failed before the transaction
 		// was able to execute (for example due to an invalid blockhash
@@ -76,12 +76,12 @@ func (cl *Client) LogsSubscribeMentions(
 
 // LogsSubscribe subscribes to transaction logging.
 func (cl *Client) logsSubscribe(
-	filter interface{},
+	filter any,
 	commitment rpc.CommitmentType,
 ) (*LogSubscription, error) {
 
-	params := []interface{}{filter}
-	conf := map[string]interface{}{}
+	params := []any{filter}
+	conf := map[string]any{}
 	if commitment != "" {
 		conf["commitment"] = commitment
 	}
@@ -91,7 +91,7 @@ func (cl *Client) logsSubscribe(
 		conf,
 		"logsSubscribe",
 		"logsUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res LogResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/parsedBlockSubscribe.go
+++ b/rpc/ws/parsedBlockSubscribe.go
@@ -27,7 +27,7 @@ type ParsedBlockResult struct {
 	} `json:"context"`
 	Value struct {
 		Slot  uint64                    `json:"slot"`
-		Err   interface{}               `json:"err,omitempty"`
+		Err   any                       `json:"err,omitempty"`
 		Block *rpc.GetParsedBlockResult `json:"block,omitempty"`
 	} `json:"value"`
 }
@@ -43,7 +43,7 @@ func (cl *Client) ParsedBlockSubscribe(
 	filter BlockSubscribeFilter,
 	opts *BlockSubscribeOpts,
 ) (*ParsedBlockSubscription, error) {
-	var params []interface{}
+	var params []any
 	if filter != nil {
 		switch v := filter.(type) {
 		case BlockSubscribeFilterAll:
@@ -76,7 +76,7 @@ func (cl *Client) ParsedBlockSubscribe(
 		nil,
 		"blockSubscribe",
 		"blockUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res ParsedBlockResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/programSubscribe.go
+++ b/rpc/ws/programSubscribe.go
@@ -51,8 +51,8 @@ func (cl *Client) ProgramSubscribeWithOpts(
 	filters []rpc.RPCFilter,
 ) (*ProgramSubscription, error) {
 
-	params := []interface{}{programID.String()}
-	conf := map[string]interface{}{
+	params := []any{programID.String()}
+	conf := map[string]any{
 		"encoding": "base64",
 	}
 	if commitment != "" {
@@ -70,7 +70,7 @@ func (cl *Client) ProgramSubscribeWithOpts(
 		conf,
 		"programSubscribe",
 		"programUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res ProgramResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/rootSubscribe.go
+++ b/rpc/ws/rootSubscribe.go
@@ -26,7 +26,7 @@ func (cl *Client) RootSubscribe() (*RootSubscription, error) {
 		nil,
 		"rootSubscribe",
 		"rootUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res RootResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/signatureSubscribe.go
+++ b/rpc/ws/signatureSubscribe.go
@@ -28,7 +28,7 @@ type SignatureResult struct {
 		Slot uint64
 	} `json:"context"`
 	Value struct {
-		Err interface{} `json:"err"`
+		Err any `json:"err"`
 	} `json:"value"`
 }
 
@@ -39,8 +39,8 @@ func (cl *Client) SignatureSubscribe(
 	signature solana.Signature, // Transaction Signature.
 	commitment rpc.CommitmentType, // (optional)
 ) (*SignatureSubscription, error) {
-	params := []interface{}{signature.String()}
-	conf := map[string]interface{}{}
+	params := []any{signature.String()}
+	conf := map[string]any{}
 	if commitment != "" {
 		conf["commitment"] = commitment
 	}
@@ -50,7 +50,7 @@ func (cl *Client) SignatureSubscribe(
 		conf,
 		"signatureSubscribe",
 		"signatureUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res SignatureResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/slotSubscribe.go
+++ b/rpc/ws/slotSubscribe.go
@@ -29,7 +29,7 @@ func (cl *Client) SlotSubscribe() (*SlotSubscription, error) {
 		nil,
 		"slotSubscribe",
 		"slotUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res SlotResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/slotsUpdatesSubscribe.go
+++ b/rpc/ws/slotsUpdatesSubscribe.go
@@ -63,7 +63,7 @@ func (cl *Client) SlotsUpdatesSubscribe() (*SlotsUpdatesSubscription, error) {
 		nil,
 		"slotsUpdatesSubscribe",
 		"slotsUpdatesUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res SlotsUpdatesResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/rpc/ws/subscription.go
+++ b/rpc/ws/subscription.go
@@ -34,7 +34,7 @@ type Subscription struct {
 	decoderFunc       decoderFunc
 }
 
-type decoderFunc func([]byte) (interface{}, error)
+type decoderFunc func([]byte) (any, error)
 
 func newSubscription(
 	req *request,
@@ -53,7 +53,7 @@ func newSubscription(
 	}
 }
 
-func (s *Subscription) Recv(ctx context.Context) (interface{}, error) {
+func (s *Subscription) Recv(ctx context.Context) (any, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/rpc/ws/types.go
+++ b/rpc/ws/types.go
@@ -26,13 +26,13 @@ import (
 )
 
 type request struct {
-	Version string      `json:"jsonrpc"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params,omitempty"`
-	ID      uint64      `json:"id"`
+	Version string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+	ID      uint64 `json:"id"`
 }
 
-func newRequest(params []interface{}, method string, configuration map[string]interface{}, shortID bool) *request {
+func newRequest(params []any, method string, configuration map[string]any, shortID bool) *request {
 	if params != nil && configuration != nil {
 		params = append(params, configuration)
 	}

--- a/rpc/ws/voteSubscribe.go
+++ b/rpc/ws/voteSubscribe.go
@@ -43,7 +43,7 @@ func (cl *Client) VoteSubscribe() (*VoteSubscription, error) {
 		nil,
 		"voteSubscribe",
 		"voteUnsubscribe",
-		func(msg []byte) (interface{}, error) {
+		func(msg []byte) (any, error) {
 			var res VoteResult
 			err := decodeResponseFromMessage(msg, &res)
 			return &res, err

--- a/text/encoder.go
+++ b/text/encoder.go
@@ -54,7 +54,7 @@ func isNil(rv reflect.Value) (b bool) {
 	return rv.IsNil()
 }
 
-func (e *Encoder) Encode(v interface{}, option *Option) (err error) {
+func (e *Encoder) Encode(v any, option *Option) (err error) {
 	if option == nil {
 		option = &Option{}
 	}

--- a/text/format/format.go
+++ b/text/format/format.go
@@ -31,7 +31,7 @@ func Instruction(name string) string {
 	return Purple(Bold("Instruction")) + ": " + Bold(name)
 }
 
-func Param(name string, value interface{}) string {
+func Param(name string, value any) string {
 	return Sf(
 		Shakespeare(name)+": %s",
 		strings.TrimSpace(

--- a/text/tools.go
+++ b/text/tools.go
@@ -25,25 +25,25 @@ import (
 
 var DisableColors = false
 
-func S(a ...interface{}) string {
+func S(a ...any) string {
 	return fmt.Sprint(a...)
 }
 
-func Sf(format string, a ...interface{}) string {
+func Sf(format string, a ...any) string {
 	return fmt.Sprintf(format, a...)
 }
 
-func Ln(a ...interface{}) string {
+func Ln(a ...any) string {
 	return fmt.Sprintln(a...)
 }
 
 // Lnsf is alias of fmt.Sprintln(fmt.Sprintf())
-func Lnsf(format string, a ...interface{}) string {
+func Lnsf(format string, a ...any) string {
 	return Ln(Sf(format, a...))
 }
 
 // LnsfI is alias of fmt.Sprintln(fmt.Sprintf())
-func LnsfI(indent int, format string, a ...interface{}) string {
+func LnsfI(indent int, format string, a ...any) string {
 	return Ln(Sf(strings.Repeat("	", indent)+format, a...))
 }
 
@@ -276,7 +276,7 @@ var hasherPool *sync.Pool
 
 func init() {
 	hasherPool = &sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return fnv.New64a()
 		},
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
@@ -263,8 +263,8 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	for k := range options.addressTables {
 		sortedTableKeys = append(sortedTableKeys, k)
 	}
-	sort.Slice(sortedTableKeys, func(i, j int) bool {
-		return bytes.Compare(sortedTableKeys[i][:], sortedTableKeys[j][:]) < 0
+	slices.SortFunc(sortedTableKeys, func(a, b PublicKey) int {
+		return bytes.Compare(a[:], b[:])
 	})
 	for _, addressTablePubKey := range sortedTableKeys {
 		addressTable := options.addressTables[addressTablePubKey]
@@ -306,8 +306,14 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	}
 
 	// Sort. Prioritizing first by signer, then by writable
-	sort.SliceStable(accounts, func(i, j int) bool {
-		return accounts[i].less(accounts[j])
+	slices.SortStableFunc(accounts, func(a, b *AccountMeta) int {
+		if a.less(b) {
+			return -1
+		}
+		if b.less(a) {
+			return 1
+		}
+		return 0
 	})
 
 	uniqAccountsMap := map[PublicKey]uint64{}
@@ -424,8 +430,8 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		for k := range lookupsMap {
 			sortedLookupKeys = append(sortedLookupKeys, k)
 		}
-		sort.Slice(sortedLookupKeys, func(i, j int) bool {
-			return bytes.Compare(sortedLookupKeys[i][:], sortedLookupKeys[j][:]) < 0
+		slices.SortFunc(sortedLookupKeys, func(a, b PublicKey) int {
+			return bytes.Compare(a[:], b[:])
 		})
 		for _, tablePubKey := range sortedLookupKeys {
 			l := lookupsMap[tablePubKey]

--- a/zap-box/encoder.go
+++ b/zap-box/encoder.go
@@ -44,7 +44,7 @@ const (
 var bufferpool = buffer.NewPool()
 var levelToColor map[zapcore.Level]Color
 
-var _loggerPool = sync.Pool{New: func() interface{} {
+var _loggerPool = sync.Pool{New: func() any {
 	return &Encoder{}
 }}
 
@@ -231,7 +231,7 @@ func addFields(enc zapcore.ObjectEncoder, fields []zapcore.Field) {
 // For JSON-escaping; see jsonEncoder.safeAddString below.
 const _hex = "0123456789abcdef"
 
-var _jsonPool = sync.Pool{New: func() interface{} {
+var _jsonPool = sync.Pool{New: func() any {
 	return &jsonEncoder{}
 }}
 
@@ -331,7 +331,7 @@ var nullLiteralBytes = []byte("null")
 
 // Only invoke the standard JSON encoder if there is actually something to
 // encode; otherwise write JSON null literal directly.
-func (enc *jsonEncoder) encodeReflected(obj interface{}) ([]byte, error) {
+func (enc *jsonEncoder) encodeReflected(obj any) ([]byte, error) {
 	if obj == nil {
 		return nullLiteralBytes, nil
 	}
@@ -343,7 +343,7 @@ func (enc *jsonEncoder) encodeReflected(obj interface{}) ([]byte, error) {
 	return enc.reflectBuf.Bytes(), nil
 }
 
-func (enc *jsonEncoder) AddReflected(key string, obj interface{}) error {
+func (enc *jsonEncoder) AddReflected(key string, obj any) error {
 	valueBytes, err := enc.encodeReflected(obj)
 	if err != nil {
 		return err
@@ -431,7 +431,7 @@ func (enc *jsonEncoder) AppendInt64(val int64) {
 	enc.buf.AppendInt(val)
 }
 
-func (enc *jsonEncoder) AppendReflected(val interface{}) error {
+func (enc *jsonEncoder) AppendReflected(val any) error {
 	valueBytes, err := enc.encodeReflected(val)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Problem

the codebase targets Go 1.24 but uses patterns deprecated or superseded in Go 1.16–1.22

### Summary of Changes

no behavioral changes - every replacement is a drop-in alias or API-compatible successor.

- `ioutil.ReadAll -> io.ReadAll`
- `sort.Slice -> slices.SortFunc`
- `sort.SliceStable -> slices.SortStableFunc`
- `interface{} -> any`