### PR TITLE
Upgrade go.mongodb.org/mongo-driver to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gagliardetto/treeout v0.1.4
 	github.com/google/uuid v1.6.0
 	github.com/mr-tron/base58 v1.2.0
+	go.mongodb.org/mongo-driver/v2 v2.5.0
 )
 
 require (
@@ -77,7 +78,6 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e
 	github.com/stretchr/testify v1.11.1
-	go.mongodb.org/mongo-driver v1.17.3
 	go.uber.org/ratelimit v0.3.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
-go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
+go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=

--- a/keys.go
+++ b/keys.go
@@ -32,8 +32,7 @@ import (
 	"filippo.io/edwards25519"
 	"github.com/gagliardetto/solana-go/base58"
 	mrtronbase58 "github.com/mr-tron/base58"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type PrivateKey []byte
@@ -256,12 +255,12 @@ func (p *PublicKey) UnmarshalBSON(data []byte) (err error) {
 }
 
 // MarshalBSONValue implements the bson.ValueMarshaler interface.
-func (p PublicKey) MarshalBSONValue() (bsontype.Type, []byte, error) {
+func (p PublicKey) MarshalBSONValue() (bson.Type, []byte, error) {
 	return bson.MarshalValue(p.String())
 }
 
 // UnmarshalBSONValue implements the bson.ValueUnmarshaler interface.
-func (p *PublicKey) UnmarshalBSONValue(t bsontype.Type, data []byte) (err error) {
+func (p *PublicKey) UnmarshalBSONValue(t bson.Type, data []byte) (err error) {
 	var s string
 	if err := bson.UnmarshalValue(t, data, &s); err != nil {
 		return err


### PR DESCRIPTION
The v1 version has been marked as deprecated. Version v2 includes multiple fixes and improvements, particularly addressing several BSON-related vulnerabilities.