### PR TITLE
Add IsTokenMint helper

### DIFF
--- a/rpc/util.go
+++ b/rpc/util.go
@@ -1,0 +1,23 @@
+package rpc
+
+import "github.com/gagliardetto/solana-go"
+
+func IsTokenMint(acc *Account) bool {
+	data := acc.Data.GetBinary()
+	n := len(data)
+
+	switch acc.Owner {
+	case solana.TokenProgramID:
+		return n == 82
+	case solana.Token2022ProgramID:
+		if n == 82 {
+			return true //Normal Mint
+		}
+		if n <= 165 {
+			return false //Normal Token Account
+		}
+		return data[165] == 1 // Mint Extensions
+	}
+
+	return false
+}


### PR DESCRIPTION
When working with Token2022 determining token mint is a bit annoying

Helper takes raw account and checks the data len + byte to check if its a mint correctly


We could add this as its own helper in token_2022 but thought it sat better pre-decode