### PR TITLE
Optimize IsOnCurve and upgrade edwards25519

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0
+	filippo.io/edwards25519 v1.2.0
 	github.com/AlekSi/pointer v1.2.0
 	github.com/buger/jsonparser v1.1.2
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
-filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/AlekSi/pointer v1.2.0 h1:glcy/gc4h8HnG2Z3ZECSzZ1IX1x2JxRVuDzaJwQE0+w=
 github.com/AlekSi/pointer v1.2.0/go.mod h1:gZGfd3dpW4vEc/UlyfKKi1roIqcCgwOIvb0tSNSBle0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/keys.go
+++ b/keys.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"sort"
 
-	"filippo.io/edwards25519"
+	"filippo.io/edwards25519/field"
 	"github.com/gagliardetto/solana-go/base58"
 	mrtronbase58 "github.com/mr-tron/base58"
 	"go.mongodb.org/mongo-driver/bson"
@@ -679,14 +679,35 @@ func CreateProgramAddress(seeds [][]byte, programID PublicKey) (PublicKey, error
 	return PublicKeyFromBytes(hash[:]), nil
 }
 
+var feOne = new(field.Element).One()
+var d, _ = new(field.Element).SetBytes([]byte{
+	0xa3, 0x78, 0x59, 0x13, 0xca, 0x4d, 0xeb, 0x75,
+	0xab, 0xd8, 0x41, 0x41, 0x4d, 0x0a, 0x70, 0x00,
+	0x98, 0xe8, 0x79, 0x77, 0x79, 0x40, 0xc7, 0x8c,
+	0x73, 0xfe, 0x6f, 0x2b, 0xee, 0x6c, 0x03, 0x52})
+
 // Check if the provided `b` is on the ed25519 curve.
 func IsOnCurve(b []byte) bool {
 	if len(b) != ed25519.PublicKeySize {
 		return false
 	}
-	_, err := new(edwards25519.Point).SetBytes(b)
-	isOnCurve := err == nil
-	return isOnCurve
+	//_, err := new(edwards25519.Point).SetBytes(b)
+	y, err := new(field.Element).SetBytes(b)
+	if err != nil {
+		return false
+	}
+
+	y2 := new(field.Element).Square(y)
+	u := new(field.Element).Subtract(y2, feOne)
+
+	vv := new(field.Element).Multiply(y2, d)
+	vv = vv.Add(vv, feOne)
+
+	_, wasSquare := new(field.Element).SqrtRatio(u, vv)
+	if wasSquare == 0 {
+		return false
+	}
+	return true
 }
 
 // Find a valid program address and its corresponding bump seed.


### PR DESCRIPTION
## 1. Optimize IsOnCurve implementation

The original implementation relied on:

```go
new(edwards25519.Point).SetBytes(b)
```
to determine whether a public key lies on the Ed25519 curve. However, `SetBytes` performs additional computations after deriving `wasSquare`, which are unnecessary for this validation use case.

This PR inlines the relevant logic from `SetBytes` and removes the redundant steps, resulting in a more efficient `IsOnCurve` check without changing its behavior.

## 2. Upgrade filippo.io/edwards25519 to v1.2.0

Upgraded from v1.1.0 to v1.2.0 to address a known vulnerability: [CVE-2026-26958](https://www.mend.io/vulnerability-database/CVE-2026-26958/)

Although this issue does not directly impact `solana-go`, upgrading ensures better security hygiene and avoids potential future risks.