### PR TITLE
fix: allign rpc client with agave

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -471,6 +471,112 @@ func TestClient_GetBlockWithOpts(t *testing.T) {
 	// - test also when requesting only signatures
 }
 
+func TestClient_GetBlockWithOpts_AccountsMode(t *testing.T) {
+	responseBody := `{"blockHeight":69213636,"blockTime":1625227950,"blockhash":"5M77sHdwzH6rckuQwF8HL1w52n7hjrh4GVTFiF6T8QyB","parentSlot":83987983,"previousBlockhash":"Aq9jSXe1jRzfiaBcRFLe4wm7j499vWVEeFQrq5nnXfZN","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"innerInstructions":[],"logMessages":[],"postBalances":[441866063495,40905918933763,1],"postTokenBalances":[],"preBalances":[441866068495,40905918933763,1],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"transaction":{"signatures":["D8emaP3CaepSGigD3TCrev7j67yPLMi82qfzTb9iZYPxHcCmm6sQBKTU4bzAee4445zbnbWduVAZ87WfbWbXoAU"],"accountKeys":[{"pubkey":"EVd8FFVB54svYdZdG6hH4F4hTbqre5mpQ7XyF5rKUmes","signer":true,"writable":true,"source":"transaction"},{"pubkey":"72miaovmbPqccdbAA861r2uxwB5yL1sMjrgbCnc4JfVT","signer":false,"writable":true,"source":"transaction"},{"pubkey":"Vote111111111111111111111111111111111111111","signer":false,"writable":false,"source":"lookupTable"}]},"version":0}]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	maxVersion := uint64(1)
+	rewards := false
+	out, err := client.GetBlockWithOpts(
+		context.Background(),
+		389906766,
+		&GetBlockOpts{
+			Commitment:                     CommitmentFinalized,
+			Encoding:                       solana.EncodingBase64,
+			TransactionDetails:             TransactionDetailsAccounts,
+			Rewards:                        &rewards,
+			MaxSupportedTransactionVersion: &maxVersion,
+		},
+	)
+	require.NoError(t, err)
+
+	// Verify the request params
+	reqBody := server.RequestBody(t)
+	assert.NotNil(t, reqBody["id"])
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getBlock",
+			"params": []any{
+				float64(389906766),
+				map[string]any{
+					"encoding":                       string(solana.EncodingBase64),
+					"transactionDetails":             string(TransactionDetailsAccounts),
+					"rewards":                        rewards,
+					"commitment":                     string(CommitmentFinalized),
+					"maxSupportedTransactionVersion": float64(1),
+				},
+			},
+		},
+		reqBody,
+	)
+
+	// Verify we can extract account keys from transactions in "accounts" mode
+	require.Len(t, out.Transactions, 1)
+	tx := out.Transactions[0]
+
+	accountKeys, err := tx.GetAccountKeys()
+	require.NoError(t, err)
+
+	require.Len(t, accountKeys.Signatures, 1)
+	assert.Equal(t,
+		solana.MustSignatureFromBase58("D8emaP3CaepSGigD3TCrev7j67yPLMi82qfzTb9iZYPxHcCmm6sQBKTU4bzAee4445zbnbWduVAZ87WfbWbXoAU"),
+		accountKeys.Signatures[0],
+	)
+
+	require.Len(t, accountKeys.AccountKeys, 3)
+
+	// First account: signer + writable, source=transaction
+	assert.Equal(t, solana.MustPublicKeyFromBase58("EVd8FFVB54svYdZdG6hH4F4hTbqre5mpQ7XyF5rKUmes"), accountKeys.AccountKeys[0].Pubkey)
+	assert.True(t, accountKeys.AccountKeys[0].Signer)
+	assert.True(t, accountKeys.AccountKeys[0].Writable)
+	require.NotNil(t, accountKeys.AccountKeys[0].Source)
+	assert.Equal(t, AccountKeySourceTransaction, *accountKeys.AccountKeys[0].Source)
+
+	// Second account: not signer, writable, source=transaction
+	assert.Equal(t, solana.MustPublicKeyFromBase58("72miaovmbPqccdbAA861r2uxwB5yL1sMjrgbCnc4JfVT"), accountKeys.AccountKeys[1].Pubkey)
+	assert.False(t, accountKeys.AccountKeys[1].Signer)
+	assert.True(t, accountKeys.AccountKeys[1].Writable)
+	require.NotNil(t, accountKeys.AccountKeys[1].Source)
+	assert.Equal(t, AccountKeySourceTransaction, *accountKeys.AccountKeys[1].Source)
+
+	// Third account: not signer, not writable, source=lookupTable
+	assert.Equal(t, solana.MustPublicKeyFromBase58("Vote111111111111111111111111111111111111111"), accountKeys.AccountKeys[2].Pubkey)
+	assert.False(t, accountKeys.AccountKeys[2].Signer)
+	assert.False(t, accountKeys.AccountKeys[2].Writable)
+	require.NotNil(t, accountKeys.AccountKeys[2].Source)
+	assert.Equal(t, AccountKeySourceLookupTable, *accountKeys.AccountKeys[2].Source)
+}
+
+func TestClient_GetBlockWithOpts_AccountsMode_GetTransactionFails(t *testing.T) {
+	// When using "accounts" mode, calling GetTransaction() should fail
+	// because there's no binary transaction data
+	responseBody := `{"blockHeight":69213636,"blockTime":1625227950,"blockhash":"5M77sHdwzH6rckuQwF8HL1w52n7hjrh4GVTFiF6T8QyB","parentSlot":83987983,"previousBlockhash":"Aq9jSXe1jRzfiaBcRFLe4wm7j499vWVEeFQrq5nnXfZN","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"innerInstructions":[],"logMessages":[],"postBalances":[100],"postTokenBalances":[],"preBalances":[200],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"transaction":{"signatures":["D8emaP3CaepSGigD3TCrev7j67yPLMi82qfzTb9iZYPxHcCmm6sQBKTU4bzAee4445zbnbWduVAZ87WfbWbXoAU"],"accountKeys":[{"pubkey":"EVd8FFVB54svYdZdG6hH4F4hTbqre5mpQ7XyF5rKUmes","signer":true,"writable":true,"source":"transaction"}]}}]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	out, err := client.GetBlockWithOpts(context.Background(), 100, nil)
+	require.NoError(t, err)
+
+	require.Len(t, out.Transactions, 1)
+
+	// GetTransaction should fail — no binary data
+	_, err = out.Transactions[0].GetTransaction()
+	assert.Error(t, err)
+
+	// GetAccountKeys should succeed
+	accountKeys, err := out.Transactions[0].GetAccountKeys()
+	require.NoError(t, err)
+	require.Len(t, accountKeys.AccountKeys, 1)
+	assert.Equal(t, solana.MustPublicKeyFromBase58("EVd8FFVB54svYdZdG6hH4F4hTbqre5mpQ7XyF5rKUmes"), accountKeys.AccountKeys[0].Pubkey)
+}
+
 func TestClient_GetBlockHeight(t *testing.T) {
 	responseBody := `69217140`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -228,6 +228,35 @@ func TestClient_GetBalance(t *testing.T) {
 		}, out)
 }
 
+func TestClient_ContextApiVersion(t *testing.T) {
+	responseBody := `{"context":{"slot":83987501,"apiVersion":"2.2.1"},"value":19039980000}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+	out, err := client.GetBalance(context.Background(), pubKey, CommitmentFinalized)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(83987501), out.Context.Slot)
+	require.NotNil(t, out.Context.ApiVersion)
+	assert.Equal(t, "2.2.1", *out.Context.ApiVersion)
+}
+
+func TestClient_ContextApiVersion_Absent(t *testing.T) {
+	responseBody := `{"context":{"slot":83987501},"value":19039980000}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+	out, err := client.GetBalance(context.Background(), pubKey, CommitmentFinalized)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(83987501), out.Context.Slot)
+	assert.Nil(t, out.Context.ApiVersion)
+}
+
 func TestClient_GetBlock(t *testing.T) {
 	responseBody := `{"blockHeight":69213636,"blockTime":1625227950,"blockhash":"5M77sHdwzH6rckuQwF8HL1w52n7hjrh4GVTFiF6T8QyB","parentSlot":83987983,"previousBlockhash":"Aq9jSXe1jRzfiaBcRFLe4wm7j499vWVEeFQrq5nnXfZN","rewards":[{"lamports":1595000,"postBalance":482032983798,"pubkey":"5rL3AaidKJa4ChSV3ys1SvpDg9L4amKiwYayGR5oL3dq","rewardType":"Fee"}],"transactions":[{"meta":{"err":null,"fee":5000,"innerInstructions":[],"logMessages":["Program Vote111111111111111111111111111111111111111 invoke [1]","Program Vote111111111111111111111111111111111111111 success"],"postBalances":[441866063495,40905918933763,1,1,1],"postTokenBalances":[],"preBalances":[441866068495,40905918933763,1,1,1],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"transaction":["AQp2TH1spzjBAVM3alvnpaePFx3YEo9dvRglDuSChZUoTMD\/\/2h0HY5+89LJjCdiGJ7Ph3+Fyvbeiz1uJF8gxw0BAAMFyH0KDkXtjL1xebUYflZxYGlpV+LvjazzZCb\/mF2T67xZmkOUM\/A0iDSEkFzD5m4Ol82vsojigvqxrmp7Z1vrQgan1RcZLwqvxvJl4\/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ\/wNo1OAAAAAAAMFYbeqrsxJ9\/vZxtOaFi3rT2w9RF5Xi4jsyu61f3t1AQQEAQIDAAR0ZXN0","base64"]},{"meta":{"err":null,"fee":5000,"innerInstructions":[],"logMessages":["Program Vote111111111111111111111111111111111111111 invoke [1]","Program Vote111111111111111111111111111111111111111 success"],"postBalances":[334759887662,151357332545078,1,1,1],"postTokenBalances":[],"preBalances":[334759892662,151357332545078,1,1,1],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"transaction":["ATA7DkBatbe2JB43QV+QRj2yoXSMXXttYFggDxZYOBfsRyYuGtzrbUevivclchxVccRIPlRP9PtS\/9NPXlwmhwwBAAMFSDrhjiNPuNqc4BWwitZz7xJ2NIXtv6XZtwtEOmgLj3n3NQ+OONLFlsu0LoUBSDsp40i9jOjZJBsliMtvTfdV+gan1RcZLwqvxvJl4\/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ\/wNo1OAAAAAAAKlcZMqS\/Oh0v+kOq2Ipg73NqbvKBRGQJDK8\/01K+MBAQQEAQIDAAR0ZXN0","base64"]}]}`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
@@ -793,6 +822,54 @@ func TestClient_GetClusterNodes(t *testing.T) {
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
 }
 
+func TestClient_GetClusterNodes_AllFields(t *testing.T) {
+	responseBody := `[{"pubkey":"hyp3Eo67t6FgeuWg5Qxbeme8NPXJPXXdKT4iJ4DsLf2","gossip":"127.0.0.1:8000","tpu":null,"tpuQuic":"127.0.0.1:8009","tpuForwards":null,"tpuForwardsQuic":"127.0.0.1:8010","tpuVote":"127.0.0.1:8005","serveRepair":"127.0.0.1:8008","rpc":"127.0.0.1:8899","pubsub":"127.0.0.1:8900","version":"2.2.1","featureSet":3580551090,"shredVersion":50093,"clientId":"Agave"}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	out, err := client.GetClusterNodes(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	node := out[0]
+
+	assert.Equal(t, solana.MustPublicKeyFromBase58("hyp3Eo67t6FgeuWg5Qxbeme8NPXJPXXdKT4iJ4DsLf2"), node.Pubkey)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8000"), node.Gossip)
+	assert.Nil(t, node.TPU)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8009"), node.TPUQUIC)
+	assert.Nil(t, node.TPUForwards)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8010"), node.TPUForwardsQUIC)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8005"), node.TPUVote)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8008"), node.ServeRepair)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8899"), node.RPC)
+	assert.Equal(t, pointer.ToString("127.0.0.1:8900"), node.PubSub)
+	assert.Equal(t, pointer.ToString("2.2.1"), node.Version)
+	require.NotNil(t, node.FeatureSet)
+	assert.Equal(t, uint32(3580551090), *node.FeatureSet)
+	assert.Equal(t, uint16(50093), node.ShredVersion)
+	assert.Equal(t, pointer.ToString("Agave"), node.ClientID)
+}
+
+func TestClient_GetClusterNodes_BackwardCompatible(t *testing.T) {
+	// Old response without new fields should still parse
+	responseBody := `[{"pubkey":"hyp3Eo67t6FgeuWg5Qxbeme8NPXJPXXdKT4iJ4DsLf2","gossip":"127.0.0.1:8000","tpu":"127.0.0.1:8003","tpuQuic":"127.0.0.1:8009","rpc":"127.0.0.1:8899","version":"1.17.22","featureSet":3580551090,"shredVersion":50093}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	out, err := client.GetClusterNodes(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	node := out[0]
+	assert.Nil(t, node.TPUForwards)
+	assert.Nil(t, node.TPUForwardsQUIC)
+	assert.Nil(t, node.TPUVote)
+	assert.Nil(t, node.ServeRepair)
+	assert.Nil(t, node.ClientID)
+}
+
 func TestClient_GetEpochInfo(t *testing.T) {
 	responseBody := `{"absoluteSlot":83994151,"blockHeight":69218302,"epoch":207,"slotIndex":93895,"slotsInEpoch":432000,"transactionCount":27287000257}`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
@@ -1068,6 +1145,21 @@ func TestClient_GetInflationRate(t *testing.T) {
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
 }
 
+func TestClient_GetInflationRate_EpochAsUint64(t *testing.T) {
+	responseBody := `{"epoch":207,"foundation":0,"total":0.1403151524615605,"validator":0.1403151524615605}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	out, err := client.GetInflationRate(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(207), out.Epoch)
+	assert.Equal(t, 0.1403151524615605, out.Total)
+	assert.Equal(t, 0.1403151524615605, out.Validator)
+	assert.Equal(t, float64(0), out.Foundation)
+}
+
 func TestClient_GetInflationReward(t *testing.T) {
 	// TODO: add test with real value
 	responseBody := `[null]`
@@ -1121,6 +1213,45 @@ func TestClient_GetInflationReward(t *testing.T) {
 	got := mustJSONToInterface(mustAnyToJSON(out))
 
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
+}
+
+func TestClient_GetInflationReward_WithCommissionBps(t *testing.T) {
+	responseBody := `[{"epoch":100,"effectiveSlot":43200000,"amount":2500000,"postBalance":1002500000,"commission":5,"commissionBps":500}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+	out, err := client.GetInflationReward(context.Background(), []solana.PublicKey{pubKey}, nil)
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0])
+	assert.Equal(t, uint64(100), out[0].Epoch)
+	assert.Equal(t, uint64(43200000), out[0].EffectiveSlot)
+	assert.Equal(t, uint64(2500000), out[0].Amount)
+	assert.Equal(t, uint64(1002500000), out[0].PostBalance)
+	require.NotNil(t, out[0].Commission)
+	assert.Equal(t, uint8(5), *out[0].Commission)
+	require.NotNil(t, out[0].CommissionBps)
+	assert.Equal(t, uint16(500), *out[0].CommissionBps)
+}
+
+func TestClient_GetInflationReward_WithoutCommissionBps(t *testing.T) {
+	responseBody := `[{"epoch":100,"effectiveSlot":43200000,"amount":2500000,"postBalance":1002500000,"commission":5}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+	out, err := client.GetInflationReward(context.Background(), []solana.PublicKey{pubKey}, nil)
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0])
+	require.NotNil(t, out[0].Commission)
+	assert.Equal(t, uint8(5), *out[0].Commission)
+	assert.Nil(t, out[0].CommissionBps)
 }
 
 func TestClient_GetLargestAccounts(t *testing.T) {
@@ -1248,6 +1379,48 @@ func TestClient_GetLargestAccounts(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, out)
+}
+
+func TestClient_GetLargestAccountsWithOpts_SortResults(t *testing.T) {
+	responseBody := `{"context":{"slot":83995022},"value":[{"address":"4Rf9mGD7FeYknun5JczX5nGLTfQuS1GRjNVfkEMKE92b","lamports":398178060209179300}]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	sortResults := true
+	out, err := client.GetLargestAccountsWithOpts(
+		context.Background(),
+		&GetLargestAccountsOpts{
+			Commitment:  CommitmentFinalized,
+			Filter:      LargestAccountsFilterCirculating,
+			SortResults: &sortResults,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getLargestAccounts",
+			"params": []any{
+				map[string]any{
+					"commitment":  string(CommitmentFinalized),
+					"filter":      string(LargestAccountsFilterCirculating),
+					"sortResults": true,
+				},
+			},
+		},
+		reqBody,
+	)
+
+	require.NotNil(t, out)
+	require.Len(t, out.Value, 1)
+	assert.Equal(t, solana.MustPublicKeyFromBase58("4Rf9mGD7FeYknun5JczX5nGLTfQuS1GRjNVfkEMKE92b"), out.Value[0].Address)
+	assert.Equal(t, uint64(398178060209179300), out.Value[0].Lamports)
 }
 
 func TestClient_GetLeaderSchedule(t *testing.T) {
@@ -1551,6 +1724,97 @@ func TestClient_GetProgramAccounts(t *testing.T) {
 	assert.Equal(t, expected, out)
 }
 
+func TestClient_GetProgramAccountsWithContext(t *testing.T) {
+	responseBody := `{"context":{"slot":83986105,"apiVersion":"2.2.1"},"value":[{"account":{"data":["dGVzdA==","base64"],"executable":true,"lamports":2039280,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":206},"pubkey":"7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"}]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	out, err := client.GetProgramAccountsWithContext(
+		context.Background(),
+		pubKey,
+		&GetProgramAccountsOpts{
+			Commitment: CommitmentFinalized,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	assert.NotNil(t, reqBody["id"])
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getProgramAccounts",
+			"params": []any{
+				pubkeyString,
+				map[string]any{
+					"encoding":    "base64",
+					"commitment":  string(CommitmentFinalized),
+					"withContext": true,
+				},
+			},
+		},
+		reqBody,
+	)
+
+	// Verify context is returned (not silently dropped)
+	assert.Equal(t, uint64(83986105), out.Context.Slot)
+	require.NotNil(t, out.Context.ApiVersion)
+	assert.Equal(t, "2.2.1", *out.Context.ApiVersion)
+
+	// Verify accounts
+	require.Len(t, out.Value, 1)
+	assert.Equal(t, solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"), out.Value[0].Pubkey)
+	assert.Equal(t, uint64(2039280), out.Value[0].Account.Lamports)
+}
+
+func TestClient_GetProgramAccountsWithOpts_SortResults(t *testing.T) {
+	responseBody := `[{"account":{"data":["dGVzdA==","base64"],"executable":true,"lamports":2039280,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":206},"pubkey":"7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	sortResults := true
+	out, err := client.GetProgramAccountsWithOpts(
+		context.Background(),
+		pubKey,
+		&GetProgramAccountsOpts{
+			SortResults: &sortResults,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getProgramAccounts",
+			"params": []any{
+				pubkeyString,
+				map[string]any{
+					"encoding":    "base64",
+					"sortResults": true,
+				},
+			},
+		},
+		reqBody,
+	)
+
+	require.Len(t, out, 1)
+}
+
 func TestClient_GetRecentPerformanceSamples(t *testing.T) {
 	responseBody := `[{"numSlots":84,"numTransactions":90402,"samplePeriodSecs":60,"slot":83998844}]`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
@@ -1586,6 +1850,42 @@ func TestClient_GetRecentPerformanceSamples(t *testing.T) {
 	got := mustJSONToInterface(mustAnyToJSON(out))
 
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
+}
+
+func TestClient_GetRecentPerformanceSamples_WithNonVoteTx(t *testing.T) {
+	// Based on Agave test fixture from response.rs
+	responseBody := `[{"slot":1286,"numTransactions":1732,"numNonVoteTransactions":757,"numSlots":393,"samplePeriodSecs":197}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	limit := uint(1)
+	out, err := client.GetRecentPerformanceSamples(context.Background(), &limit)
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	assert.Equal(t, uint64(1286), out[0].Slot)
+	assert.Equal(t, uint64(1732), out[0].NumTransactions)
+	require.NotNil(t, out[0].NumNonVoteTransactions)
+	assert.Equal(t, uint64(757), *out[0].NumNonVoteTransactions)
+	assert.Equal(t, uint64(393), out[0].NumSlots)
+	assert.Equal(t, uint16(197), out[0].SamplePeriodSecs)
+}
+
+func TestClient_GetRecentPerformanceSamples_WithoutNonVoteTx(t *testing.T) {
+	// Backward compatibility: old response without numNonVoteTransactions (from Agave response.rs test)
+	responseBody := `[{"slot":424,"numTransactions":2597,"numSlots":2783,"samplePeriodSecs":398}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	limit := uint(1)
+	out, err := client.GetRecentPerformanceSamples(context.Background(), &limit)
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	assert.Nil(t, out[0].NumNonVoteTransactions)
+	assert.Equal(t, uint64(2597), out[0].NumTransactions)
 }
 
 func TestClient_GetSignaturesForAddress(t *testing.T) {
@@ -1645,6 +1945,41 @@ func TestClient_GetSignaturesForAddress(t *testing.T) {
 	got := mustJSONToInterface(mustAnyToJSON(out))
 
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
+}
+
+func TestClient_GetSignaturesForAddress_WithTransactionIndex(t *testing.T) {
+	responseBody := `[{"blockTime":1234567890,"confirmationStatus":"finalized","err":null,"memo":"test memo","signature":"5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW","slot":123,"transactionIndex":42}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+	out, err := client.GetSignaturesForAddress(context.Background(), pubKey)
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	sig := out[0]
+	assert.Equal(t, uint64(123), sig.Slot)
+	assert.Nil(t, sig.Err)
+	require.NotNil(t, sig.Memo)
+	assert.Equal(t, "test memo", *sig.Memo)
+	require.NotNil(t, sig.TransactionIndex)
+	assert.Equal(t, uint32(42), *sig.TransactionIndex)
+	assert.Equal(t, ConfirmationStatusType("finalized"), sig.ConfirmationStatus)
+}
+
+func TestClient_GetSignaturesForAddress_WithoutTransactionIndex(t *testing.T) {
+	responseBody := `[{"blockTime":1234567890,"confirmationStatus":"finalized","err":null,"memo":null,"signature":"5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW","slot":123}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+	out, err := client.GetSignaturesForAddress(context.Background(), pubKey)
+	require.NoError(t, err)
+
+	require.Len(t, out, 1)
+	assert.Nil(t, out[0].TransactionIndex)
 }
 
 func TestClient_GetSignatureStatuses(t *testing.T) {
@@ -2304,6 +2639,36 @@ func TestClient_GetVoteAccounts(t *testing.T) {
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
 }
 
+func TestClient_GetVoteAccounts_WithCommissionBps(t *testing.T) {
+	responseBody := `{"current":[{"activatedStake":5000000000,"commission":7,"inflationRewardsCommissionBps":700,"epochCredits":[[127,1124979,892885]],"epochVoteAccount":true,"lastVote":51699331,"nodePubkey":"z3roU4WgvZvYkAEAYmUGK4LkPK6qFii6uzgMAswGYjb","rootSlot":51699288,"votePubkey":"vot33MHDqT6nSwubGzqtc6m16ChcUywxV7tNULF19Vu"}],"delinquent":[]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	out, err := client.GetVoteAccounts(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.Len(t, out.Current, 1)
+	va := out.Current[0]
+	assert.Equal(t, uint8(7), va.Commission)
+	require.NotNil(t, va.InflationRewardsCommissionBps)
+	assert.Equal(t, uint16(700), *va.InflationRewardsCommissionBps)
+}
+
+func TestClient_GetVoteAccounts_WithoutCommissionBps(t *testing.T) {
+	// Backward compatibility: pre-SIMD-0291 responses without inflationRewardsCommissionBps
+	responseBody := `{"current":[{"activatedStake":5000000000,"commission":7,"epochCredits":[[127,1124979,892885]],"epochVoteAccount":true,"lastVote":51699331,"nodePubkey":"z3roU4WgvZvYkAEAYmUGK4LkPK6qFii6uzgMAswGYjb","rootSlot":51699288,"votePubkey":"vot33MHDqT6nSwubGzqtc6m16ChcUywxV7tNULF19Vu"}],"delinquent":[]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	out, err := client.GetVoteAccounts(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.Len(t, out.Current, 1)
+	assert.Nil(t, out.Current[0].InflationRewardsCommissionBps)
+}
+
 func TestClient_MinimumLedgerSlot(t *testing.T) {
 	responseBody := `83686753`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
@@ -2380,6 +2745,95 @@ func TestClient_RequestAirdrop(t *testing.T) {
 	got := mustJSONToInterface(mustAnyToJSON(out))
 
 	assert.Equal(t, expected, got, "both deserialized values must be equal")
+}
+
+func TestClient_RequestAirdropWithOpts(t *testing.T) {
+	responseBody := `"3ZmWDnFJ5REjxtmtQRrczmVDraVZs7BpUFo3NRfnoQs6wvTJ2kTkw9YyGod291UHjK5Qg6w63Hqn7t6nrGMLWhga"`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	blockhash := solana.MustHashFromBase58("EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N")
+	lamports := uint64(10000000)
+	out, err := client.RequestAirdropWithOpts(
+		context.Background(),
+		pubKey,
+		lamports,
+		&RequestAirdropOpts{
+			Commitment:      CommitmentFinalized,
+			RecentBlockhash: &blockhash,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	assert.NotNil(t, reqBody["id"])
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "requestAirdrop",
+			"params": []any{
+				pubkeyString,
+				float64(lamports),
+				map[string]any{
+					"commitment":      string(CommitmentFinalized),
+					"recentBlockhash": blockhash.String(),
+				},
+			},
+		},
+		reqBody,
+	)
+
+	assert.Equal(t,
+		solana.MustSignatureFromBase58("3ZmWDnFJ5REjxtmtQRrczmVDraVZs7BpUFo3NRfnoQs6wvTJ2kTkw9YyGod291UHjK5Qg6w63Hqn7t6nrGMLWhga"),
+		out,
+	)
+}
+
+func TestClient_RequestAirdropWithOpts_OnlyCommitment(t *testing.T) {
+	responseBody := `"3ZmWDnFJ5REjxtmtQRrczmVDraVZs7BpUFo3NRfnoQs6wvTJ2kTkw9YyGod291UHjK5Qg6w63Hqn7t6nrGMLWhga"`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	lamports := uint64(10000000)
+	_, err := client.RequestAirdropWithOpts(
+		context.Background(),
+		pubKey,
+		lamports,
+		&RequestAirdropOpts{
+			Commitment: CommitmentFinalized,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "requestAirdrop",
+			"params": []any{
+				pubkeyString,
+				float64(lamports),
+				map[string]any{
+					"commitment": string(CommitmentFinalized),
+				},
+			},
+		},
+		reqBody,
+	)
 }
 
 func TestClient_GetTokenAccountBalance(t *testing.T) {

--- a/rpc/getClusterNodes.go
+++ b/rpc/getClusterNodes.go
@@ -41,6 +41,18 @@ type GetClusterNodesResult struct {
 	// TPU QUIC network address for the node.
 	TPUQUIC *string `json:"tpuQuic,omitempty"`
 
+	// TPU forwards network address for the node.
+	TPUForwards *string `json:"tpuForwards,omitempty"`
+
+	// TPU forwards QUIC network address for the node.
+	TPUForwardsQUIC *string `json:"tpuForwardsQuic,omitempty"`
+
+	// TPU vote network address for the node.
+	TPUVote *string `json:"tpuVote,omitempty"`
+
+	// Serve repair network address for the node.
+	ServeRepair *string `json:"serveRepair,omitempty"`
+
 	// RPC WebSocket network address for the node, or empty if the WebSocket RPC service is not enabled.
 	PubSub *string `json:"pubsub,omitempty"`
 
@@ -50,10 +62,12 @@ type GetClusterNodesResult struct {
 	// The software version of the node, or empty if the version information is not available.
 	Version *string `json:"version,omitempty"`
 
-	// TODO: what type is this?
 	// The unique identifier of the node's feature set.
-	FeatureSet uint32 `json:"featureSet,omitempty"`
+	FeatureSet *uint32 `json:"featureSet,omitempty"`
 
 	// The shred version the node has been configured to use.
 	ShredVersion uint16 `json:"shredVersion,omitempty"`
+
+	// The client identifier for the node.
+	ClientID *string `json:"clientId,omitempty"`
 }

--- a/rpc/getInflationRate.go
+++ b/rpc/getInflationRate.go
@@ -35,5 +35,5 @@ type GetInflationRateResult struct {
 	Foundation float64 `json:"foundation"`
 
 	// Epoch for which these values are valid.
-	Epoch float64 `json:"epoch"`
+	Epoch uint64 `json:"epoch"`
 }

--- a/rpc/getInflationReward.go
+++ b/rpc/getInflationReward.go
@@ -57,7 +57,7 @@ func (cl *Client) GetInflationReward(
 }
 
 type GetInflationRewardResult struct {
-	// Epoch for which reward occured.
+	// Epoch for which reward occurred.
 	Epoch uint64 `json:"epoch"`
 
 	// The slot in which the rewards are effective.
@@ -71,4 +71,7 @@ type GetInflationRewardResult struct {
 
 	// Vote account commission when the reward was credited.
 	Commission *uint8 `json:"commission,omitempty"`
+
+	// Vote account commission in basis points when the reward was credited.
+	CommissionBps *uint16 `json:"commissionBps,omitempty"`
 }

--- a/rpc/getLargestAccounts.go
+++ b/rpc/getLargestAccounts.go
@@ -27,6 +27,12 @@ const (
 	LargestAccountsFilterNonCirculating LargestAccountsFilterType = "nonCirculating"
 )
 
+type GetLargestAccountsOpts struct {
+	Commitment  CommitmentType
+	Filter      LargestAccountsFilterType
+	SortResults *bool
+}
+
 // GetLargestAccounts returns the 20 largest accounts,
 // by lamport balance (results may be cached up to two hours).
 func (cl *Client) GetLargestAccounts(
@@ -34,13 +40,30 @@ func (cl *Client) GetLargestAccounts(
 	commitment CommitmentType,
 	filter LargestAccountsFilterType, // filter results by account type; currently supported: circulating|nonCirculating
 ) (out *GetLargestAccountsResult, err error) {
+	return cl.GetLargestAccountsWithOpts(ctx, &GetLargestAccountsOpts{
+		Commitment: commitment,
+		Filter:     filter,
+	})
+}
+
+// GetLargestAccountsWithOpts returns the 20 largest accounts,
+// by lamport balance (results may be cached up to two hours).
+func (cl *Client) GetLargestAccountsWithOpts(
+	ctx context.Context,
+	opts *GetLargestAccountsOpts,
+) (out *GetLargestAccountsResult, err error) {
 	params := []any{}
 	obj := M{}
-	if commitment != "" {
-		obj["commitment"] = commitment
-	}
-	if filter != "" {
-		obj["filter"] = filter
+	if opts != nil {
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.Filter != "" {
+			obj["filter"] = opts.Filter
+		}
+		if opts.SortResults != nil {
+			obj["sortResults"] = *opts.SortResults
+		}
 	}
 	if len(obj) > 0 {
 		params = append(params, obj)

--- a/rpc/getProgramAccounts.go
+++ b/rpc/getProgramAccounts.go
@@ -53,12 +53,13 @@ func (cl *Client) GetProgramAccountsWithContext(
 	publicKey solana.PublicKey,
 	opts *GetProgramAccountsOpts,
 ) (out *GetProgramAccountsWithContextResult, err error) {
-	if opts == nil {
-		opts = &GetProgramAccountsOpts{}
+	var o GetProgramAccountsOpts
+	if opts != nil {
+		o = *opts
 	}
 	withCtx := true
-	opts.WithContext = &withCtx
-	params := buildGetProgramAccountsParams(publicKey, opts)
+	o.WithContext = &withCtx
+	params := buildGetProgramAccountsParams(publicKey, &o)
 	err = cl.rpcClient.CallForInto(ctx, &out, "getProgramAccounts", params)
 	return
 }

--- a/rpc/getProgramAccounts.go
+++ b/rpc/getProgramAccounts.go
@@ -40,6 +40,30 @@ func (cl *Client) GetProgramAccountsWithOpts(
 	publicKey solana.PublicKey,
 	opts *GetProgramAccountsOpts,
 ) (out GetProgramAccountsResult, err error) {
+	params := buildGetProgramAccountsParams(publicKey, opts)
+	err = cl.rpcClient.CallForInto(ctx, &out, "getProgramAccounts", params)
+	return
+}
+
+// GetProgramAccountsWithContext returns all accounts owned by the provided program publicKey,
+// wrapped in an RPC response with context (slot and apiVersion).
+// The WithContext option is automatically set to true.
+func (cl *Client) GetProgramAccountsWithContext(
+	ctx context.Context,
+	publicKey solana.PublicKey,
+	opts *GetProgramAccountsOpts,
+) (out *GetProgramAccountsWithContextResult, err error) {
+	if opts == nil {
+		opts = &GetProgramAccountsOpts{}
+	}
+	withCtx := true
+	opts.WithContext = &withCtx
+	params := buildGetProgramAccountsParams(publicKey, opts)
+	err = cl.rpcClient.CallForInto(ctx, &out, "getProgramAccounts", params)
+	return
+}
+
+func buildGetProgramAccountsParams(publicKey solana.PublicKey, opts *GetProgramAccountsOpts) []any {
 	obj := M{
 		"encoding": "base64",
 	}
@@ -59,10 +83,12 @@ func (cl *Client) GetProgramAccountsWithOpts(
 				"length": opts.DataSlice.Length,
 			}
 		}
+		if opts.WithContext != nil {
+			obj["withContext"] = *opts.WithContext
+		}
+		if opts.SortResults != nil {
+			obj["sortResults"] = *opts.SortResults
+		}
 	}
-
-	params := []any{publicKey, obj}
-
-	err = cl.rpcClient.CallForInto(ctx, &out, "getProgramAccounts", params)
-	return
+	return []any{publicKey, obj}
 }

--- a/rpc/getRecentPerformanceSamples.go
+++ b/rpc/getRecentPerformanceSamples.go
@@ -40,6 +40,9 @@ type GetRecentPerformanceSamplesResult struct {
 	// Number of transactions in sample.
 	NumTransactions uint64 `json:"numTransactions"`
 
+	// Number of non-vote transactions in sample.
+	NumNonVoteTransactions *uint64 `json:"numNonVoteTransactions,omitempty"`
+
 	// Number of slots in sample.
 	NumSlots uint64 `json:"numSlots"`
 

--- a/rpc/getVoteAccounts.go
+++ b/rpc/getVoteAccounts.go
@@ -86,6 +86,9 @@ type VoteAccountsResult struct {
 	// Percentage (0-100) of rewards payout owed to the vote account.
 	Commission uint8 `json:"commission,omitempty"`
 
+	// Commission in basis points for inflation rewards.
+	InflationRewardsCommissionBps *uint16 `json:"inflationRewardsCommissionBps,omitempty"`
+
 	// Most recent slot voted on by this vote account.
 	LastVote uint64 `json:"lastVote,omitempty"`
 

--- a/rpc/requestAirdrop.go
+++ b/rpc/requestAirdrop.go
@@ -22,6 +22,14 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+type RequestAirdropOpts struct {
+	Commitment CommitmentType
+
+	// Must be a recent blockhash as a base-58 encoded string.
+	// If not provided, a recent blockhash is used.
+	RecentBlockhash *solana.Hash
+}
+
 // RequestAirdrop requests an airdrop of lamports to a publicKey.
 // Returns transaction signature of airdrop.
 func (cl *Client) RequestAirdrop(
@@ -30,14 +38,34 @@ func (cl *Client) RequestAirdrop(
 	lamports uint64,
 	commitment CommitmentType, // optional; used for retrieving blockhash and verifying airdrop success.
 ) (signature solana.Signature, err error) {
+	return cl.RequestAirdropWithOpts(ctx, account, lamports, &RequestAirdropOpts{
+		Commitment: commitment,
+	})
+}
+
+// RequestAirdropWithOpts requests an airdrop of lamports to a publicKey with additional options.
+// Returns transaction signature of airdrop.
+func (cl *Client) RequestAirdropWithOpts(
+	ctx context.Context,
+	account solana.PublicKey,
+	lamports uint64,
+	opts *RequestAirdropOpts,
+) (signature solana.Signature, err error) {
 	params := []any{
 		account,
 		lamports,
 	}
-	if commitment != "" {
-		params = append(params,
-			M{"commitment": commitment},
-		)
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.RecentBlockhash != nil {
+			obj["recentBlockhash"] = opts.RecentBlockhash.String()
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 	err = cl.rpcClient.CallForInto(ctx, &signature, "requestAirdrop", params)
 	return

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -125,6 +125,57 @@ func (twm TransactionWithMeta) GetTransaction() (*solana.Transaction, error) {
 	return tx, nil
 }
 
+// GetAccountKeys returns the account keys when the block was fetched with
+// TransactionDetailsAccounts. In this mode the transaction field contains
+// {"signatures": [...], "accountKeys": [...]} instead of the full encoded transaction.
+func (twm TransactionWithMeta) GetAccountKeys() (*TransactionAccountKeys, error) {
+	if twm.Transaction == nil {
+		return nil, fmt.Errorf("transaction is nil")
+	}
+	raw := twm.Transaction.GetRawJSON()
+	if raw == nil {
+		return nil, fmt.Errorf("transaction is not JSON (accounts mode requires transactionDetails=accounts)")
+	}
+	var out TransactionAccountKeys
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal account keys: %w", err)
+	}
+	return &out, nil
+}
+
+// TransactionAccountKeys is the transaction representation returned when
+// transactionDetails is "accounts". Instead of the full message, it contains
+// only the signatures and the list of account keys with their roles.
+type TransactionAccountKeys struct {
+	Signatures  []solana.Signature `json:"signatures"`
+	AccountKeys []AccountKey       `json:"accountKeys"`
+}
+
+// AccountKey represents a single account involved in a transaction,
+// as returned in the "accounts" transaction detail mode.
+type AccountKey struct {
+	// The account's public key.
+	Pubkey solana.PublicKey `json:"pubkey"`
+
+	// Whether this account signed the transaction.
+	Signer bool `json:"signer"`
+
+	// Whether the transaction marks this account as writable.
+	Writable bool `json:"writable"`
+
+	// The source of the account key: "transaction" for keys from the
+	// message itself, "lookupTable" for keys resolved from address
+	// lookup tables. Nil for legacy transactions.
+	Source *AccountKeySource `json:"source,omitempty"`
+}
+
+type AccountKeySource string
+
+const (
+	AccountKeySourceTransaction AccountKeySource = "transaction"
+	AccountKeySourceLookupTable AccountKeySource = "lookupTable"
+)
+
 type TransactionParsed struct {
 	Meta        *TransactionMeta    `json:"meta,omitempty"`
 	Transaction *solana.Transaction `json:"transaction"`

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -29,7 +29,8 @@ import (
 )
 
 type Context struct {
-	Slot uint64 `json:"slot"`
+	Slot       uint64  `json:"slot"`
+	ApiVersion *string `json:"apiVersion,omitempty"`
 }
 
 type RPCContext struct {
@@ -258,6 +259,9 @@ type TransactionSignature struct {
 	BlockTime *solana.UnixTimeSeconds `json:"blockTime,omitempty"`
 
 	ConfirmationStatus ConfirmationStatusType `json:"confirmationStatus,omitempty"`
+
+	// The transaction's index within the block.
+	TransactionIndex *uint32 `json:"transactionIndex,omitempty"`
 }
 
 type GetAccountInfoResult struct {
@@ -406,9 +410,20 @@ type GetProgramAccountsOpts struct {
 	// Filter results using various filter objects;
 	// account must meet all filter criteria to be included in results.
 	Filters []RPCFilter `json:"filters,omitempty"`
+
+	// Wrap the result in an RpcResponse JSON object with context.
+	WithContext *bool `json:"withContext,omitempty"`
+
+	// Sort the results (useful for deterministic pagination).
+	SortResults *bool `json:"sortResults,omitempty"`
 }
 
 type GetProgramAccountsResult []*KeyedAccount
+
+type GetProgramAccountsWithContextResult struct {
+	RPCContext
+	Value GetProgramAccountsResult `json:"value"`
+}
 
 type KeyedAccount struct {
 	Pubkey  solana.PublicKey `json:"pubkey"`


### PR DESCRIPTION
### Problem

RPC client  has drifted behind the Agave reference implementation
several response fields added in recent Agave releases are missing
these gaps mean callers cannot access data that Agave validators already return, and some request options available in the Rust client have no Go equivalen

### Summary of Changes
resp fields added:
- ApiVersion
- GetClusterNodesResult - TPUForwards, TPUForwardsQUIC, TPUVote, ServeRepair, ClientID; FeatureSet changed to *uint32 to match Option<u32>
- TransactionIndex in TransactionSignature
- InflationRewardsCommissionBps in VoteAccountsResult
- NumNonVoteTransactions in GetRecentPerformanceSamplesResult

req options added:
- GetProgramAccountsOpts - WithContext, SortResults
- new GetProgramAccountsWithContext method that returns context (slot/apiVersion) instead of silently discarding it
- GetLargestAccountsOpts struct + GetLargestAccountsWithOpts method with SortResults
- RequestAirdropOpts struct + RequestAirdropWithOpts method with RecentBlockhash

GetInflationRateResult.Epoch: float64 -> uint64
closes https://github.com/solana-foundation/solana-go/issues/345
