### PR TITLE
fix: ws race and leak fixes

### DIFF
--- a/rpc/sendAndConfirmTransaction/sendAndConfirmTransaction.go
+++ b/rpc/sendAndConfirmTransaction/sendAndConfirmTransaction.go
@@ -120,25 +120,18 @@ func WaitForConfirmation(
 		timeout = &t
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return false, ctx.Err()
-		case <-time.After(*timeout):
+	timeoutCtx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+
+	got, err := sub.Recv(timeoutCtx)
+	if err != nil {
+		if timeoutCtx.Err() == context.DeadlineExceeded {
 			return false, ErrTimeout
-		case resp, ok := <-sub.Response():
-			if !ok {
-				return false, fmt.Errorf("subscription closed")
-			}
-			if resp.Value.Err != nil {
-				// The transaction was confirmed, but it failed while executing (one of the instructions failed).
-				return true, fmt.Errorf("confirmed transaction with execution error: %v", resp.Value.Err)
-			} else {
-				// Success! Confirmed! And there was no error while executing the transaction.
-				return true, nil
-			}
-		case err := <-sub.Err():
-			return false, err
 		}
+		return false, err
 	}
+	if got.Value.Err != nil {
+		return true, fmt.Errorf("confirmed transaction with execution error: %v", got.Value.Err)
+	}
+	return true, nil
 }

--- a/rpc/ws/accountSubscribe.go
+++ b/rpc/ws/accountSubscribe.go
@@ -101,19 +101,6 @@ func (sw *AccountSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *AccountSubscription) Response() <-chan *AccountResult {
-	typedChan := make(chan *AccountResult, 1)
-	go func(ch chan *AccountResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*AccountResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *AccountSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/blockSubscribe.go
+++ b/rpc/ws/blockSubscribe.go
@@ -167,19 +167,6 @@ func (sw *BlockSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *BlockSubscription) Response() <-chan *BlockResult {
-	typedChan := make(chan *BlockResult, 1)
-	go func(ch chan *BlockResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*BlockResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *BlockSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/client.go
+++ b/rpc/ws/client.go
@@ -42,10 +42,10 @@ type Client struct {
 	conn                    *websocket.Conn
 	connCtx                 context.Context
 	connCtxCancel           context.CancelFunc
+	wg                      sync.WaitGroup
 	lock                    sync.RWMutex
 	subscriptionByRequestID map[uint64]*Subscription
 	subscriptionByWSSubID   map[uint64]*Subscription
-	reconnectOnErr          bool
 	shortID                 bool
 }
 
@@ -105,10 +105,13 @@ func ConnectWithOptions(ctx context.Context, rpcEndpoint string, opt *Options) (
 	}
 
 	c.connCtx, c.connCtxCancel = context.WithCancel(context.Background())
+	c.wg.Add(2)
 	go func() {
+		defer c.wg.Done()
 		c.conn.SetReadDeadline(time.Now().Add(pongWait))
 		c.conn.SetPongHandler(func(string) error { c.conn.SetReadDeadline(time.Now().Add(pongWait)); return nil })
 		ticker := time.NewTicker(pingPeriod)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-c.connCtx.Done():
@@ -132,14 +135,20 @@ func (c *Client) sendPing() {
 	}
 }
 
+// Close cancels the connection context, closes the underlying websocket
+// connection, and waits for background goroutines to finish.
 func (c *Client) Close() {
 	c.lock.Lock()
-	defer c.lock.Unlock()
 	c.connCtxCancel()
 	c.conn.Close()
+	c.lock.Unlock()
+	c.wg.Wait()
 }
 
 func (c *Client) receiveMessages() {
+	defer c.wg.Done()
+	defer c.closeAllSubscription(ErrSubscriptionClosed)
+
 	for {
 		select {
 		case <-c.connCtx.Done():
@@ -147,7 +156,6 @@ func (c *Client) receiveMessages() {
 		default:
 			_, message, err := c.conn.ReadMessage()
 			if err != nil {
-				c.closeAllSubscription(err)
 				return
 			}
 			c.handleMessage(message)
@@ -218,7 +226,6 @@ func (c *Client) handleNewSubscriptionMessage(requestID, subID uint64) {
 		zap.Uint64("request_id", requestID),
 		zap.Int("subscription_count", len(c.subscriptionByWSSubID)),
 	)
-	return
 }
 
 func (c *Client) handleSubscriptionMessage(subID uint64, message []byte) {
@@ -239,7 +246,6 @@ func (c *Client) handleSubscriptionMessage(subID uint64, message []byte) {
 	// Decode the message using the subscription-provided decoderFunc.
 	result, err := sub.decoderFunc(message)
 	if err != nil {
-		fmt.Println("*****************************")
 		c.closeSubscription(sub.req.ID, fmt.Errorf("unable to decode client response: %w", err))
 		return
 	}
@@ -247,18 +253,18 @@ func (c *Client) handleSubscriptionMessage(subID uint64, message []byte) {
 	// this cannot be blocking or else
 	// we  will no read any other message
 	if len(sub.stream) >= cap(sub.stream) {
-		zlog.Warn("closing ws client subscription... not consuming fast en ought",
+		zlog.Warn("closing ws client subscription... not consuming fast enough",
 			zap.Uint64("request_id", sub.req.ID),
 		)
 		c.closeSubscription(sub.req.ID, fmt.Errorf("reached channel max capacity %d", len(sub.stream)))
 		return
 	}
 
-	sub.mutex.Lock()
-	defer sub.mutex.Unlock()
+	sub.mu.Lock()
 	if !sub.closed {
 		sub.stream <- result
 	}
+	sub.mu.Unlock()
 }
 
 func (c *Client) closeAllSubscription(err error) {
@@ -266,7 +272,17 @@ func (c *Client) closeAllSubscription(err error) {
 	defer c.lock.Unlock()
 
 	for _, sub := range c.subscriptionByRequestID {
-		sub.err <- err
+		sub.mu.Lock()
+		if !sub.closed {
+			select {
+			case sub.err <- err:
+			default:
+			}
+			sub.closed = true
+			close(sub.stream)
+			close(sub.err)
+		}
+		sub.mu.Unlock()
 	}
 
 	c.subscriptionByRequestID = map[uint64]*Subscription{}
@@ -282,12 +298,21 @@ func (c *Client) closeSubscription(reqID uint64, err error) {
 		return
 	}
 
-	sub.err <- err
+	sub.mu.Lock()
+	if !sub.closed {
+		select {
+		case sub.err <- err:
+		default:
+		}
+		sub.closed = true
+		close(sub.stream)
+		close(sub.err)
+	}
+	sub.mu.Unlock()
 
-	err = c.unsubscribe(sub.subID, sub.unsubscribeMethod)
-	if err != nil {
+	if e := c.unsubscribe(sub.subID, sub.unsubscribeMethod); e != nil {
 		zlog.Warn("unable to send rpc unsubscribe call",
-			zap.Error(err),
+			zap.Error(e),
 		)
 	}
 

--- a/rpc/ws/fixes_test.go
+++ b/rpc/ws/fixes_test.go
@@ -1,0 +1,482 @@
+package ws
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWSServer creates a test WebSocket server that can be controlled from tests.
+type mockWSServer struct {
+	server    *httptest.Server
+	connMu    sync.Mutex
+	conn      *websocket.Conn
+	incoming  chan []byte
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func newMockWSServer(t *testing.T) *mockWSServer {
+	t.Helper()
+	m := &mockWSServer{
+		incoming: make(chan []byte, 100),
+		closed:   make(chan struct{}),
+	}
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade error: %v", err)
+			return
+		}
+		m.connMu.Lock()
+		m.conn = conn
+		m.connMu.Unlock()
+
+		defer conn.Close()
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				m.closeOnce.Do(func() { close(m.closed) })
+				return
+			}
+			m.incoming <- msg
+		}
+	}))
+	return m
+}
+
+func (m *mockWSServer) wsURL() string {
+	return "ws" + strings.TrimPrefix(m.server.URL, "http")
+}
+
+// trySend sends a message to the connected client. Returns false if the
+// connection is nil or the write fails — safe to call from non-test goroutines.
+func (m *mockWSServer) trySend(msg string) bool {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.conn == nil {
+		return false
+	}
+	return m.conn.WriteMessage(websocket.TextMessage, []byte(msg)) == nil
+}
+
+// send sends a message and fails the test on error. Only call from the test
+// goroutine (not from spawned goroutines).
+func (m *mockWSServer) send(t *testing.T, msg string) {
+	t.Helper()
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	require.NotNil(t, m.conn, "no client connected")
+	err := m.conn.WriteMessage(websocket.TextMessage, []byte(msg))
+	require.NoError(t, err)
+}
+
+func (m *mockWSServer) closeConn() {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.conn != nil {
+		m.conn.Close()
+	}
+}
+
+func (m *mockWSServer) stop() {
+	m.closeConn()
+	m.server.Close()
+}
+
+// waitForSubscriptionAndRespond reads the subscribe request from the mock server's
+// incoming channel and sends back a subscription confirmation with the given subID.
+func (m *mockWSServer) waitForSubscriptionAndRespond(t *testing.T, subID uint64) {
+	t.Helper()
+	select {
+	case msg := <-m.incoming:
+		reqID, ok := getUint64WithOk(msg, "id")
+		require.True(t, ok, "could not parse request ID from: %s", string(msg))
+		resp := fmt.Sprintf(`{"jsonrpc":"2.0","result":%d,"id":%d}`, subID, reqID)
+		m.send(t, resp)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for subscription request")
+	}
+}
+
+// connectClient creates a ws.Client connected to the mock server.
+func connectClient(t *testing.T, m *mockWSServer) *Client {
+	t.Helper()
+	c, err := Connect(context.Background(), m.wsURL())
+	require.NoError(t, err)
+	return c
+}
+
+// subscribeWithMock creates a subscription on the client, and confirms it on
+// the mock server side, returning the Subscription.
+func subscribeWithMock(t *testing.T, c *Client, m *mockWSServer, wsSubID uint64) *Subscription {
+	t.Helper()
+
+	type subResult struct {
+		sub *Subscription
+		err error
+	}
+	ch := make(chan subResult, 1)
+
+	go func() {
+		sub, err := c.subscribe(
+			[]any{"test"},
+			nil,
+			"testSubscribe",
+			"testUnsubscribe",
+			func(msg []byte) (any, error) {
+				var res SlotResult
+				err := decodeResponseFromMessage(msg, &res)
+				return &res, err
+			},
+		)
+		ch <- subResult{sub, err}
+	}()
+
+	m.waitForSubscriptionAndRespond(t, wsSubID)
+
+	r := <-ch
+	require.NoError(t, r.err)
+	return r.sub
+}
+
+// sendSubscriptionMessage sends a slot notification for the given wsSubID.
+// Only call from the test goroutine.
+func sendSubscriptionMessage(t *testing.T, m *mockWSServer, wsSubID uint64, slot, parent, root uint64) {
+	t.Helper()
+	msg := fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"testNotification","params":{"subscription":%d,"result":{"parent":%d,"root":%d,"slot":%d}}}`,
+		wsSubID, parent, root, slot,
+	)
+	m.send(t, msg)
+}
+
+// trySendSubscriptionMessage is safe to call from non-test goroutines.
+func trySendSubscriptionMessage(m *mockWSServer, wsSubID uint64, slot uint64) {
+	msg := fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"testNotification","params":{"subscription":%d,"result":{"parent":0,"root":0,"slot":%d}}}`,
+		wsSubID, slot,
+	)
+	m.trySend(msg)
+}
+
+// --- Tests ---
+
+func TestClose_WaitsForGoroutines(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+
+	done := make(chan struct{})
+	go func() {
+		c.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close() did not return in time — goroutines likely leaked")
+	}
+}
+
+func TestCloseAllSubscription_ClosesChannelsOnConnectionDrop(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	// Drop the server-side connection to trigger receiveMessages exit.
+	m.closeConn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := sub.Recv(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSubscriptionClosed)
+}
+
+func TestRecv_ReturnsClosedAfterUnsubscribe(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	sub.Unsubscribe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := sub.Recv(ctx)
+	require.Error(t, err)
+}
+
+func TestRecv_DeliversMessages(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	sendSubscriptionMessage(t, m, 42, 100, 99, 98)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got, err := sub.Recv(ctx)
+	require.NoError(t, err)
+	slotResult, ok := got.(*SlotResult)
+	require.True(t, ok)
+	assert.Equal(t, uint64(100), slotResult.Slot)
+	assert.Equal(t, uint64(99), slotResult.Parent)
+	assert.Equal(t, uint64(98), slotResult.Root)
+}
+
+func TestRecv_ContextCancellation(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := sub.Recv(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	sub.Unsubscribe()
+}
+
+func TestConcurrentUnsubscribeDuringMessageDelivery_NoPanic(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	var wg sync.WaitGroup
+
+	// Sender goroutine: sends messages as fast as possible.
+	// Uses trySend to avoid calling t.Fatal from a non-test goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range 50 {
+			trySendSubscriptionMessage(m, 42, uint64(i))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// Give some messages time to arrive before unsubscribing.
+	time.Sleep(10 * time.Millisecond)
+
+	// Unsubscribe from another goroutine — this used to panic with
+	// "send on closed channel" before the mutex fix.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sub.Unsubscribe()
+	}()
+
+	wg.Wait()
+}
+
+func TestDoubleUnsubscribe_NoPanic(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	sub.Unsubscribe()
+	sub.Unsubscribe()
+}
+
+func TestCloseSubscription_Idempotent(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+	reqID := sub.req.ID
+
+	c.closeSubscription(reqID, fmt.Errorf("test error"))
+	c.closeSubscription(reqID, fmt.Errorf("test error again"))
+}
+
+func TestStreamCapacityOverflow_ClosesSubscription(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub := subscribeWithMock(t, c, m, 42)
+
+	// Fill the stream channel to capacity.
+	for range cap(sub.stream) {
+		sub.stream <- &SlotResult{Slot: 0}
+	}
+
+	// Next message delivery should trigger a close due to capacity overflow.
+	sendSubscriptionMessage(t, m, 42, 999, 0, 0)
+
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		return sub.closed
+	}, 2*time.Second, 10*time.Millisecond, "subscription should be closed after capacity overflow")
+}
+
+func TestMultipleSubscriptions_IndependentLifecycles(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub1 := subscribeWithMock(t, c, m, 10)
+	sub2 := subscribeWithMock(t, c, m, 20)
+
+	sendSubscriptionMessage(t, m, 20, 200, 0, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got, err := sub2.Recv(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(200), got.(*SlotResult).Slot)
+
+	// Unsubscribe sub1, sub2 should still work.
+	sub1.Unsubscribe()
+
+	sendSubscriptionMessage(t, m, 20, 300, 0, 0)
+	got, err = sub2.Recv(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(300), got.(*SlotResult).Slot)
+
+	sub2.Unsubscribe()
+}
+
+func TestConnectionDrop_AllSubscriptionsNotified(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+	defer c.Close()
+
+	sub1 := subscribeWithMock(t, c, m, 10)
+	sub2 := subscribeWithMock(t, c, m, 20)
+	sub3 := subscribeWithMock(t, c, m, 30)
+
+	m.closeConn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	for _, sub := range []*Subscription{sub1, sub2, sub3} {
+		_, err := sub.Recv(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSubscriptionClosed)
+	}
+}
+
+func TestConcurrentUnsubscribeAndConnectionDrop_NoPanic(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+
+	c := connectClient(t, m)
+
+	sub1 := subscribeWithMock(t, c, m, 10)
+	sub2 := subscribeWithMock(t, c, m, 20)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		sub1.Unsubscribe()
+	}()
+	go func() {
+		defer wg.Done()
+		m.closeConn()
+	}()
+	wg.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := sub2.Recv(ctx)
+	if err != nil {
+		assert.True(t, err == ErrSubscriptionClosed || err == context.DeadlineExceeded,
+			"unexpected error: %v", err)
+	}
+
+	c.Close()
+}
+
+func TestSubscription_RecvAfterChannelsClosed(t *testing.T) {
+	sub := newSubscription(
+		&request{ID: 1},
+		func(err error) {},
+		"testUnsubscribe",
+		func(msg []byte) (any, error) { return nil, nil },
+	)
+
+	// Manually close channels as closeAllSubscription would.
+	sub.mu.Lock()
+	sub.err <- ErrSubscriptionClosed
+	sub.closed = true
+	close(sub.stream)
+	close(sub.err)
+	sub.mu.Unlock()
+
+	ctx := context.Background()
+	_, err := sub.Recv(ctx)
+	assert.ErrorIs(t, err, ErrSubscriptionClosed)
+
+	// Subsequent Recv returns ErrSubscriptionClosed from closed channels.
+	_, err = sub.Recv(ctx)
+	assert.ErrorIs(t, err, ErrSubscriptionClosed)
+}
+
+func TestSubscription_BufferSizes(t *testing.T) {
+	sub := newSubscription(
+		&request{ID: 1},
+		func(err error) {},
+		"testUnsubscribe",
+		func(msg []byte) (any, error) { return nil, nil },
+	)
+
+	assert.Equal(t, 200, cap(sub.stream), "stream buffer should be 200")
+	assert.Equal(t, 1, cap(sub.err), "err buffer should be 1")
+}

--- a/rpc/ws/logsSubscribe.go
+++ b/rpc/ws/logsSubscribe.go
@@ -127,19 +127,6 @@ func (sw *LogSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *LogSubscription) Response() <-chan *LogResult {
-	typedChan := make(chan *LogResult, 1)
-	go func(ch chan *LogResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*LogResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *LogSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/parsedBlockSubscribe.go
+++ b/rpc/ws/parsedBlockSubscribe.go
@@ -98,7 +98,10 @@ func (sw *ParsedBlockSubscription) Recv(ctx context.Context) (*ParsedBlockResult
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case d := <-sw.sub.stream:
+	case d, ok := <-sw.sub.stream:
+		if !ok {
+			return nil, ErrSubscriptionClosed
+		}
 		return d.(*ParsedBlockResult), nil
 	case err := <-sw.sub.err:
 		return nil, err
@@ -107,19 +110,6 @@ func (sw *ParsedBlockSubscription) Recv(ctx context.Context) (*ParsedBlockResult
 
 func (sw *ParsedBlockSubscription) Err() <-chan error {
 	return sw.sub.err
-}
-
-func (sw *ParsedBlockSubscription) Response() <-chan *ParsedBlockResult {
-	typedChan := make(chan *ParsedBlockResult, 1)
-	go func(ch chan *ParsedBlockResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*ParsedBlockResult)
-	}(typedChan)
-	return typedChan
 }
 
 func (sw *ParsedBlockSubscription) Unsubscribe() {

--- a/rpc/ws/programSubscribe.go
+++ b/rpc/ws/programSubscribe.go
@@ -106,19 +106,6 @@ func (sw *ProgramSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *ProgramSubscription) Response() <-chan *ProgramResult {
-	typedChan := make(chan *ProgramResult, 1)
-	go func(ch chan *ProgramResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*ProgramResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *ProgramSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/rootSubscribe.go
+++ b/rpc/ws/rootSubscribe.go
@@ -62,19 +62,6 @@ func (sw *RootSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *RootSubscription) Response() <-chan *RootResult {
-	typedChan := make(chan *RootResult, 1)
-	go func(ch chan *RootResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*RootResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *RootSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/signatureSubscribe.go
+++ b/rpc/ws/signatureSubscribe.go
@@ -16,8 +16,6 @@ package ws
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -84,32 +82,6 @@ func (sw *SignatureSubscription) Recv(ctx context.Context) (*SignatureResult, er
 
 func (sw *SignatureSubscription) Err() <-chan error {
 	return sw.sub.err
-}
-
-func (sw *SignatureSubscription) Response() <-chan *SignatureResult {
-	typedChan := make(chan *SignatureResult, 1)
-	go func(ch chan *SignatureResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*SignatureResult)
-	}(typedChan)
-	return typedChan
-}
-
-var ErrTimeout = fmt.Errorf("timeout waiting for confirmation")
-
-func (sw *SignatureSubscription) RecvWithTimeout(timeout time.Duration) (*SignatureResult, error) {
-	select {
-	case <-time.After(timeout):
-		return nil, ErrTimeout
-	case d := <-sw.sub.stream:
-		return d.(*SignatureResult), nil
-	case err := <-sw.sub.err:
-		return nil, err
-	}
 }
 
 func (sw *SignatureSubscription) Unsubscribe() {

--- a/rpc/ws/slotSubscribe.go
+++ b/rpc/ws/slotSubscribe.go
@@ -65,19 +65,6 @@ func (sw *SlotSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *SlotSubscription) Response() <-chan *SlotResult {
-	typedChan := make(chan *SlotResult, 1)
-	go func(ch chan *SlotResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*SlotResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *SlotSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/slotsUpdatesSubscribe.go
+++ b/rpc/ws/slotsUpdatesSubscribe.go
@@ -99,19 +99,6 @@ func (sw *SlotsUpdatesSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *SlotsUpdatesSubscription) Response() <-chan *SlotsUpdatesResult {
-	typedChan := make(chan *SlotsUpdatesResult, 1)
-	go func(ch chan *SlotsUpdatesResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*SlotsUpdatesResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *SlotsUpdatesSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/subscription.go
+++ b/rpc/ws/subscription.go
@@ -28,7 +28,7 @@ type Subscription struct {
 	stream            chan result
 	err               chan error
 	closeFunc         func(err error)
-	mutex             sync.Mutex
+	mu                sync.Mutex
 	closed            bool
 	unsubscribeMethod string
 	decoderFunc       decoderFunc
@@ -45,8 +45,8 @@ func newSubscription(
 	return &Subscription{
 		req:               req,
 		subID:             0,
-		stream:            make(chan result, 200_000),
-		err:               make(chan error, 100_000),
+		stream:            make(chan result, 200),
+		err:               make(chan error, 1),
 		closeFunc:         closeFunc,
 		unsubscribeMethod: unsubscribeMethod,
 		decoderFunc:       decoderFunc,
@@ -57,22 +57,19 @@ func (s *Subscription) Recv(ctx context.Context) (any, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case d := <-s.stream:
+	case d, ok := <-s.stream:
+		if !ok {
+			return nil, ErrSubscriptionClosed
+		}
 		return d, nil
-	case err := <-s.err:
+	case err, ok := <-s.err:
+		if !ok {
+			return nil, ErrSubscriptionClosed
+		}
 		return nil, err
 	}
 }
 
 func (s *Subscription) Unsubscribe() {
-	s.unsubscribe(nil)
-}
-
-func (s *Subscription) unsubscribe(err error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.closeFunc(err)
-	s.closed = true
-	close(s.stream)
-	close(s.err)
+	s.closeFunc(ErrSubscriptionClosed)
 }

--- a/rpc/ws/voteSubscribe.go
+++ b/rpc/ws/voteSubscribe.go
@@ -79,19 +79,6 @@ func (sw *VoteSubscription) Err() <-chan error {
 	return sw.sub.err
 }
 
-func (sw *VoteSubscription) Response() <-chan *VoteResult {
-	typedChan := make(chan *VoteResult, 1)
-	go func(ch chan *VoteResult) {
-		// TODO: will this subscription yield more than one result?
-		d, ok := <-sw.sub.stream
-		if !ok {
-			return
-		}
-		ch <- d.(*VoteResult)
-	}(typedChan)
-	return typedChan
-}
-
 func (sw *VoteSubscription) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }


### PR DESCRIPTION
### Problem

ws client has a couple of concurency bugs:
- goroutine and chan leaks on conn drop
- no sync on the closed flag
- `Close()` returning before background goroutines finished
- `Response()` methods that leaked a goroutine per call. For example. `WaitForConfirmation` method leaks in the loop

### Summary of Changes
- added a per-subscription mutex to protect channel sends and closes
- removed the fundamentally broken Response() and RecvWithTimeout() methods from all subscription wrappers, replacing their only caller with Recv + context timeout
- added WaitGroup to Close so callers can rely on cleanup being complete
- reduced channel buffers from 200K/100K to 200/1, which made error sends non-blocking to prevent deadlocks
- extended unit tests to cover all the cases above with `-race` flag

closes https://github.com/solana-foundation/solana-go/issues/327
closes https://github.com/solana-foundation/solana-go/issues/334
closes https://github.com/solana-foundation/solana-go/issues/270

