### PR TITLE
Add `changedSinceSlot` on account fetch operations

### DIFF
--- a/rpc/getAccountInfo.go
+++ b/rpc/getAccountInfo.go
@@ -85,6 +85,9 @@ type GetAccountInfoOpts struct {
 	// The minimum slot that the request can be evaluated at.
 	// This parameter is optional.
 	MinContextSlot *uint64
+
+	// Return only if the account(s) have changed since this slot
+	ChangedSinceSlot *uint64 `json:"changedSinceSlot,omitempty"`
 }
 
 // GetAccountInfoWithOpts returns all information associated with the account of provided publicKey.
@@ -134,6 +137,9 @@ func (cl *Client) getAccountInfoWithOpts(
 		}
 		if opts.MinContextSlot != nil {
 			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if opts.ChangedSinceSlot != nil {
+			obj["changedSinceSlot"] = *opts.ChangedSinceSlot
 		}
 	}
 

--- a/rpc/getAccountInfo.go
+++ b/rpc/getAccountInfo.go
@@ -85,6 +85,21 @@ type GetAccountInfoOpts struct {
 	// The minimum slot that the request can be evaluated at.
 	// This parameter is optional.
 	MinContextSlot *uint64
+
+	// ChangedSinceSlot, if set, asks the RPC node to return account data only
+	// when it has changed since the given slot. Useful for incremental sync of
+	// large programs (e.g. PumpFun) where a full getProgramAccounts is no longer
+	// feasible.
+	//
+	// NOTE: This is NOT part of the official Solana JSON-RPC specification
+	// (https://solana.com/docs/rpc/http). It is a non-standard extension
+	// supported by some commercial RPC providers (e.g. Helius, FluxRPC).
+	// Public RPC endpoints and stock agave-validator nodes will ignore this
+	// field or reject the request. Verify support with your provider before
+	// using.
+	//
+	// This parameter is optional.
+	ChangedSinceSlot *uint64 `json:"changedSinceSlot,omitempty"`
 }
 
 // GetAccountInfoWithOpts returns all information associated with the account of provided publicKey.
@@ -134,6 +149,9 @@ func (cl *Client) getAccountInfoWithOpts(
 		}
 		if opts.MinContextSlot != nil {
 			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if opts.ChangedSinceSlot != nil {
+			obj["changedSinceSlot"] = *opts.ChangedSinceSlot
 		}
 	}
 

--- a/rpc/getMultipleAccounts.go
+++ b/rpc/getMultipleAccounts.go
@@ -68,6 +68,9 @@ func (cl *Client) GetMultipleAccountsWithOpts(
 		if opts.MinContextSlot != nil {
 			obj["minContextSlot"] = *opts.MinContextSlot
 		}
+		if opts.ChangedSinceSlot != nil {
+			obj["changedSinceSlot"] = *opts.ChangedSinceSlot
+		}
 		if len(obj) > 0 {
 			params = append(params, obj)
 		}

--- a/rpc/getProgramAccounts.go
+++ b/rpc/getProgramAccounts.go
@@ -59,6 +59,9 @@ func (cl *Client) GetProgramAccountsWithOpts(
 				"length": opts.DataSlice.Length,
 			}
 		}
+		if opts.ChangedSinceSlot != nil {
+			obj["changedSinceSlot"] = *opts.ChangedSinceSlot
+		}
 	}
 
 	params := []any{publicKey, obj}

--- a/rpc/getProgramAccounts.go
+++ b/rpc/getProgramAccounts.go
@@ -84,6 +84,9 @@ func buildGetProgramAccountsParams(publicKey solana.PublicKey, opts *GetProgramA
 				"length": opts.DataSlice.Length,
 			}
 		}
+		if opts.ChangedSinceSlot != nil {
+			obj["changedSinceSlot"] = *opts.ChangedSinceSlot
+		}
 		if opts.WithContext != nil {
 			obj["withContext"] = *opts.WithContext
 		}

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -406,6 +406,9 @@ type GetProgramAccountsOpts struct {
 	// Filter results using various filter objects;
 	// account must meet all filter criteria to be included in results.
 	Filters []RPCFilter `json:"filters,omitempty"`
+
+	// Return only the accounts that have changed since this slot
+	ChangedSinceSlot *uint64 `json:"changedSinceSlot,omitempty"`
 }
 
 type GetProgramAccountsResult []*KeyedAccount

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -461,6 +461,21 @@ type GetProgramAccountsOpts struct {
 	// account must meet all filter criteria to be included in results.
 	Filters []RPCFilter `json:"filters,omitempty"`
 
+	// ChangedSinceSlot, if set, asks the RPC node to return account data only
+	// when it has changed since the given slot. Useful for incremental sync of
+	// large programs (e.g. PumpFun) where a full getProgramAccounts is no longer
+	// feasible.
+	//
+	// NOTE: This is NOT part of the official Solana JSON-RPC specification
+	// (https://solana.com/docs/rpc/http). It is a non-standard extension
+	// supported by some commercial RPC providers (e.g. Helius, FluxRPC).
+	// Public RPC endpoints and stock agave-validator nodes will ignore this
+	// field or reject the request. Verify support with your provider before
+	// using.
+	//
+	// This parameter is optional.
+	ChangedSinceSlot *uint64 `json:"changedSinceSlot,omitempty"`
+
 	// Wrap the result in an RpcResponse JSON object with context.
 	WithContext *bool `json:"withContext,omitempty"`
 


### PR DESCRIPTION
FluxRPC & Helius both offer `changedSinceSlot` arg for account fetch calls - this significantly reduces the gPA data loads needed for keeping 3rd party services in sync as incremental sync can be done rather than fetching full account state data.

Especially useful for large programs such as PumpFun (most RPCs disallow a full gPA on this program now) 