### PR TITLE
fix: sol/wsol addresses mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2148,7 +2148,7 @@ func main() {
     context.TODO(),
     pubKey,
     &rpc.GetTokenAccountsConfig{
-      Mint: solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+      Mint: solana.WrappedSol,
     },
     nil,
   )

--- a/program_ids.go
+++ b/program_ids.go
@@ -74,9 +74,8 @@ var (
 )
 
 var (
-	// The Mint for native SOL Token accounts
-	SolMint    = MustPublicKeyFromBase58("So11111111111111111111111111111111111111112")
-	WrappedSol = SolMint
+	SolMint    = MustPublicKeyFromBase58("So11111111111111111111111111111111111111111")
+	WrappedSol = MustPublicKeyFromBase58("So11111111111111111111111111111111111111112")
 )
 
 var TokenMetadataProgramID = MustPublicKeyFromBase58("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s")

--- a/programs/token/accounts_test.go
+++ b/programs/token/accounts_test.go
@@ -74,7 +74,7 @@ func TestAccount(t *testing.T) {
 		balance := uint64(2039280)
 		require.Equal(t,
 			&Account{
-				Mint:            solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+				Mint:            solana.WrappedSol,
 				Owner:           solana.MustPublicKeyFromBase58("7HZaCWazgTuuFuajxaaxGYbGnyVKwxvsJKue1W4Nvyro"),
 				Amount:          (uint64)(28320298),
 				Delegate:        (*solana.PublicKey)(nil),

--- a/rpc/examples/getTokenAccountsByDelegate/getTokenAccountsByDelegate.go
+++ b/rpc/examples/getTokenAccountsByDelegate/getTokenAccountsByDelegate.go
@@ -31,7 +31,7 @@ func main() {
 		context.TODO(),
 		pubKey,
 		&rpc.GetTokenAccountsConfig{
-			Mint: solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112").ToPointer(),
+			Mint: solana.WrappedSol.ToPointer(),
 		},
 		nil,
 	)


### PR DESCRIPTION
### Problem

[SOL](https://solscan.io/token/So11111111111111111111111111111111111111111) and  [WSOL](https://solscan.io/token/So11111111111111111111111111111111111111112) have address of `So11111111111111111111111111111111111111112` which mislead consumers of SDK

### Summary of Changes

- use correct addresses
- reduce code duplications