### PR TITLE
feat: stake state types & ext tests

### DIFF
--- a/programs/stake/AuthorizeChecked_test.go
+++ b/programs/stake/AuthorizeChecked_test.go
@@ -1,0 +1,26 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_AuthorizeChecked(t *testing.T) {
+	inst := NewAuthorizeCheckedInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetClockSysvar(solana.SysVarClockPubkey).
+		SetCurrentAuthority(pubkeyOf(2)).
+		SetNewAuthority(pubkeyOf(3)).
+		SetStakeAuthorize(StakeAuthorizeStaker)
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_AuthorizeChecked), data[:4])
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	ac := decoded.Impl.(*AuthorizeChecked)
+	require.Equal(t, StakeAuthorizeStaker, *ac.StakeAuthorize)
+}

--- a/programs/stake/Authorize_test.go
+++ b/programs/stake/Authorize_test.go
@@ -1,0 +1,28 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_Authorize(t *testing.T) {
+	newAuth := pubkeyOf(5)
+	inst := NewAuthorizeInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetClockSysvar(solana.SysVarClockPubkey).
+		SetAuthority(pubkeyOf(2)).
+		SetNewAuthorized(newAuth).
+		SetStakeAuthorize(StakeAuthorizeWithdrawer)
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_Authorize), data[:4])
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	auth := decoded.Impl.(*Authorize)
+	require.Equal(t, newAuth, *auth.NewAuthorized)
+	require.Equal(t, StakeAuthorizeWithdrawer, *auth.StakeAuthorize)
+}

--- a/programs/stake/DeactivateDelinquent_test.go
+++ b/programs/stake/DeactivateDelinquent_test.go
@@ -1,0 +1,15 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_DeactivateDelinquent(t *testing.T) {
+	inst := NewDeactivateDelinquentInstruction(pubkeyOf(1), pubkeyOf(2), pubkeyOf(3))
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_DeactivateDelinquent), data[:4])
+	require.Len(t, data, 4)
+}

--- a/programs/stake/Deactivate_test.go
+++ b/programs/stake/Deactivate_test.go
@@ -1,0 +1,20 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_Deactivate(t *testing.T) {
+	inst := NewDeactivateInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetClockSysvar(solana.SysVarClockPubkey).
+		SetStakeAuthority(pubkeyOf(2))
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_Deactivate), data[:4])
+	require.Len(t, data, 4)
+}

--- a/programs/stake/DelegateStake_test.go
+++ b/programs/stake/DelegateStake_test.go
@@ -1,0 +1,27 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_DelegateStake(t *testing.T) {
+	inst := NewDelegateStakeInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetVoteAccount(pubkeyOf(2)).
+		SetClockSysvar(solana.SysVarClockPubkey).
+		SetStakeHistorySysvar(solana.SysVarStakeHistoryPubkey).
+		SetConfigAccount(pubkeyOf(3)).
+		SetStakeAuthority(pubkeyOf(4))
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_DelegateStake), data[:4])
+	require.Len(t, data, 4)
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	require.IsType(t, &DelegateStake{}, decoded.Impl)
+}

--- a/programs/stake/GetMinimumDelegation_test.go
+++ b/programs/stake/GetMinimumDelegation_test.go
@@ -1,0 +1,15 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_GetMinimumDelegation(t *testing.T) {
+	inst := NewGetMinimumDelegationInstruction()
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_GetMinimumDelegation), data[:4])
+	require.Len(t, data, 4)
+}

--- a/programs/stake/InitializeChecked_test.go
+++ b/programs/stake/InitializeChecked_test.go
@@ -1,0 +1,21 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_InitializeChecked(t *testing.T) {
+	inst := NewInitializeCheckedInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetRentSysvar(solana.SysVarRentPubkey).
+		SetStakeAuthority(pubkeyOf(2)).
+		SetWithdrawAuthority(pubkeyOf(3))
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_InitializeChecked), data[:4])
+	require.Len(t, data, 4)
+}

--- a/programs/stake/Initialize_test.go
+++ b/programs/stake/Initialize_test.go
@@ -1,0 +1,39 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_Initialize(t *testing.T) {
+	staker := pubkeyOf(1)
+	withdrawer := pubkeyOf(2)
+	custodian := pubkeyOf(3)
+
+	inst := NewInitializeInstructionBuilder().
+		SetStakeAccount(pubkeyOf(10)).
+		SetRentSysvarAccount(solana.SysVarRentPubkey).
+		SetStaker(staker).
+		SetWithdrawer(withdrawer).
+		SetLockupTimestamp(1000).
+		SetLockupEpoch(42).
+		SetCustodian(custodian)
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+
+	// First 4 bytes: instruction ID (u32 LE)
+	require.Equal(t, u32LE(Instruction_Initialize), data[:4])
+
+	// Decode back
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	init := decoded.Impl.(*Initialize)
+	require.Equal(t, staker, *init.Authorized.Staker)
+	require.Equal(t, withdrawer, *init.Authorized.Withdrawer)
+	require.Equal(t, int64(1000), *init.Lockup.UnixTimestamp)
+	require.Equal(t, uint64(42), *init.Lockup.Epoch)
+	require.Equal(t, custodian, *init.Lockup.Custodian)
+}

--- a/programs/stake/Merge_test.go
+++ b/programs/stake/Merge_test.go
@@ -1,0 +1,22 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_Merge(t *testing.T) {
+	inst := NewMergeInstructionBuilder().
+		SetDestinationStakeAccount(pubkeyOf(1)).
+		SetSourceStakeAccount(pubkeyOf(2)).
+		SetClockSysvar(solana.SysVarClockPubkey).
+		SetStakeHistorySysvar(solana.SysVarStakeHistoryPubkey).
+		SetStakeAuthority(pubkeyOf(3))
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_Merge), data[:4])
+	require.Len(t, data, 4)
+}

--- a/programs/stake/MoveLamports_test.go
+++ b/programs/stake/MoveLamports_test.go
@@ -1,0 +1,19 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_MoveLamports(t *testing.T) {
+	inst := NewMoveLamportsInstruction(3_000_000_000, pubkeyOf(1), pubkeyOf(2), pubkeyOf(3))
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_MoveLamports), data[:4])
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	ml := decoded.Impl.(*MoveLamports)
+	require.Equal(t, uint64(3_000_000_000), *ml.Lamports)
+}

--- a/programs/stake/MoveStake_test.go
+++ b/programs/stake/MoveStake_test.go
@@ -1,0 +1,19 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_MoveStake(t *testing.T) {
+	inst := NewMoveStakeInstruction(2_000_000_000, pubkeyOf(1), pubkeyOf(2), pubkeyOf(3))
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_MoveStake), data[:4])
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	ms := decoded.Impl.(*MoveStake)
+	require.Equal(t, uint64(2_000_000_000), *ms.Lamports)
+}

--- a/programs/stake/SetLockup_test.go
+++ b/programs/stake/SetLockup_test.go
@@ -1,0 +1,30 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_SetLockup(t *testing.T) {
+	ts := int64(999)
+	epoch := uint64(100)
+	custodian := pubkeyOf(7)
+	inst := NewSetLockupInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetAuthority(pubkeyOf(2)).
+		SetLockupTimestamp(ts).
+		SetLockupEpoch(epoch).
+		SetCustodian(custodian)
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_SetLockup), data[:4])
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	sl := decoded.Impl.(*SetLockup)
+	require.Equal(t, ts, *sl.LockupArgs.UnixTimestamp)
+	require.Equal(t, epoch, *sl.LockupArgs.Epoch)
+	require.Equal(t, custodian, *sl.LockupArgs.Custodian)
+}

--- a/programs/stake/Split_test.go
+++ b/programs/stake/Split_test.go
@@ -1,0 +1,22 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_Split(t *testing.T) {
+	inst := NewSplitInstruction(1_000_000_000, pubkeyOf(1), pubkeyOf(2), pubkeyOf(3))
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_Split), data[:4])
+
+	expected := concat(u32LE(3), u64LE(1_000_000_000))
+	require.Equal(t, expected, data)
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	split := decoded.Impl.(*Split)
+	require.Equal(t, uint64(1_000_000_000), *split.Lamports)
+}

--- a/programs/stake/Withdraw_test.go
+++ b/programs/stake/Withdraw_test.go
@@ -1,0 +1,27 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip_Withdraw(t *testing.T) {
+	inst := NewWithdrawInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetRecipientAccount(pubkeyOf(2)).
+		SetClockSysvar(solana.SysVarClockPubkey).
+		SetStakeHistorySysvar(solana.SysVarStakeHistoryPubkey).
+		SetWithdrawAuthority(pubkeyOf(3)).
+		SetLamports(500_000)
+
+	data, err := encodeInst(inst)
+	require.NoError(t, err)
+	require.Equal(t, u32LE(Instruction_Withdraw), data[:4])
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	w := decoded.Impl.(*Withdraw)
+	require.Equal(t, uint64(500_000), *w.Lamports)
+}

--- a/programs/stake/instructions_test.go
+++ b/programs/stake/instructions_test.go
@@ -1,0 +1,28 @@
+package stake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstructionIDValues(t *testing.T) {
+	require.Equal(t, uint32(0), Instruction_Initialize)
+	require.Equal(t, uint32(1), Instruction_Authorize)
+	require.Equal(t, uint32(2), Instruction_DelegateStake)
+	require.Equal(t, uint32(3), Instruction_Split)
+	require.Equal(t, uint32(4), Instruction_Withdraw)
+	require.Equal(t, uint32(5), Instruction_Deactivate)
+	require.Equal(t, uint32(6), Instruction_SetLockup)
+	require.Equal(t, uint32(7), Instruction_Merge)
+	require.Equal(t, uint32(8), Instruction_AuthorizeWithSeed)
+	require.Equal(t, uint32(9), Instruction_InitializeChecked)
+	require.Equal(t, uint32(10), Instruction_AuthorizeChecked)
+	require.Equal(t, uint32(11), Instruction_AuthorizeCheckedWithSeed)
+	require.Equal(t, uint32(12), Instruction_SetLockupChecked)
+	require.Equal(t, uint32(13), Instruction_GetMinimumDelegation)
+	require.Equal(t, uint32(14), Instruction_DeactivateDelinquent)
+	require.Equal(t, uint32(15), Instruction_Redelegate)
+	require.Equal(t, uint32(16), Instruction_MoveStake)
+	require.Equal(t, uint32(17), Instruction_MoveLamports)
+}

--- a/programs/stake/state.go
+++ b/programs/stake/state.go
@@ -1,0 +1,310 @@
+package stake
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+)
+
+// StakeAccountSize is the fixed size of a stake account (200 bytes).
+const StakeAccountSize = 200
+
+// StakeStateType identifies the variant of a StakeStateV2 account.
+type StakeStateType uint32
+
+// StakeStateV2 discriminator values (u32 LE).
+const (
+	StakeStateUninitialized StakeStateType = 0
+	StakeStateInitialized   StakeStateType = 1
+	StakeStateStake         StakeStateType = 2
+	StakeStateRewardsPool   StakeStateType = 3
+)
+
+// StakeFlags is a bitflags wrapper for stake account flags.
+type StakeFlags struct {
+	Bits uint8
+}
+
+var (
+	StakeFlagsEmpty = StakeFlags{Bits: 0}
+	// MustFullyActivateBeforeDeactivationIsPermitted is deprecated (was for redelegate).
+	StakeFlagsMustFullyActivateBeforeDeactivationIsPermitted = StakeFlags{Bits: 0b0000_0001}
+)
+
+// Delegation contains the delegation information for a stake account.
+type Delegation struct {
+	// Voter public key to which the stake is delegated.
+	VoterPubkey solana.PublicKey
+	// Activated stake amount in lamports.
+	Stake uint64
+	// Epoch at which the stake was activated.
+	ActivationEpoch uint64
+	// Epoch at which the stake was deactivated (u64::MAX means not deactivated).
+	DeactivationEpoch uint64
+	// Warmup/cooldown rate (deprecated since 1.16.7).
+	WarmupCooldownRate float64
+}
+
+func (d *Delegation) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	v, err := dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	d.VoterPubkey = solana.PublicKeyFromBytes(v)
+
+	d.Stake, err = dec.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	d.ActivationEpoch, err = dec.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	d.DeactivationEpoch, err = dec.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	bits, err := dec.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	d.WarmupCooldownRate = math.Float64frombits(bits)
+	return nil
+}
+
+func (d Delegation) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteBytes(d.VoterPubkey[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(d.Stake, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(d.ActivationEpoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(d.DeactivationEpoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(math.Float64bits(d.WarmupCooldownRate), binary.LittleEndian); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StakeInfo contains the staking information (Delegation + credits_observed).
+type StakeInfo struct {
+	Delegation      Delegation
+	CreditsObserved uint64
+}
+
+func (s *StakeInfo) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Delegation.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	var err error
+	s.CreditsObserved, err = dec.ReadUint64(binary.LittleEndian)
+	return err
+}
+
+func (s StakeInfo) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Delegation.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return enc.WriteUint64(s.CreditsObserved, binary.LittleEndian)
+}
+
+// Meta contains the metadata for a stake account.
+type Meta struct {
+	// Rent exempt reserve in lamports (deprecated since 3.0.1).
+	RentExemptReserve uint64
+	// Authorization settings.
+	Authorized StateAuthorized
+	// Lockup settings.
+	Lockup StateLockup
+}
+
+// StateAuthorized is the on-chain Authorized struct (non-optional pubkeys).
+// This differs from the instruction-level Authorized struct which uses pointer fields.
+type StateAuthorized struct {
+	Staker     solana.PublicKey
+	Withdrawer solana.PublicKey
+}
+
+// StateLockup is the on-chain Lockup struct (non-optional fields).
+// This differs from the instruction-level Lockup struct which uses pointer fields.
+type StateLockup struct {
+	UnixTimestamp int64
+	Epoch         uint64
+	Custodian     solana.PublicKey
+}
+
+func (m *Meta) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	m.RentExemptReserve, err = dec.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	// Authorized.Staker
+	v, err := dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	m.Authorized.Staker = solana.PublicKeyFromBytes(v)
+	// Authorized.Withdrawer
+	v, err = dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	m.Authorized.Withdrawer = solana.PublicKeyFromBytes(v)
+	// Lockup.UnixTimestamp
+	m.Lockup.UnixTimestamp, err = dec.ReadInt64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	// Lockup.Epoch
+	m.Lockup.Epoch, err = dec.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	// Lockup.Custodian
+	v, err = dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	m.Lockup.Custodian = solana.PublicKeyFromBytes(v)
+	return nil
+}
+
+func (m Meta) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteUint64(m.RentExemptReserve, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(m.Authorized.Staker[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(m.Authorized.Withdrawer[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteInt64(m.Lockup.UnixTimestamp, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(m.Lockup.Epoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(m.Lockup.Custodian[:], false); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StakeStateV2 represents the on-chain state of a stake account.
+// The account is always 200 bytes. The discriminator (u32 LE) determines the variant.
+type StakeStateV2 struct {
+	// Discriminator: 0=Uninitialized, 1=Initialized, 2=Stake, 3=RewardsPool
+	Type StakeStateType
+	// Meta is present for Initialized and Stake variants (Type 1 or 2).
+	Meta *Meta
+	// Stake is present only for the Stake variant (Type 2).
+	Stake *StakeInfo
+	// Flags is present only for the Stake variant (Type 2).
+	Flags *StakeFlags
+}
+
+// IsUninitialized returns true if the stake account is uninitialized.
+func (s *StakeStateV2) IsUninitialized() bool { return s.Type == StakeStateUninitialized }
+
+// IsInitialized returns true if the stake account is initialized but not staked.
+func (s *StakeStateV2) IsInitialized() bool { return s.Type == StakeStateInitialized }
+
+// IsStake returns true if the stake account is staked (delegated).
+func (s *StakeStateV2) IsStake() bool { return s.Type == StakeStateStake }
+
+// IsRewardsPool returns true if the stake account is a rewards pool.
+func (s *StakeStateV2) IsRewardsPool() bool { return s.Type == StakeStateRewardsPool }
+
+func (s *StakeStateV2) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	raw, err := dec.ReadUint32(binary.LittleEndian)
+	s.Type = StakeStateType(raw)
+	if err != nil {
+		return err
+	}
+	switch s.Type {
+	case StakeStateUninitialized, StakeStateRewardsPool:
+		// No additional data.
+	case StakeStateInitialized:
+		s.Meta = new(Meta)
+		if err := s.Meta.UnmarshalWithDecoder(dec); err != nil {
+			return err
+		}
+	case StakeStateStake:
+		s.Meta = new(Meta)
+		if err := s.Meta.UnmarshalWithDecoder(dec); err != nil {
+			return err
+		}
+		s.Stake = new(StakeInfo)
+		if err := s.Stake.UnmarshalWithDecoder(dec); err != nil {
+			return err
+		}
+		flagByte, err := dec.ReadUint8()
+		if err != nil {
+			return err
+		}
+		s.Flags = &StakeFlags{Bits: flagByte}
+	default:
+		return fmt.Errorf("unknown stake state discriminator: %d", s.Type)
+	}
+	return nil
+}
+
+// MarshalWithEncoder encodes the state WITHOUT padding to 200 bytes.
+// On-chain accounts are always 200 bytes with trailing zero padding.
+func (s StakeStateV2) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteUint32(uint32(s.Type), binary.LittleEndian); err != nil {
+		return err
+	}
+	switch s.Type {
+	case StakeStateUninitialized, StakeStateRewardsPool:
+		// No additional data.
+	case StakeStateInitialized:
+		if s.Meta != nil {
+			if err := s.Meta.MarshalWithEncoder(enc); err != nil {
+				return err
+			}
+		}
+	case StakeStateStake:
+		if s.Meta != nil {
+			if err := s.Meta.MarshalWithEncoder(enc); err != nil {
+				return err
+			}
+		}
+		if s.Stake != nil {
+			if err := s.Stake.MarshalWithEncoder(enc); err != nil {
+				return err
+			}
+		}
+		flags := uint8(0)
+		if s.Flags != nil {
+			flags = s.Flags.Bits
+		}
+		if err := enc.WriteUint8(flags); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecodeStakeAccount decodes a StakeStateV2 from raw account data (200 bytes).
+func DecodeStakeAccount(data []byte) (*StakeStateV2, error) {
+	if len(data) < StakeAccountSize {
+		return nil, fmt.Errorf("stake account data too short: %d < %d", len(data), StakeAccountSize)
+	}
+	state := new(StakeStateV2)
+	dec := bin.NewBinDecoder(data)
+	if err := state.UnmarshalWithDecoder(dec); err != nil {
+		return nil, fmt.Errorf("unable to decode stake account: %w", err)
+	}
+	return state, nil
+}

--- a/programs/stake/state_test.go
+++ b/programs/stake/state_test.go
@@ -1,0 +1,298 @@
+package stake
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// Official test vector: borsh_deserialization_live_data
+// A real on-chain Initialized stake account (200 bytes).
+var liveInitializedStakeAccount = []byte{
+	1, 0, 0, 0, // discriminator = 1 (Initialized)
+	128, 213, 34, 0, 0, 0, 0, 0, // rent_exempt_reserve = 2282880
+	133, 0, 79, 231, 141, 29, 73, 61, // authorized.staker (32 bytes)
+	232, 35, 119, 124, 168, 12, 120, 216,
+	195, 29, 12, 166, 139, 28, 36, 182,
+	186, 154, 246, 149, 224, 109, 52, 100,
+	133, 0, 79, 231, 141, 29, 73, 61, // authorized.withdrawer (32 bytes, same as staker)
+	232, 35, 119, 124, 168, 12, 120, 216,
+	195, 29, 12, 166, 139, 28, 36, 182,
+	186, 154, 246, 149, 224, 109, 52, 100,
+	0, 0, 0, 0, 0, 0, 0, 0, // lockup.unix_timestamp = 0
+	0, 0, 0, 0, 0, 0, 0, 0, // lockup.epoch = 0
+	0, 0, 0, 0, 0, 0, 0, 0, // lockup.custodian (32 bytes, all zeros)
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	// remaining 76 bytes are zeros (padding to 200 total)
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+}
+
+func TestOfficialVector_InitializedStakeAccount(t *testing.T) {
+	require.Len(t, liveInitializedStakeAccount, 200)
+
+	state, err := DecodeStakeAccount(liveInitializedStakeAccount)
+	require.NoError(t, err)
+
+	require.True(t, state.IsInitialized())
+	require.False(t, state.IsStake())
+	require.False(t, state.IsUninitialized())
+	require.False(t, state.IsRewardsPool())
+
+	require.NotNil(t, state.Meta)
+	require.Equal(t, uint64(2282880), state.Meta.RentExemptReserve)
+
+	expectedAuth := solana.PublicKey{
+		133, 0, 79, 231, 141, 29, 73, 61,
+		232, 35, 119, 124, 168, 12, 120, 216,
+		195, 29, 12, 166, 139, 28, 36, 182,
+		186, 154, 246, 149, 224, 109, 52, 100,
+	}
+	require.Equal(t, expectedAuth, state.Meta.Authorized.Staker)
+	require.Equal(t, expectedAuth, state.Meta.Authorized.Withdrawer)
+
+	require.Equal(t, int64(0), state.Meta.Lockup.UnixTimestamp)
+	require.Equal(t, uint64(0), state.Meta.Lockup.Epoch)
+	require.Equal(t, solana.PublicKey{}, state.Meta.Lockup.Custodian)
+
+	require.Nil(t, state.Stake)
+	require.Nil(t, state.Flags)
+}
+
+func TestDecodeStakeState_Uninitialized(t *testing.T) {
+	data := make([]byte, 200)
+
+	state, err := DecodeStakeAccount(data)
+	require.NoError(t, err)
+	require.True(t, state.IsUninitialized())
+	require.Nil(t, state.Meta)
+	require.Nil(t, state.Stake)
+}
+
+func TestDecodeStakeState_RewardsPool(t *testing.T) {
+	data := make([]byte, 200)
+	binary.LittleEndian.PutUint32(data, 3)
+
+	state, err := DecodeStakeAccount(data)
+	require.NoError(t, err)
+	require.True(t, state.IsRewardsPool())
+	require.Nil(t, state.Meta)
+	require.Nil(t, state.Stake)
+}
+
+func TestDecodeStakeState_Stake(t *testing.T) {
+	data := make([]byte, 200)
+	offset := 0
+
+	binary.LittleEndian.PutUint32(data[offset:], 2)
+	offset += 4
+
+	binary.LittleEndian.PutUint64(data[offset:], 2282880)
+	offset += 8
+
+	staker := pubkeyOf(0xAA)
+	copy(data[offset:], staker[:])
+	offset += 32
+
+	withdrawer := pubkeyOf(0xBB)
+	copy(data[offset:], withdrawer[:])
+	offset += 32
+
+	binary.LittleEndian.PutUint64(data[offset:], uint64(1234567890))
+	offset += 8
+
+	binary.LittleEndian.PutUint64(data[offset:], 100)
+	offset += 8
+
+	custodian := pubkeyOf(0xCC)
+	copy(data[offset:], custodian[:])
+	offset += 32
+
+	voter := pubkeyOf(0xDD)
+	copy(data[offset:], voter[:])
+	offset += 32
+
+	binary.LittleEndian.PutUint64(data[offset:], 5_000_000_000)
+	offset += 8
+
+	binary.LittleEndian.PutUint64(data[offset:], 50)
+	offset += 8
+
+	binary.LittleEndian.PutUint64(data[offset:], ^uint64(0))
+	offset += 8
+
+	binary.LittleEndian.PutUint64(data[offset:], math.Float64bits(0.25))
+	offset += 8
+
+	binary.LittleEndian.PutUint64(data[offset:], 999)
+	offset += 8
+
+	data[offset] = 1
+	offset += 1
+
+	require.Equal(t, 197, offset)
+
+	state, err := DecodeStakeAccount(data)
+	require.NoError(t, err)
+	require.True(t, state.IsStake())
+
+	require.Equal(t, uint64(2282880), state.Meta.RentExemptReserve)
+	require.Equal(t, staker, state.Meta.Authorized.Staker)
+	require.Equal(t, withdrawer, state.Meta.Authorized.Withdrawer)
+	require.Equal(t, int64(1234567890), state.Meta.Lockup.UnixTimestamp)
+	require.Equal(t, uint64(100), state.Meta.Lockup.Epoch)
+	require.Equal(t, custodian, state.Meta.Lockup.Custodian)
+
+	require.NotNil(t, state.Stake)
+	require.Equal(t, voter, state.Stake.Delegation.VoterPubkey)
+	require.Equal(t, uint64(5_000_000_000), state.Stake.Delegation.Stake)
+	require.Equal(t, uint64(50), state.Stake.Delegation.ActivationEpoch)
+	require.Equal(t, ^uint64(0), state.Stake.Delegation.DeactivationEpoch)
+	require.Equal(t, 0.25, state.Stake.Delegation.WarmupCooldownRate)
+	require.Equal(t, uint64(999), state.Stake.CreditsObserved)
+
+	require.NotNil(t, state.Flags)
+	require.Equal(t, uint8(1), state.Flags.Bits)
+}
+
+func TestStakeFlagsOffset(t *testing.T) {
+	const flagOffset = 196
+
+	data := make([]byte, 200)
+	binary.LittleEndian.PutUint32(data, 2)
+	data[flagOffset] = 1
+
+	state, err := DecodeStakeAccount(data)
+	require.NoError(t, err)
+	require.True(t, state.IsStake())
+	require.NotNil(t, state.Flags)
+	require.Equal(t, StakeFlagsMustFullyActivateBeforeDeactivationIsPermitted.Bits, state.Flags.Bits)
+}
+
+func TestStakeStateV2_RoundTrip_Initialized(t *testing.T) {
+	state := &StakeStateV2{
+		Type: StakeStateInitialized,
+		Meta: &Meta{
+			RentExemptReserve: 2282880,
+			Authorized: StateAuthorized{
+				Staker:     pubkeyOf(1),
+				Withdrawer: pubkeyOf(2),
+			},
+			Lockup: StateLockup{
+				UnixTimestamp: 1000,
+				Epoch:         42,
+				Custodian:     pubkeyOf(3),
+			},
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	err := state.MarshalWithEncoder(bin.NewBinEncoder(buf))
+	require.NoError(t, err)
+
+	padded := make([]byte, 200)
+	copy(padded, buf.Bytes())
+
+	decoded, err := DecodeStakeAccount(padded)
+	require.NoError(t, err)
+	require.True(t, decoded.IsInitialized())
+	require.Equal(t, state.Meta.RentExemptReserve, decoded.Meta.RentExemptReserve)
+	require.Equal(t, state.Meta.Authorized.Staker, decoded.Meta.Authorized.Staker)
+	require.Equal(t, state.Meta.Authorized.Withdrawer, decoded.Meta.Authorized.Withdrawer)
+	require.Equal(t, state.Meta.Lockup.UnixTimestamp, decoded.Meta.Lockup.UnixTimestamp)
+	require.Equal(t, state.Meta.Lockup.Epoch, decoded.Meta.Lockup.Epoch)
+	require.Equal(t, state.Meta.Lockup.Custodian, decoded.Meta.Lockup.Custodian)
+}
+
+func TestStakeStateV2_RoundTrip_Stake(t *testing.T) {
+	state := &StakeStateV2{
+		Type: StakeStateStake,
+		Meta: &Meta{
+			RentExemptReserve: 2282880,
+			Authorized: StateAuthorized{
+				Staker:     pubkeyOf(1),
+				Withdrawer: pubkeyOf(2),
+			},
+			Lockup: StateLockup{},
+		},
+		Stake: &StakeInfo{
+			Delegation: Delegation{
+				VoterPubkey:        pubkeyOf(5),
+				Stake:              1_000_000_000,
+				ActivationEpoch:    100,
+				DeactivationEpoch:  ^uint64(0),
+				WarmupCooldownRate: 0.25,
+			},
+			CreditsObserved: 500,
+		},
+		Flags: &StakeFlags{Bits: 0},
+	}
+
+	buf := new(bytes.Buffer)
+	err := state.MarshalWithEncoder(bin.NewBinEncoder(buf))
+	require.NoError(t, err)
+	require.Equal(t, 197, buf.Len())
+
+	padded := make([]byte, 200)
+	copy(padded, buf.Bytes())
+
+	decoded, err := DecodeStakeAccount(padded)
+	require.NoError(t, err)
+	require.True(t, decoded.IsStake())
+	require.Equal(t, pubkeyOf(5), decoded.Stake.Delegation.VoterPubkey)
+	require.Equal(t, uint64(1_000_000_000), decoded.Stake.Delegation.Stake)
+	require.Equal(t, uint64(100), decoded.Stake.Delegation.ActivationEpoch)
+	require.Equal(t, ^uint64(0), decoded.Stake.Delegation.DeactivationEpoch)
+	require.Equal(t, 0.25, decoded.Stake.Delegation.WarmupCooldownRate)
+	require.Equal(t, uint64(500), decoded.Stake.CreditsObserved)
+	require.Equal(t, uint8(0), decoded.Flags.Bits)
+}
+
+func TestStakeAccountSize(t *testing.T) {
+	require.Equal(t, 200, StakeAccountSize)
+
+	state := &StakeStateV2{
+		Type: StakeStateInitialized,
+		Meta: &Meta{},
+	}
+	buf := new(bytes.Buffer)
+	err := state.MarshalWithEncoder(bin.NewBinEncoder(buf))
+	require.NoError(t, err)
+	require.Equal(t, 124, buf.Len())
+
+	state = &StakeStateV2{
+		Type:  StakeStateStake,
+		Meta:  &Meta{},
+		Stake: &StakeInfo{},
+		Flags: &StakeFlags{},
+	}
+	buf = new(bytes.Buffer)
+	err = state.MarshalWithEncoder(bin.NewBinEncoder(buf))
+	require.NoError(t, err)
+	require.Equal(t, 197, buf.Len())
+}
+
+func TestDecodeStakeAccount_TooShort(t *testing.T) {
+	data := make([]byte, 100)
+	_, err := DecodeStakeAccount(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too short")
+}
+
+func TestDecodeStakeAccount_InvalidDiscriminator(t *testing.T) {
+	data := make([]byte, 200)
+	binary.LittleEndian.PutUint32(data, 99)
+	_, err := DecodeStakeAccount(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown stake state discriminator")
+}

--- a/programs/stake/testing_utils_test.go
+++ b/programs/stake/testing_utils_test.go
@@ -1,0 +1,40 @@
+package stake
+
+import (
+	"encoding/binary"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+func pubkeyOf(v byte) solana.PublicKey {
+	var pk solana.PublicKey
+	for i := range pk {
+		pk[i] = v
+	}
+	return pk
+}
+
+func u32LE(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return b
+}
+
+func u64LE(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, v)
+	return b
+}
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+func encodeInst(inst interface{ Build() *Instruction }) ([]byte, error) {
+	built := inst.Build()
+	return built.Data()
+}


### PR DESCRIPTION
### Problem

stake program implementation covered all instructions but was missing the on-chain account state types needed to read stake accounts from RPC
users could build and send staking transactions but couldn't decode the returned account data to inspect delegation status, authorities, lockup, or stake flags
the program also had zero test coverage

### Summary of Changes

- added on-chain state types: StakeStateV2, Meta, StateAuthorized, etc, and DecodeStakeAccount convenience fn
- added StakeStateType named type for discriminator constants

related to https://github.com/solana-foundation/solana-go/issues/352