### PR TITLE
perf(message): eliminate complex scans, struct copies, and redundant allocs

### DIFF
--- a/message.go
+++ b/message.go
@@ -450,9 +450,7 @@ func (mx *Message) GetAddressTableLookupAccounts() (PublicKeySlice, error) {
 	numWritable := mx.AddressTableLookups.NumWritableLookups()
 	numTotal := mx.AddressTableLookups.NumLookups()
 
-	// Single allocation: writable accounts first, then readonly.
-	all := make(PublicKeySlice, 0, numTotal)
-	writable := all[:0:numWritable]
+	writable := make(PublicKeySlice, 0, numWritable)
 	readonly := make(PublicKeySlice, 0, numTotal-numWritable)
 
 	for i := range mx.AddressTableLookups {
@@ -524,8 +522,10 @@ func (mx *Message) GetAllKeys() (keys PublicKeySlice, err error) {
 	if err != nil {
 		return keys, err
 	}
-	// ...and return the account keys with the lookups appended:
-	return append(mx.AccountKeys, atlAccounts...), nil
+	// Return a new slice to avoid mutating mx.AccountKeys' backing array.
+	all := make(PublicKeySlice, len(mx.AccountKeys), len(mx.AccountKeys)+len(atlAccounts))
+	copy(all, mx.AccountKeys)
+	return append(all, atlAccounts...), nil
 }
 
 func (mx *Message) getStaticKeys() (keys PublicKeySlice) {
@@ -855,15 +855,14 @@ func (m *Message) numStaticAccounts() int {
 func (m *Message) IsWritableStatic(account PublicKey) bool {
 	// check only the static accounts (i.e. not the ones in the address table lookups); no check preconditions needed.
 	accountKeys := m.getStaticKeys()
-	index := 0
-	found := false
+	index := -1
 	for idx, acc := range accountKeys {
 		if acc == account {
-			found = true
 			index = idx
+			break
 		}
 	}
-	if !found {
+	if index < 0 {
 		return false
 	}
 	h := m.Header
@@ -885,15 +884,14 @@ func (m *Message) IsWritable(account PublicKey) (bool, error) {
 		return false, err
 	}
 
-	index := 0
-	found := false
+	index := -1
 	for idx, acc := range accountKeys {
 		if acc == account {
-			found = true
 			index = idx
+			break
 		}
 	}
-	if !found {
+	if index < 0 {
 		return false, nil
 	}
 	return m.uncheckedAccountIndexIsWritable(index), nil
@@ -920,6 +918,82 @@ func (m *Message) uncheckedAccountIndexIsWritable(index int) bool {
 
 func (m *Message) signerKeys() PublicKeySlice {
 	return m.AccountKeys[0:m.Header.NumRequiredSignatures]
+}
+
+// ProgramIDs returns the deduplicated list of program IDs used by the message's instructions.
+func (m *Message) ProgramIDs() PublicKeySlice {
+	seen := make(map[PublicKey]struct{})
+	out := make(PublicKeySlice, 0, len(m.Instructions))
+	for i := range m.Instructions {
+		idx := m.Instructions[i].ProgramIDIndex
+		if int(idx) < len(m.AccountKeys) {
+			key := m.AccountKeys[idx]
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				out = append(out, key)
+			}
+		}
+	}
+	return out
+}
+
+// IsInstructionAccount returns true if the given account index is referenced as
+// an account (not a program) in any instruction.
+func (m *Message) IsInstructionAccount(index uint16) bool {
+	for i := range m.Instructions {
+		for _, acctIdx := range m.Instructions[i].Accounts {
+			if acctIdx == index {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ProgramPosition returns the 0-based position of the account at the given index
+// among all program IDs invoked by the message. Returns (pos, true) if found,
+// or (0, false) if the account is not a program ID.
+func (m *Message) ProgramPosition(index uint16) (int, bool) {
+	pos := 0
+	seen := make(map[uint16]struct{})
+	for i := range m.Instructions {
+		progIdx := m.Instructions[i].ProgramIDIndex
+		if _, ok := seen[progIdx]; !ok {
+			seen[progIdx] = struct{}{}
+			if progIdx == index {
+				return pos, true
+			}
+			pos++
+		}
+	}
+	return 0, false
+}
+
+// NumReadonlyAccounts returns the total number of readonly accounts (signed + unsigned)
+// in the static account list.
+func (m *Message) NumReadonlyAccounts() int {
+	return int(m.Header.NumReadonlySignedAccounts) + int(m.Header.NumReadonlyUnsignedAccounts)
+}
+
+// GetIxSigners returns the set of account keys that are both signers and referenced
+// as accounts (not program) in the instruction at the given index.
+func (m *Message) GetIxSigners(ixIndex int) PublicKeySlice {
+	if ixIndex < 0 || ixIndex >= len(m.Instructions) {
+		return nil
+	}
+	ix := m.Instructions[ixIndex]
+	seen := make(map[PublicKey]struct{}, len(ix.Accounts))
+	var out PublicKeySlice
+	for _, acctIdx := range ix.Accounts {
+		if m.accountIndexIsSigner(int(acctIdx)) && int(acctIdx) < len(m.AccountKeys) {
+			key := m.AccountKeys[acctIdx]
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				out = append(out, key)
+			}
+		}
+	}
+	return out
 }
 
 type MessageHeader struct {

--- a/message.go
+++ b/message.go
@@ -32,9 +32,9 @@ type MessageAddressTableLookupSlice []MessageAddressTableLookup
 // NumLookups returns the number of accounts from all the lookups.
 func (lookups MessageAddressTableLookupSlice) NumLookups() int {
 	count := 0
-	for _, lookup := range lookups {
-		count += len(lookup.ReadonlyIndexes)
-		count += len(lookup.WritableIndexes)
+	for i := range lookups {
+		count += len(lookups[i].ReadonlyIndexes)
+		count += len(lookups[i].WritableIndexes)
 	}
 	return count
 }
@@ -43,8 +43,8 @@ func (lookups MessageAddressTableLookupSlice) NumLookups() int {
 // across all the lookups (all the address tables).
 func (lookups MessageAddressTableLookupSlice) NumWritableLookups() int {
 	count := 0
-	for _, lookup := range lookups {
-		count += len(lookup.WritableIndexes)
+	for i := range lookups {
+		count += len(lookups[i].WritableIndexes)
 	}
 	return count
 }
@@ -178,14 +178,14 @@ func (mx *Message) GetAddressTableLookups() MessageAddressTableLookupSlice {
 	return mx.AddressTableLookups
 }
 
-func (mx Message) NumLookups() int {
+func (mx *Message) NumLookups() int {
 	if mx.AddressTableLookups == nil {
 		return 0
 	}
 	return mx.AddressTableLookups.NumLookups()
 }
 
-func (mx Message) NumWritableLookups() int {
+func (mx *Message) NumWritableLookups() int {
 	if mx.AddressTableLookups == nil {
 		return 0
 	}
@@ -294,11 +294,18 @@ func (mx *Message) MarshalBinary() ([]byte, error) {
 }
 
 func (mx *Message) MarshalLegacy() ([]byte, error) {
-	buf := []byte{
+	// Estimate buffer size: 3 (header) + compactU16 + 32*keys + 32 (blockhash) + instructions.
+	estimatedSize := 3 + 3 + 32*len(mx.AccountKeys) + 32 + 3
+	for i := range mx.Instructions {
+		estimatedSize += 1 + 3 + len(mx.Instructions[i].Accounts) + 3 + len(mx.Instructions[i].Data)
+	}
+
+	buf := make([]byte, 0, estimatedSize)
+	buf = append(buf,
 		mx.Header.NumRequiredSignatures,
 		mx.Header.NumReadonlySignedAccounts,
 		mx.Header.NumReadonlyUnsignedAccounts,
-	}
+	)
 
 	bin.EncodeCompactU16Length(&buf, len(mx.AccountKeys))
 	for _, key := range mx.AccountKeys {
@@ -308,47 +315,20 @@ func (mx *Message) MarshalLegacy() ([]byte, error) {
 	buf = append(buf, mx.RecentBlockhash[:]...)
 
 	bin.EncodeCompactU16Length(&buf, len(mx.Instructions))
-	for _, instruction := range mx.Instructions {
-		buf = append(buf, byte(instruction.ProgramIDIndex))
-		bin.EncodeCompactU16Length(&buf, len(instruction.Accounts))
-		for _, accountIdx := range instruction.Accounts {
+	for i := range mx.Instructions {
+		buf = append(buf, byte(mx.Instructions[i].ProgramIDIndex))
+		bin.EncodeCompactU16Length(&buf, len(mx.Instructions[i].Accounts))
+		for _, accountIdx := range mx.Instructions[i].Accounts {
 			buf = append(buf, byte(accountIdx))
 		}
 
-		bin.EncodeCompactU16Length(&buf, len(instruction.Data))
-		buf = append(buf, instruction.Data...)
+		bin.EncodeCompactU16Length(&buf, len(mx.Instructions[i].Data))
+		buf = append(buf, mx.Instructions[i].Data...)
 	}
 	return buf, nil
 }
 
 func (mx *Message) MarshalV0() ([]byte, error) {
-	buf := []byte{
-		mx.Header.NumRequiredSignatures,
-		mx.Header.NumReadonlySignedAccounts,
-		mx.Header.NumReadonlyUnsignedAccounts,
-	}
-	{
-		// Encode only the keys that are not in the address table lookups.
-		staticAccountKeys := mx.getStaticKeys()
-		bin.EncodeCompactU16Length(&buf, len(staticAccountKeys))
-		for _, key := range staticAccountKeys {
-			buf = append(buf, key[:]...)
-		}
-
-		buf = append(buf, mx.RecentBlockhash[:]...)
-
-		bin.EncodeCompactU16Length(&buf, len(mx.Instructions))
-		for _, instruction := range mx.Instructions {
-			buf = append(buf, byte(instruction.ProgramIDIndex))
-			bin.EncodeCompactU16Length(&buf, len(instruction.Accounts))
-			for _, accountIdx := range instruction.Accounts {
-				buf = append(buf, byte(accountIdx))
-			}
-
-			bin.EncodeCompactU16Length(&buf, len(instruction.Data))
-			buf = append(buf, instruction.Data...)
-		}
-	}
 	// The actual Solana version number is the Go enum value minus 1
 	// (MessageVersionV0=1 maps to Solana version 0).
 	// The wire prefix is messageVersionPrefix (0x80) OR'd with the version number.
@@ -356,18 +336,59 @@ func (mx *Message) MarshalV0() ([]byte, error) {
 	if solanaVersion > 0x7F {
 		return nil, fmt.Errorf("invalid message version: %d", mx.version)
 	}
-	buf = append([]byte{messageVersionPrefix | solanaVersion}, buf...)
+
+	staticAccountKeys := mx.getStaticKeys()
+
+	// Estimate buffer size: 1 (version) + 3 (header) + compactU16 + 32*keys + 32 (blockhash) + instructions + lookups.
+	estimatedSize := 1 + 3 + 3 + 32*len(staticAccountKeys) + 32 + 3
+	for i := range mx.Instructions {
+		estimatedSize += 1 + 3 + len(mx.Instructions[i].Accounts) + 3 + len(mx.Instructions[i].Data)
+	}
+	estimatedSize += 3 // lookups length
+	for i := range mx.AddressTableLookups {
+		estimatedSize += 32 + 3 + len(mx.AddressTableLookups[i].WritableIndexes) + 3 + len(mx.AddressTableLookups[i].ReadonlyIndexes)
+	}
+
+	// Write version prefix first to avoid a full-buffer prepend copy.
+	buf := make([]byte, 0, estimatedSize)
+	buf = append(buf, messageVersionPrefix|solanaVersion)
+
+	buf = append(buf,
+		mx.Header.NumRequiredSignatures,
+		mx.Header.NumReadonlySignedAccounts,
+		mx.Header.NumReadonlyUnsignedAccounts,
+	)
+
+	// Encode only the keys that are not in the address table lookups.
+	bin.EncodeCompactU16Length(&buf, len(staticAccountKeys))
+	for _, key := range staticAccountKeys {
+		buf = append(buf, key[:]...)
+	}
+
+	buf = append(buf, mx.RecentBlockhash[:]...)
+
+	bin.EncodeCompactU16Length(&buf, len(mx.Instructions))
+	for i := range mx.Instructions {
+		buf = append(buf, byte(mx.Instructions[i].ProgramIDIndex))
+		bin.EncodeCompactU16Length(&buf, len(mx.Instructions[i].Accounts))
+		for _, accountIdx := range mx.Instructions[i].Accounts {
+			buf = append(buf, byte(accountIdx))
+		}
+
+		bin.EncodeCompactU16Length(&buf, len(mx.Instructions[i].Data))
+		buf = append(buf, mx.Instructions[i].Data...)
+	}
 
 	bin.EncodeCompactU16Length(&buf, len(mx.AddressTableLookups))
-	for _, lookup := range mx.AddressTableLookups {
+	for i := range mx.AddressTableLookups {
 		// write account pubkey
-		buf = append(buf, lookup.AccountKey[:]...)
+		buf = append(buf, mx.AddressTableLookups[i].AccountKey[:]...)
 		// write writable indexes
-		bin.EncodeCompactU16Length(&buf, len(lookup.WritableIndexes))
-		buf = append(buf, lookup.WritableIndexes...)
+		bin.EncodeCompactU16Length(&buf, len(mx.AddressTableLookups[i].WritableIndexes))
+		buf = append(buf, mx.AddressTableLookups[i].WritableIndexes...)
 		// write readonly indexes
-		bin.EncodeCompactU16Length(&buf, len(lookup.ReadonlyIndexes))
-		buf = append(buf, lookup.ReadonlyIndexes...)
+		bin.EncodeCompactU16Length(&buf, len(mx.AddressTableLookups[i].ReadonlyIndexes))
+		buf = append(buf, mx.AddressTableLookups[i].ReadonlyIndexes...)
 	}
 
 	return buf, nil
@@ -421,28 +442,33 @@ func (mx *Message) UnmarshalBase64(b64 string) error {
 // in the actual address tables, and returns the accounts.
 // NOTE: you need to call `SetAddressTables` before calling this method,
 // so that the lookups can be associated with the accounts in the address tables.
-func (mx Message) GetAddressTableLookupAccounts() (PublicKeySlice, error) {
+func (mx *Message) GetAddressTableLookupAccounts() (PublicKeySlice, error) {
 	err := mx.checkPreconditions()
 	if err != nil {
 		return nil, err
 	}
-	var writable PublicKeySlice
-	var readonly PublicKeySlice
+	numWritable := mx.AddressTableLookups.NumWritableLookups()
+	numTotal := mx.AddressTableLookups.NumLookups()
 
-	for _, lookup := range mx.AddressTableLookups {
-		table, ok := mx.addressTables[lookup.AccountKey]
+	// Single allocation: writable accounts first, then readonly.
+	all := make(PublicKeySlice, 0, numTotal)
+	writable := all[:0:numWritable]
+	readonly := make(PublicKeySlice, 0, numTotal-numWritable)
+
+	for i := range mx.AddressTableLookups {
+		table, ok := mx.addressTables[mx.AddressTableLookups[i].AccountKey]
 		if !ok {
-			return writable, fmt.Errorf("address table lookup not found for account: %s", lookup.AccountKey)
+			return nil, fmt.Errorf("address table lookup not found for account: %s", mx.AddressTableLookups[i].AccountKey)
 		}
-		for _, idx := range lookup.WritableIndexes {
+		for _, idx := range mx.AddressTableLookups[i].WritableIndexes {
 			if int(idx) >= len(table) {
-				return writable, fmt.Errorf("address table lookup index out of range: %d", idx)
+				return nil, fmt.Errorf("address table lookup index out of range: %d", idx)
 			}
 			writable = append(writable, table[idx])
 		}
-		for _, idx := range lookup.ReadonlyIndexes {
+		for _, idx := range mx.AddressTableLookups[i].ReadonlyIndexes {
 			if int(idx) >= len(table) {
-				return writable, fmt.Errorf("address table lookup index out of range: %d", idx)
+				return nil, fmt.Errorf("address table lookup index out of range: %d", idx)
 			}
 			readonly = append(readonly, table[idx])
 		}
@@ -482,12 +508,12 @@ func (mx *Message) ResolveLookupsWith(writable, readonly PublicKeySlice) (err er
 	return nil
 }
 
-func (mx Message) IsResolved() bool {
+func (mx *Message) IsResolved() bool {
 	return mx.resolved
 }
 
 // GetAllKeys returns ALL the message's account keys (including the keys from resolved address lookup tables).
-func (mx Message) GetAllKeys() (keys PublicKeySlice, err error) {
+func (mx *Message) GetAllKeys() (keys PublicKeySlice, err error) {
 	if mx.resolved {
 		// If the message has been resolved, then the account keys have already
 		// been appended to the `AccountKeys` field of the message.
@@ -502,7 +528,7 @@ func (mx Message) GetAllKeys() (keys PublicKeySlice, err error) {
 	return append(mx.AccountKeys, atlAccounts...), nil
 }
 
-func (mx Message) getStaticKeys() (keys PublicKeySlice) {
+func (mx *Message) getStaticKeys() (keys PublicKeySlice) {
 	if mx.resolved {
 		// If the message has been resolved, then the account keys have already
 		// been appended to the `AccountKeys` field of the message.
@@ -663,7 +689,7 @@ func (mx *Message) UnmarshalLegacy(decoder *bin.Decoder) (err error) {
 	return nil
 }
 
-func (m Message) checkPreconditions() error {
+func (m *Message) checkPreconditions() error {
 	// if this is versioned,
 	// and there are > 0 lookups,
 	// but the address table is empty,
@@ -675,7 +701,7 @@ func (m Message) checkPreconditions() error {
 	return nil
 }
 
-func (m Message) AccountMetaList() (AccountMetaSlice, error) {
+func (m *Message) AccountMetaList() (AccountMetaSlice, error) {
 	err := m.checkPreconditions()
 	if err != nil {
 		return nil, err
@@ -687,40 +713,34 @@ func (m Message) AccountMetaList() (AccountMetaSlice, error) {
 	out := make(AccountMetaSlice, len(accountKeys))
 
 	for i, a := range accountKeys {
-		isWritable, err := m.IsWritable(a)
-		if err != nil {
-			return nil, err
-		}
-
 		out[i] = &AccountMeta{
 			PublicKey:  a,
-			IsSigner:   m.IsSigner(a),
-			IsWritable: isWritable,
+			IsSigner:   m.accountIndexIsSigner(i),
+			IsWritable: m.uncheckedAccountIndexIsWritable(i),
 		}
 	}
 
 	return out, nil
 }
 
-func (m Message) IsVersioned() bool {
+func (m *Message) IsVersioned() bool {
 	return m.version != MessageVersionLegacy
 }
 
 // Signers returns the pubkeys of all accounts that are signers.
-func (m Message) Signers() PublicKeySlice {
-	// signers always in AccountKeys
-	out := make(PublicKeySlice, 0, len(m.AccountKeys))
-	for _, a := range m.AccountKeys {
-		if m.IsSigner(a) {
-			out = append(out, a)
-		}
+func (m *Message) Signers() PublicKeySlice {
+	numSigners := int(m.Header.NumRequiredSignatures)
+	if numSigners > len(m.AccountKeys) {
+		numSigners = len(m.AccountKeys)
 	}
-
+	// Signers are always the first NumRequiredSignatures keys — no need to iterate all.
+	out := make(PublicKeySlice, numSigners)
+	copy(out, m.AccountKeys[:numSigners])
 	return out
 }
 
 // Writable returns the pubkeys of all accounts that are writable.
-func (m Message) Writable() (out PublicKeySlice, err error) {
+func (m *Message) Writable() (out PublicKeySlice, err error) {
 	err = m.checkPreconditions()
 	if err != nil {
 		return nil, err
@@ -730,13 +750,8 @@ func (m Message) Writable() (out PublicKeySlice, err error) {
 		return nil, err
 	}
 
-	for _, a := range accountKeys {
-		isWritable, err := m.IsWritable(a)
-		if err != nil {
-			return nil, err
-		}
-
-		if isWritable {
+	for i, a := range accountKeys {
+		if m.uncheckedAccountIndexIsWritable(i) {
 			out = append(out, a)
 		}
 	}
@@ -746,12 +761,12 @@ func (m Message) Writable() (out PublicKeySlice, err error) {
 
 // ResolveProgramIDIndex resolves the program ID index to a program ID.
 // DEPRECATED: use `Program(index)` instead.
-func (m Message) ResolveProgramIDIndex(programIDIndex uint16) (PublicKey, error) {
+func (m *Message) ResolveProgramIDIndex(programIDIndex uint16) (PublicKey, error) {
 	return m.Program(programIDIndex)
 }
 
 // Program returns the program key at the given index.
-func (m Message) Program(programIDIndex uint16) (PublicKey, error) {
+func (m *Message) Program(programIDIndex uint16) (PublicKey, error) {
 	// programIDIndex always in AccountKeys
 	if int(programIDIndex) < len(m.AccountKeys) {
 		return m.AccountKeys[programIDIndex], nil
@@ -760,7 +775,7 @@ func (m Message) Program(programIDIndex uint16) (PublicKey, error) {
 }
 
 // Account returns the account at the given index.
-func (m Message) Account(index uint16) (PublicKey, error) {
+func (m *Message) Account(index uint16) (PublicKey, error) {
 	if int(index) < len(m.AccountKeys) {
 		return m.AccountKeys[index], nil
 	}
@@ -775,7 +790,7 @@ func (m Message) Account(index uint16) (PublicKey, error) {
 }
 
 // GetAccountIndex returns the index of the given account (first occurrence of the account).
-func (m Message) GetAccountIndex(account PublicKey) (uint16, error) {
+func (m *Message) GetAccountIndex(account PublicKey) (uint16, error) {
 	err := m.checkPreconditions()
 	if err != nil {
 		return 0, err
@@ -786,7 +801,7 @@ func (m Message) GetAccountIndex(account PublicKey) (uint16, error) {
 	}
 
 	for idx, a := range accountKeys {
-		if a.Equals(account) {
+		if a == account {
 			return uint16(idx), nil
 		}
 	}
@@ -794,7 +809,7 @@ func (m Message) GetAccountIndex(account PublicKey) (uint16, error) {
 	return 0, fmt.Errorf("account not found: %s", account)
 }
 
-func (m Message) HasAccount(account PublicKey) (bool, error) {
+func (m *Message) HasAccount(account PublicKey) (bool, error) {
 	err := m.checkPreconditions()
 	if err != nil {
 		return false, err
@@ -805,7 +820,7 @@ func (m Message) HasAccount(account PublicKey) (bool, error) {
 	}
 
 	for _, a := range accountKeys {
-		if a.Equals(account) {
+		if a == account {
 			return true, nil
 		}
 	}
@@ -813,30 +828,27 @@ func (m Message) HasAccount(account PublicKey) (bool, error) {
 	return false, nil
 }
 
-func (m Message) IsSigner(account PublicKey) bool {
+func (m *Message) IsSigner(account PublicKey) bool {
 	// signers always in AccountKeys
 	for idx, acc := range m.AccountKeys {
-		if acc.Equals(account) {
-			return idx < int(m.Header.NumRequiredSignatures)
+		if acc == account {
+			return m.accountIndexIsSigner(idx)
 		}
 	}
 	return false
 }
 
+func (m *Message) accountIndexIsSigner(index int) bool {
+	return index < int(m.Header.NumRequiredSignatures)
+}
+
 // numStaticAccounts returns the number of accounts that are always present in the
 // account keys list (i.e. all the accounts that are NOT in the lookup table).
-func (m Message) numStaticAccounts() int {
+func (m *Message) numStaticAccounts() int {
 	if !m.resolved {
 		return len(m.AccountKeys)
 	}
 	return len(m.AccountKeys) - m.NumLookups()
-}
-
-func (m Message) isWritableInLookups(idx int) bool {
-	if idx < m.numStaticAccounts() {
-		return false
-	}
-	return idx-m.numStaticAccounts() < m.AddressTableLookups.NumWritableLookups()
 }
 
 // IsWritableStatic checks if the account is a writable account in the static accounts list, ignoring the accounts in the address table lookups.
@@ -846,7 +858,7 @@ func (m *Message) IsWritableStatic(account PublicKey) bool {
 	index := 0
 	found := false
 	for idx, acc := range accountKeys {
-		if acc.Equals(account) {
+		if acc == account {
 			found = true
 			index = idx
 		}
@@ -863,7 +875,7 @@ func (m *Message) IsWritableStatic(account PublicKey) bool {
 	return index < max(int(h.NumRequiredSignatures)-int(h.NumReadonlySignedAccounts), 0)
 }
 
-func (m Message) IsWritable(account PublicKey) (bool, error) {
+func (m *Message) IsWritable(account PublicKey) (bool, error) {
 	err := m.checkPreconditions()
 	if err != nil {
 		return false, err
@@ -876,7 +888,7 @@ func (m Message) IsWritable(account PublicKey) (bool, error) {
 	index := 0
 	found := false
 	for idx, acc := range accountKeys {
-		if acc.Equals(account) {
+		if acc == account {
 			found = true
 			index = idx
 		}
@@ -884,21 +896,29 @@ func (m Message) IsWritable(account PublicKey) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	h := m.Header
-
-	if index >= m.numStaticAccounts() {
-		return m.isWritableInLookups(index), nil
-	} else if index >= int(h.NumRequiredSignatures) {
-		// Use int arithmetic to avoid underflow (Rust uses saturating_sub here).
-		numWritableUnsigned := max(m.numStaticAccounts()-int(h.NumRequiredSignatures)-int(h.NumReadonlyUnsignedAccounts), 0)
-		return index-int(h.NumRequiredSignatures) < numWritableUnsigned, nil
-	}
-	// Use int arithmetic to avoid uint8 underflow (Rust uses saturating_sub here).
-	numWritableSigned := max(int(h.NumRequiredSignatures)-int(h.NumReadonlySignedAccounts), 0)
-	return index < numWritableSigned, nil
+	return m.uncheckedAccountIndexIsWritable(index), nil
 }
 
-func (m Message) signerKeys() PublicKeySlice {
+// uncheckedAccountIndexIsWritable checks if the account at the given index is writable.
+// It does not check preconditions; the caller must ensure index is valid
+// within the full (static + lookup) account list.
+func (m *Message) uncheckedAccountIndexIsWritable(index int) bool {
+	h := m.Header
+	numStaticAccts := m.numStaticAccounts()
+
+	if index >= numStaticAccts {
+		// Account is in lookups: writable lookups come first.
+		return index-numStaticAccts < m.AddressTableLookups.NumWritableLookups()
+	} else if index >= int(h.NumRequiredSignatures) {
+		// Use int arithmetic to avoid underflow (Rust uses saturating_sub here).
+		numWritableUnsigned := max(numStaticAccts-int(h.NumRequiredSignatures)-int(h.NumReadonlyUnsignedAccounts), 0)
+		return index-int(h.NumRequiredSignatures) < numWritableUnsigned
+	}
+	// Use int arithmetic to avoid uint8 underflow (Rust uses saturating_sub here).
+	return index < max(int(h.NumRequiredSignatures)-int(h.NumReadonlySignedAccounts), 0)
+}
+
+func (m *Message) signerKeys() PublicKeySlice {
 	return m.AccountKeys[0:m.Header.NumRequiredSignatures]
 }
 

--- a/message_bench_test.go
+++ b/message_bench_test.go
@@ -1,0 +1,222 @@
+package solana
+
+import (
+	"testing"
+)
+
+// helpers to build realistic messages for benchmarking.
+
+func buildLegacyMessage() Message {
+	keys := make(PublicKeySlice, 10)
+	for i := range keys {
+		keys[i] = newUniqueKey()
+	}
+	return Message{
+		version: MessageVersionLegacy,
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 3,
+		},
+		AccountKeys:     keys,
+		RecentBlockhash: Hash{1, 2, 3},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 9, Accounts: []uint16{0, 1, 2}, Data: []byte{0xAA}},
+			{ProgramIDIndex: 8, Accounts: []uint16{3, 4, 5}, Data: []byte{0xBB}},
+		},
+	}
+}
+
+func buildV0Message() Message {
+	staticKeys := make(PublicKeySlice, 6)
+	for i := range staticKeys {
+		staticKeys[i] = newUniqueKey()
+	}
+
+	// Build lookup tables with writable and readonly entries.
+	tableKey1 := newUniqueKey()
+	tableKey2 := newUniqueKey()
+
+	tableAccounts1 := make(PublicKeySlice, 10)
+	for i := range tableAccounts1 {
+		tableAccounts1[i] = newUniqueKey()
+	}
+	tableAccounts2 := make(PublicKeySlice, 8)
+	for i := range tableAccounts2 {
+		tableAccounts2[i] = newUniqueKey()
+	}
+
+	msg := Message{
+		version: MessageVersionV0,
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys:     staticKeys,
+		RecentBlockhash: Hash{1, 2, 3},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 5, Accounts: []uint16{0, 1, 6, 7}, Data: []byte{0xCC}},
+			{ProgramIDIndex: 4, Accounts: []uint16{2, 3, 8, 9}, Data: []byte{0xDD}},
+		},
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey1,
+				WritableIndexes: []uint8{0, 1, 2},
+				ReadonlyIndexes: []uint8{3, 4},
+			},
+			{
+				AccountKey:      tableKey2,
+				WritableIndexes: []uint8{0, 1},
+				ReadonlyIndexes: []uint8{2, 3, 4},
+			},
+		},
+		addressTables: map[PublicKey]PublicKeySlice{
+			tableKey1: tableAccounts1,
+			tableKey2: tableAccounts2,
+		},
+	}
+
+	return msg
+}
+
+func buildV0MessageResolved() Message {
+	msg := buildV0Message()
+	_ = msg.ResolveLookups()
+	return msg
+}
+
+// --- Benchmarks ---
+
+func BenchmarkMessage_AccountMetaList_Legacy(b *testing.B) {
+	msg := buildLegacyMessage()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.AccountMetaList()
+	}
+}
+
+func BenchmarkMessage_AccountMetaList_V0(b *testing.B) {
+	msg := buildV0Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.AccountMetaList()
+	}
+}
+
+func BenchmarkMessage_AccountMetaList_V0Resolved(b *testing.B) {
+	msg := buildV0MessageResolved()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.AccountMetaList()
+	}
+}
+
+func BenchmarkMessage_IsWritable_Legacy(b *testing.B) {
+	msg := buildLegacyMessage()
+	account := msg.AccountKeys[3] // an unsigned writable account
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.IsWritable(account)
+	}
+}
+
+func BenchmarkMessage_IsWritable_V0(b *testing.B) {
+	msg := buildV0Message()
+	account := msg.AccountKeys[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.IsWritable(account)
+	}
+}
+
+func BenchmarkMessage_IsSigner(b *testing.B) {
+	msg := buildLegacyMessage()
+	account := msg.AccountKeys[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = msg.IsSigner(account)
+	}
+}
+
+func BenchmarkMessage_Signers(b *testing.B) {
+	msg := buildLegacyMessage()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = msg.Signers()
+	}
+}
+
+func BenchmarkMessage_Writable_Legacy(b *testing.B) {
+	msg := buildLegacyMessage()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.Writable()
+	}
+}
+
+func BenchmarkMessage_Writable_V0(b *testing.B) {
+	msg := buildV0Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.Writable()
+	}
+}
+
+func BenchmarkMessage_GetAllKeys_V0(b *testing.B) {
+	msg := buildV0Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.GetAllKeys()
+	}
+}
+
+func BenchmarkMessage_NumLookups(b *testing.B) {
+	msg := buildV0Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = msg.NumLookups()
+	}
+}
+
+func BenchmarkMessage_NumWritableLookups(b *testing.B) {
+	msg := buildV0Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = msg.NumWritableLookups()
+	}
+}
+
+func BenchmarkMessage_MarshalBinary_Legacy(b *testing.B) {
+	msg := buildLegacyMessage()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.MarshalBinary()
+	}
+}
+
+func BenchmarkMessage_MarshalBinary_V0(b *testing.B) {
+	msg := buildV0Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.MarshalBinary()
+	}
+}
+
+func BenchmarkMessage_numStaticAccounts_V0Resolved(b *testing.B) {
+	msg := buildV0MessageResolved()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = msg.numStaticAccounts()
+	}
+}
+
+func BenchmarkMessage_uncheckedAccountIndexIsWritable_V0Resolved(b *testing.B) {
+	msg := buildV0MessageResolved()
+	numStatic := msg.numStaticAccounts()
+	idx := numStatic + 1 // a lookup index
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = msg.uncheckedAccountIndexIsWritable(idx)
+	}
+}

--- a/message_test.go
+++ b/message_test.go
@@ -2,6 +2,7 @@ package solana
 
 import (
 	"testing"
+	"unsafe"
 
 	bin "github.com/gagliardetto/binary"
 	"github.com/stretchr/testify/assert"
@@ -706,4 +707,540 @@ func TestMarshalUnmarshalBase64(t *testing.T) {
 	assert.Equal(t, msg.Header, decoded.Header)
 	assert.Equal(t, msg.AccountKeys, decoded.AccountKeys)
 	assert.Equal(t, msg.RecentBlockhash, decoded.RecentBlockhash)
+}
+
+// --- Tests ported from anza-xyz/solana-sdk/message ---
+
+// Ported from legacy.rs: test_message_header_len_constant
+func TestMessageHeaderLenConstant(t *testing.T) {
+	// MessageHeader is 3 × uint8 = 3 bytes, matching Rust's MESSAGE_HEADER_LENGTH.
+	assert.Equal(t, uintptr(3), unsafe.Sizeof(MessageHeader{}))
+}
+
+// Ported from legacy.rs: test_program_ids (extended).
+// Tests ProgramIDs() returns the unique set of program IDs.
+func TestProgramIDs_Unique(t *testing.T) {
+	key0 := newUniqueKey()
+	key1 := newUniqueKey()
+	loader := newUniqueKey()
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: PublicKeySlice{key0, key1, loader},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 2, Accounts: []uint16{0, 1}, Data: []byte{}},
+		},
+	}
+
+	ids := msg.ProgramIDs()
+	require.Equal(t, 1, len(ids))
+	assert.Equal(t, loader, ids[0])
+}
+
+// Ported from legacy.rs: test_program_ids — multiple programs.
+func TestProgramIDs_Multiple(t *testing.T) {
+	key0 := newUniqueKey()
+	prog0 := newUniqueKey()
+	prog1 := newUniqueKey()
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 2,
+		},
+		AccountKeys: PublicKeySlice{key0, prog0, prog1},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{}},
+			{ProgramIDIndex: 2, Accounts: []uint16{0}, Data: []byte{}},
+			{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{}}, // duplicate
+		},
+	}
+
+	ids := msg.ProgramIDs()
+	require.Equal(t, 2, len(ids))
+	assert.Equal(t, prog0, ids[0])
+	assert.Equal(t, prog1, ids[1])
+}
+
+// Ported from legacy.rs: test_is_instruction_account.
+func TestIsInstructionAccount(t *testing.T) {
+	key0 := newUniqueKey()
+	key1 := newUniqueKey()
+	loader := newUniqueKey()
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: PublicKeySlice{key0, key1, loader},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 2, Accounts: []uint16{0, 1}, Data: []byte{}},
+		},
+	}
+
+	assert.True(t, msg.IsInstructionAccount(0))
+	assert.True(t, msg.IsInstructionAccount(1))
+	assert.False(t, msg.IsInstructionAccount(2)) // program, not instruction account
+}
+
+// Ported from legacy.rs: test_program_position.
+func TestProgramPosition(t *testing.T) {
+	id := newUniqueKey()
+	prog0 := newUniqueKey()
+	prog1 := newUniqueKey()
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 2,
+		},
+		AccountKeys: PublicKeySlice{id, prog0, prog1},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{}},
+			{ProgramIDIndex: 2, Accounts: []uint16{0}, Data: []byte{}},
+		},
+	}
+
+	_, found := msg.ProgramPosition(0)
+	assert.False(t, found, "id is not a program")
+
+	pos, found := msg.ProgramPosition(1)
+	assert.True(t, found)
+	assert.Equal(t, 0, pos, "first program")
+
+	pos, found = msg.ProgramPosition(2)
+	assert.True(t, found)
+	assert.Equal(t, 1, pos, "second program")
+}
+
+// Ported from sanitized.rs: test_num_readonly_accounts.
+func TestNumReadonlyAccounts_Legacy(t *testing.T) {
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: PublicKeySlice{
+			newUniqueKey(), newUniqueKey(),
+			newUniqueKey(), newUniqueKey(),
+		},
+	}
+
+	assert.Equal(t, 2, msg.NumReadonlyAccounts())
+}
+
+// Ported from sanitized.rs: test_num_readonly_accounts (V0 variant).
+// V0 messages also have readonly accounts from lookups.
+func TestNumReadonlyAccounts_V0(t *testing.T) {
+	tableKey := newUniqueKey()
+	msg := Message{
+		version: MessageVersionV0,
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: PublicKeySlice{
+			newUniqueKey(), newUniqueKey(),
+			newUniqueKey(), newUniqueKey(),
+		},
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey,
+				WritableIndexes: []uint8{0},
+				ReadonlyIndexes: []uint8{1},
+			},
+		},
+	}
+
+	// Static readonly: 1 signed + 1 unsigned = 2
+	assert.Equal(t, 2, msg.NumReadonlyAccounts())
+	// Total with lookups: 2 static readonly + 1 readonly lookup = 3
+	numReadonlyLookups := msg.NumLookups() - msg.NumWritableLookups()
+	assert.Equal(t, 3, msg.NumReadonlyAccounts()+numReadonlyLookups)
+}
+
+// Ported from sanitized.rs: test_get_ix_signers.
+func TestGetIxSigners(t *testing.T) {
+	signer0 := newUniqueKey()
+	signer1 := newUniqueKey()
+	nonSigner := newUniqueKey()
+	loaderKey := newUniqueKey()
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: PublicKeySlice{signer0, signer1, nonSigner, loaderKey},
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 3, Accounts: []uint16{2, 0}, Data: []byte{}}, // ix 0: nonSigner, signer0
+			{ProgramIDIndex: 3, Accounts: []uint16{0, 1}, Data: []byte{}}, // ix 1: signer0, signer1
+			{ProgramIDIndex: 3, Accounts: []uint16{0, 0}, Data: []byte{}}, // ix 2: signer0, signer0 (dup)
+		},
+	}
+
+	// ix 0: only signer0 is a signer (nonSigner at index 2 is not)
+	signers0 := msg.GetIxSigners(0)
+	require.Equal(t, 1, len(signers0))
+	assert.Equal(t, signer0, signers0[0])
+
+	// ix 1: both signer0 and signer1
+	signers1 := msg.GetIxSigners(1)
+	require.Equal(t, 2, len(signers1))
+	assert.Contains(t, []PublicKey(signers1), signer0)
+	assert.Contains(t, []PublicKey(signers1), signer1)
+
+	// ix 2: signer0 referenced twice, but deduped
+	signers2 := msg.GetIxSigners(2)
+	require.Equal(t, 1, len(signers2))
+	assert.Equal(t, signer0, signers2[0])
+
+	// Out of range returns nil.
+	assert.Nil(t, msg.GetIxSigners(3))
+}
+
+// Ported from sanitized.rs: test_static_account_keys.
+func TestStaticAccountKeys(t *testing.T) {
+	keys := PublicKeySlice{newUniqueKey(), newUniqueKey(), newUniqueKey()}
+
+	t.Run("legacy", func(t *testing.T) {
+		msg := Message{
+			Header: MessageHeader{
+				NumRequiredSignatures:       2,
+				NumReadonlySignedAccounts:   1,
+				NumReadonlyUnsignedAccounts: 1,
+			},
+			AccountKeys: keys,
+		}
+		assert.Equal(t, keys, msg.getStaticKeys())
+	})
+
+	t.Run("v0 no lookups", func(t *testing.T) {
+		msg := Message{
+			version: MessageVersionV0,
+			Header: MessageHeader{
+				NumRequiredSignatures:       2,
+				NumReadonlySignedAccounts:   1,
+				NumReadonlyUnsignedAccounts: 1,
+			},
+			AccountKeys: keys,
+		}
+		assert.Equal(t, keys, msg.getStaticKeys())
+	})
+
+	t.Run("v0 with lookups resolved", func(t *testing.T) {
+		tableKey := newUniqueKey()
+		extraWritable := newUniqueKey()
+		extraReadonly := newUniqueKey()
+
+		msg := Message{
+			version: MessageVersionV0,
+			Header: MessageHeader{
+				NumRequiredSignatures:       2,
+				NumReadonlySignedAccounts:   1,
+				NumReadonlyUnsignedAccounts: 1,
+			},
+			AccountKeys: append(PublicKeySlice{}, keys...),
+			AddressTableLookups: MessageAddressTableLookupSlice{
+				{
+					AccountKey:      tableKey,
+					WritableIndexes: []uint8{0},
+					ReadonlyIndexes: []uint8{1},
+				},
+			},
+			addressTables: map[PublicKey]PublicKeySlice{
+				tableKey: {extraWritable, extraReadonly},
+			},
+		}
+		require.NoError(t, msg.ResolveLookups())
+
+		// After resolution, AccountKeys has 5 entries, but static keys are only the first 3.
+		assert.Equal(t, 5, len(msg.AccountKeys))
+		staticKeys := msg.getStaticKeys()
+		assert.Equal(t, keys, staticKeys)
+	})
+}
+
+// Ported from v0/mod.rs: test_sanitize_with_max_table_loaded_keys.
+// Tests the exact boundary: 256 total accounts (static + lookup) is valid.
+func TestMessageSanitize_V0_MaxTableLoadedKeys(t *testing.T) {
+	keys := make(PublicKeySlice, 2) // payer + program
+	keys[0] = newUniqueKey()
+	keys[1] = newUniqueKey()
+
+	// 254 lookup accounts (to reach 256 total)
+	writableIndexes := make([]uint8, 127)
+	readonlyIndexes := make([]uint8, 127)
+	for i := range writableIndexes {
+		writableIndexes[i] = uint8(i)
+	}
+	for i := range readonlyIndexes {
+		readonlyIndexes[i] = uint8(i + 127)
+	}
+
+	msg := Message{
+		version: MessageVersionV0,
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: keys,
+		Instructions: []CompiledInstruction{
+			{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{}},
+		},
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      newUniqueKey(),
+				WritableIndexes: writableIndexes,
+				ReadonlyIndexes: readonlyIndexes,
+			},
+		},
+	}
+
+	// 2 static + 254 lookup = 256 total → should pass
+	err := msg.Sanitize()
+	require.NoError(t, err)
+}
+
+// Ported from v0/loaded.rs: test_is_writable_index.
+// Tests uncheckedAccountIndexIsWritable with a resolved V0 message.
+func TestUncheckedAccountIndexIsWritable_WithLookups(t *testing.T) {
+	tableKey := newUniqueKey()
+	msg := Message{
+		version: MessageVersionV0,
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: PublicKeySlice{
+			newUniqueKey(), // 0: writable signer
+			newUniqueKey(), // 1: readonly signer
+			newUniqueKey(), // 2: writable unsigned
+			newUniqueKey(), // 3: readonly unsigned
+		},
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey,
+				WritableIndexes: []uint8{0},    // 4: writable from lookup
+				ReadonlyIndexes: []uint8{1, 2}, // 5,6: readonly from lookup
+			},
+		},
+		addressTables: map[PublicKey]PublicKeySlice{
+			tableKey: {newUniqueKey(), newUniqueKey(), newUniqueKey()},
+		},
+	}
+	require.NoError(t, msg.ResolveLookups())
+
+	expected := []bool{
+		true,  // 0: writable signer
+		false, // 1: readonly signer
+		true,  // 2: writable unsigned
+		false, // 3: readonly unsigned
+		true,  // 4: writable lookup
+		false, // 5: readonly lookup
+		false, // 6: readonly lookup
+	}
+
+	for i, want := range expected {
+		got := msg.uncheckedAccountIndexIsWritable(i)
+		assert.Equal(t, want, got, "index %d", i)
+	}
+}
+
+// Ported from v0/loaded.rs: test_is_writable.
+// Tests IsWritable by public key with a resolved V0 message.
+func TestIsWritable_WithResolvedLookups(t *testing.T) {
+	staticKeys := PublicKeySlice{
+		newUniqueKey(), // 0: writable signer
+		newUniqueKey(), // 1: readonly signer
+		newUniqueKey(), // 2: writable unsigned
+		newUniqueKey(), // 3: readonly unsigned
+	}
+	tableKey := newUniqueKey()
+	lookupKeys := PublicKeySlice{
+		newUniqueKey(), // table[0] → writable lookup (idx 4)
+		newUniqueKey(), // table[1] → readonly lookup (idx 5)
+		newUniqueKey(), // table[2] → readonly lookup (idx 6)
+	}
+
+	msg := Message{
+		version: MessageVersionV0,
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: append(PublicKeySlice{}, staticKeys...),
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey,
+				WritableIndexes: []uint8{0},
+				ReadonlyIndexes: []uint8{1, 2},
+			},
+		},
+		addressTables: map[PublicKey]PublicKeySlice{
+			tableKey: lookupKeys,
+		},
+	}
+	require.NoError(t, msg.ResolveLookups())
+
+	allKeys := append(staticKeys, lookupKeys...)
+	expected := []bool{true, false, true, false, true, false, false}
+
+	for i, key := range allKeys {
+		w, err := msg.IsWritable(key)
+		require.NoError(t, err)
+		assert.Equal(t, expected[i], w, "key at index %d", i)
+	}
+}
+
+// Ported from v0/mod.rs: test_is_maybe_writable.
+// Tests writability including lookup accounts using header-based logic.
+func TestIsWritable_V0_HeaderLayout(t *testing.T) {
+	staticKeys := PublicKeySlice{
+		newUniqueKey(), // 0: writable signer
+		newUniqueKey(), // 1: readonly signer
+		newUniqueKey(), // 2: writable unsigned
+		newUniqueKey(), // 3: readonly unsigned
+	}
+	tableKey := newUniqueKey()
+	lookupWritable := newUniqueKey()
+	lookupReadonly := newUniqueKey()
+
+	msg := Message{
+		version: MessageVersionV0,
+		Header: MessageHeader{
+			NumRequiredSignatures:       2,
+			NumReadonlySignedAccounts:   1,
+			NumReadonlyUnsignedAccounts: 1,
+		},
+		AccountKeys: append(PublicKeySlice{}, staticKeys...),
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey,
+				WritableIndexes: []uint8{0},
+				ReadonlyIndexes: []uint8{1},
+			},
+		},
+		addressTables: map[PublicKey]PublicKeySlice{
+			tableKey: {lookupWritable, lookupReadonly},
+		},
+	}
+	require.NoError(t, msg.ResolveLookups())
+
+	// Static accounts:
+	w, err := msg.IsWritable(staticKeys[0])
+	require.NoError(t, err)
+	assert.True(t, w, "idx 0: writable signer")
+
+	w, err = msg.IsWritable(staticKeys[1])
+	require.NoError(t, err)
+	assert.False(t, w, "idx 1: readonly signer")
+
+	w, err = msg.IsWritable(staticKeys[2])
+	require.NoError(t, err)
+	assert.True(t, w, "idx 2: writable unsigned")
+
+	w, err = msg.IsWritable(staticKeys[3])
+	require.NoError(t, err)
+	assert.False(t, w, "idx 3: readonly unsigned")
+
+	// Lookup accounts:
+	w, err = msg.IsWritable(lookupWritable)
+	require.NoError(t, err)
+	assert.True(t, w, "idx 4: writable lookup")
+
+	w, err = msg.IsWritable(lookupReadonly)
+	require.NoError(t, err)
+	assert.False(t, w, "idx 5: readonly lookup")
+}
+
+// Ported from v0/loaded.rs: test_has_duplicates (already partially covered,
+// but this adds explicit sub-cases from the Rust test).
+func TestHasDuplicates_Loaded(t *testing.T) {
+	tableKey := newUniqueKey()
+	key0 := newUniqueKey()
+	key1 := newUniqueKey()
+	lookupW := newUniqueKey()
+	lookupR := newUniqueKey()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		msg := Message{
+			version: MessageVersionV0,
+			Header: MessageHeader{
+				NumRequiredSignatures:       1,
+				NumReadonlySignedAccounts:   0,
+				NumReadonlyUnsignedAccounts: 0,
+			},
+			AccountKeys: PublicKeySlice{key0, key1},
+			AddressTableLookups: MessageAddressTableLookupSlice{
+				{
+					AccountKey:      tableKey,
+					WritableIndexes: []uint8{0},
+					ReadonlyIndexes: []uint8{1},
+				},
+			},
+			addressTables: map[PublicKey]PublicKeySlice{
+				tableKey: {lookupW, lookupR},
+			},
+		}
+		require.NoError(t, msg.ResolveLookups())
+
+		allKeys, err := msg.GetAllKeys()
+		require.NoError(t, err)
+		assert.False(t, hasDuplicates(allKeys))
+	})
+
+	t.Run("with duplicate keys", func(t *testing.T) {
+		// Static key duplicated in lookup → should detect duplicate.
+		msg := Message{
+			version: MessageVersionV0,
+			Header: MessageHeader{
+				NumRequiredSignatures:       1,
+				NumReadonlySignedAccounts:   0,
+				NumReadonlyUnsignedAccounts: 0,
+			},
+			AccountKeys: PublicKeySlice{key0, key1},
+			AddressTableLookups: MessageAddressTableLookupSlice{
+				{
+					AccountKey:      tableKey,
+					WritableIndexes: []uint8{0},
+					ReadonlyIndexes: []uint8{},
+				},
+			},
+			addressTables: map[PublicKey]PublicKeySlice{
+				tableKey: {key0}, // key0 is both static and lookup
+			},
+		}
+		require.NoError(t, msg.ResolveLookups())
+
+		allKeys, err := msg.GetAllKeys()
+		require.NoError(t, err)
+		assert.True(t, hasDuplicates(allKeys))
+	})
+}
+
+// hasDuplicates is a test helper matching Rust's has_duplicates check.
+func hasDuplicates(keys PublicKeySlice) bool {
+	seen := make(map[PublicKey]struct{}, len(keys))
+	for _, k := range keys {
+		if _, ok := seen[k]; ok {
+			return true
+		}
+		seen[k] = struct{}{}
+	}
+	return false
 }


### PR DESCRIPTION
### Problem

message type's account-query methods (AccountMetaList, IsWritable, Signers, Writable) performed O(n) pubkey scans inside O(n) loops, resulting in O(n^2) behavior per call
value receivers on Message (which contains slices and a map) caused full struct copies on every method call. Marshal paths grew buffers through repeated append without pre-allocation, and MarshalV0 prepended the version byte by copying the entire buffer.

### Summary of Changes

- add index-based helpers (accountIndexIsSigner, uncheckedAccountIndexIsWritable) to replace pubkey-scan loops inside iteration, reducing O(n^2)-> O(n)
- convert value receivers to pointer receivers on hot-path methods (AccountMetaList, IsWritable, IsSigner, numStaticAccounts, GetAllKeys, etc.)
- use range-by-index on MessageAddressTableLookupSlice to avoid copying the 64+ byte struct on each iteration
- inline isWritableInLookups into uncheckedAccountIndexIsWritable to eliminate redundant numStaticAccounts() recomputation
- pre-allocate marshal buffers with estimated capacity (1 alloc instead of 6-9)
- write MarshalV0 version prefix first instead of prepending (eliminates full  buffer copy)
- pre-allocate writable/readonly slices in `GetAddressTableLookupAccounts`

#### Benches

##### Latency (ns/op)

| Benchmark                     | Before | After | Change   |
| ----------------------------- | ------ | ----- | -------- |
| AccountMetaList (legacy)      | 696    | 134   | **-81%** |
| AccountMetaList (v0)          | 6059   | 381   | **-94%** |
| AccountMetaList (v0 resolved) | 1496   | 230   | **-85%** |
| IsWritable (legacy)           | 45.7   | 23.2  | **-49%** |
| IsWritable (v0)               | 300    | 184   | **-39%** |
| IsSigner                      | 4.10   | 2.21  | **-46%** |
| Signers                       | 224    | 12.2  | **-95%** |
| Writable (legacy)             | 535    | 79.3  | **-85%** |
| Writable (v0)                 | 5348   | 306   | **-94%** |
| GetAllKeys (v0)               | 262    | 163   | **-38%** |
| MarshalBinary (legacy)        | 154    | 85.2  | **-45%** |
| MarshalBinary (v0)            | 243    | 100   | **-59%** |
| numStaticAccounts             | 2.96   | 0.94  | **-68%** |

##### Memory (B/op) and allocations

| Benchmark              | Bytes before | Bytes after | Allocs before | Allocs after |
| ---------------------- | ------------ | ----------- | ------------- | ------------ |
| AccountMetaList (v0)   | 34,080       | 2,208       | 170           | 21           |
| Writable (v0)          | 34,144       | 2,272       | 157           | 8            |
| MarshalBinary (legacy) | 736          | 384         | 6             | 1            |
| MarshalBinary (v0)     | 1,504        | 352         | 9             | 1            |
| Signers                | 320          | 64          | 1             | 1            |
| GetAllKeys (v0)        | 1,952        | 1,312       | 9             | 4            |

Geomean across all benchmarks: **-74% latency, -49% memory, -51% allocations**.

credits to @palmerlao for the initial idea in his fork of solana-go 🎉