### PR TITLE
fix(ws): pubsub parity

### DIFF
--- a/message.go
+++ b/message.go
@@ -23,7 +23,7 @@ import (
 
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/treeout"
-	jsoniter "github.com/json-iterator/go"
+	gojson "github.com/goccy/go-json"
 
 	"github.com/gagliardetto/solana-go/text"
 )
@@ -242,7 +242,7 @@ func (mx *Message) UnmarshalJSON(data []byte) error {
 		Header              MessageHeader         `json:"header"`
 		RecentBlockhash     Hash                  `json:"recentBlockhash"`
 		Instructions        []CompiledInstruction `json:"instructions"`
-		AddressTableLookups *jsoniter.RawMessage  `json:"addressTableLookups"`
+		AddressTableLookups *gojson.RawMessage    `json:"addressTableLookups"`
 	}{}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err

--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 
 	"github.com/davecgh/go-spew/spew"
-	stdjson "github.com/goccy/go-json"
 	gojson "github.com/goccy/go-json"
+	stdjson "github.com/goccy/go-json"
 	"github.com/google/uuid"
 )
 

--- a/rpc/sendAndConfirmTransaction/sendAndConfirmTransaction.go
+++ b/rpc/sendAndConfirmTransaction/sendAndConfirmTransaction.go
@@ -123,15 +123,22 @@ func WaitForConfirmation(
 	timeoutCtx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
 
-	got, err := sub.Recv(timeoutCtx)
-	if err != nil {
-		if timeoutCtx.Err() == context.DeadlineExceeded {
-			return false, ErrTimeout
+	// Drain any "receivedSignature" notifications (if the caller opted in
+	// to enableReceivedNotification) until we get the processed one.
+	for {
+		got, err := sub.Recv(timeoutCtx)
+		if err != nil {
+			if timeoutCtx.Err() == context.DeadlineExceeded {
+				return false, ErrTimeout
+			}
+			return false, err
 		}
-		return false, err
+		if got.Value.IsReceived {
+			continue
+		}
+		if got.Value.Processed != nil && got.Value.Processed.Err != nil {
+			return true, fmt.Errorf("confirmed transaction with execution error: %v", got.Value.Processed.Err)
+		}
+		return true, nil
 	}
-	if got.Value.Err != nil {
-		return true, fmt.Errorf("confirmed transaction with execution error: %v", got.Value.Err)
-	}
-	return true, nil
 }

--- a/rpc/util_test.go
+++ b/rpc/util_test.go
@@ -11,19 +11,21 @@ import (
 // Layout references for the test data below:
 //
 // SPL Token (solana-program/token):
-//   Mint::LEN    = 82
-//   Account::LEN = 165
+//
+//	Mint::LEN    = 82
+//	Account::LEN = 165
 //
 // Token-2022 (solana-program/token-2022):
-//   Extended records place a 1-byte AccountType discriminator at offset
-//   Account::LEN (= 165). Mint base (82 bytes) is padded with 83 zeros so
-//   Mint and Account share the discriminator offset.
 //
-//   AccountType::Uninitialized = 0
-//   AccountType::Mint          = 1
-//   AccountType::Account       = 2
+//	Extended records place a 1-byte AccountType discriminator at offset
+//	Account::LEN (= 165). Mint base (82 bytes) is padded with 83 zeros so
+//	Mint and Account share the discriminator offset.
 //
-//   Extensions follow as TLV: [u16 LE type][u16 LE length][value...].
+//	AccountType::Uninitialized = 0
+//	AccountType::Mint          = 1
+//	AccountType::Account       = 2
+//
+//	Extensions follow as TLV: [u16 LE type][u16 LE length][value...].
 const (
 	testAccountTypeUninitialized uint8 = 0
 	testAccountTypeMint          uint8 = 1

--- a/rpc/ws/accountSubscribe.go
+++ b/rpc/ws/accountSubscribe.go
@@ -22,47 +22,78 @@ import (
 )
 
 type AccountResult struct {
-	Context struct {
-		Slot uint64 `json:"slot"`
-	} `json:"context"`
-	Value *rpc.Account `json:"value"`
+	Context RPCResponseContext `json:"context"`
+	Value   *rpc.Account       `json:"value"`
+}
+
+// AccountSubscribeConfig matches Agave's RpcAccountInfoConfig. It
+// supports every encoding the RPC does — base58, base64, base64+zstd,
+// and jsonParsed — via rpc.Account.Data, which is a union type
+// (rpc.DataBytesOrJSON) that decodes all of them transparently.
+type AccountSubscribeConfig struct {
+	Commitment     rpc.CommitmentType
+	Encoding       solana.EncodingType
+	DataSlice      *rpc.DataSlice
+	MinContextSlot *uint64
+}
+
+// params converts the config to the JSON-RPC params object the
+// accountSubscribe method expects. Missing options are omitted so the
+// wire format matches Agave's serde(skip_serializing_if) behavior.
+func (c *AccountSubscribeConfig) params() map[string]any {
+	conf := map[string]any{"encoding": solana.EncodingBase64}
+	if c == nil {
+		return conf
+	}
+	if c.Commitment != "" {
+		conf["commitment"] = c.Commitment
+	}
+	if c.Encoding != "" {
+		conf["encoding"] = c.Encoding
+	}
+	if c.DataSlice != nil {
+		conf["dataSlice"] = c.DataSlice
+	}
+	if c.MinContextSlot != nil {
+		conf["minContextSlot"] = *c.MinContextSlot
+	}
+	return conf
 }
 
 // AccountSubscribe subscribes to an account to receive notifications
-// when the lamports or data for a given account public key changes.
+// when its lamports or data change. Defaults to base64 encoding.
 func (cl *Client) AccountSubscribe(
 	account solana.PublicKey,
 	commitment rpc.CommitmentType,
 ) (*AccountSubscription, error) {
-	return cl.AccountSubscribeWithOpts(
-		account,
-		commitment,
-		"",
-	)
+	return cl.AccountSubscribeWithOpts(account, commitment, "")
 }
 
-// AccountSubscribe subscribes to an account to receive notifications
-// when the lamports or data for a given account public key changes.
+// AccountSubscribeWithOpts is the simple variant that accepts bare
+// commitment and encoding arguments.
+//
+// Deprecated: use AccountSubscribeWithConfig for the full option set
+// (dataSlice, minContextSlot) exposed by Agave's RpcAccountInfoConfig.
 func (cl *Client) AccountSubscribeWithOpts(
 	account solana.PublicKey,
 	commitment rpc.CommitmentType,
 	encoding solana.EncodingType,
 ) (*AccountSubscription, error) {
+	return cl.AccountSubscribeWithConfig(account, &AccountSubscribeConfig{
+		Commitment: commitment,
+		Encoding:   encoding,
+	})
+}
 
-	params := []any{account.String()}
-	conf := map[string]any{
-		"encoding": "base64",
-	}
-	if commitment != "" {
-		conf["commitment"] = commitment
-	}
-	if encoding != "" {
-		conf["encoding"] = encoding
-	}
-
+// AccountSubscribeWithConfig mirrors the full RpcAccountInfoConfig
+// option surface of the underlying accountSubscribe RPC.
+func (cl *Client) AccountSubscribeWithConfig(
+	account solana.PublicKey,
+	config *AccountSubscribeConfig,
+) (*AccountSubscription, error) {
 	genSub, err := cl.subscribe(
-		params,
-		conf,
+		[]any{account.String()},
+		config.params(),
 		"accountSubscribe",
 		"accountUnsubscribe",
 		func(msg []byte) (any, error) {
@@ -74,9 +105,7 @@ func (cl *Client) AccountSubscribeWithOpts(
 	if err != nil {
 		return nil, err
 	}
-	return &AccountSubscription{
-		sub: genSub,
-	}, nil
+	return &AccountSubscription{sub: genSub}, nil
 }
 
 type AccountSubscription struct {

--- a/rpc/ws/blockSubscribe.go
+++ b/rpc/ws/blockSubscribe.go
@@ -22,15 +22,34 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 )
 
+// BlockResult is the unified notification payload for blockSubscribe.
+// Exactly one of Value.Block or Value.ParsedBlock is populated per
+// frame, based on the Encoding the caller passed at subscribe time.
 type BlockResult struct {
-	Context struct {
-		Slot uint64
-	} `json:"context"`
-	Value struct {
-		Slot  uint64              `json:"slot"`
-		Err   any                 `json:"err,omitempty"`
-		Block *rpc.GetBlockResult `json:"block,omitempty"`
-	} `json:"value"`
+	Context RPCResponseContext `json:"context"`
+	Value   BlockResultValue   `json:"value"`
+}
+
+// BlockResultValue mirrors Agave's RpcBlockUpdate with a Go-style union
+// over the two block shapes.
+//
+//	Encoding                              Field populated
+//	----------------------------------------------------
+//	base58 / base64 / base64+zstd         Block        (*rpc.GetBlockResult)
+//	jsonParsed                            ParsedBlock  (*rpc.GetParsedBlockResult)
+//
+// Err / Slot are always decoded regardless of which block field is set.
+type BlockResultValue struct {
+	Slot uint64 `json:"slot"`
+	Err  any    `json:"err,omitempty"`
+
+	// Block is populated for binary encodings.
+	Block *rpc.GetBlockResult `json:"block,omitempty"`
+
+	// ParsedBlock is populated when Encoding=jsonParsed was requested.
+	// BlockSubscribe sets this at decode time; it is not read by the
+	// default json.Unmarshal path.
+	ParsedBlock *rpc.GetParsedBlockResult `json:"-"`
 }
 
 type BlockSubscribeFilter interface {
@@ -76,7 +95,11 @@ type BlockSubscribeOpts struct {
 
 // NOTE: Unstable, disabled by default
 //
-// Subscribe to receive notification anytime a new block is Confirmed or Finalized.
+// BlockSubscribe subscribes to new blocks. Supports every encoding the
+// RPC does — base58, base64, base64+zstd, and jsonParsed. The
+// BlockResult.Value field is a union: the binary encodings populate
+// Block (*rpc.GetBlockResult); jsonParsed populates ParsedBlock
+// (*rpc.GetParsedBlockResult).
 //
 // **This subscription is unstable and only available if the validator was started
 // with the `--rpc-pubsub-enable-block-subscription` flag. The format of this
@@ -85,6 +108,8 @@ func (cl *Client) BlockSubscribe(
 	filter BlockSubscribeFilter,
 	opts *BlockSubscribeOpts,
 ) (*BlockSubscription, error) {
+	isParsed := opts != nil && opts.Encoding == solana.EncodingJSONParsed
+
 	var params []any
 	if filter != nil {
 		switch v := filter.(type) {
@@ -94,6 +119,7 @@ func (cl *Client) BlockSubscribe(
 			params = append(params, rpc.M{"mentionsAccountOrProgram": v.Pubkey})
 		}
 	}
+
 	if opts != nil {
 		obj := make(rpc.M)
 		if opts.Commitment != "" {
@@ -102,12 +128,10 @@ func (cl *Client) BlockSubscribe(
 		if opts.Encoding != "" {
 			if !solana.IsAnyOfEncodingType(
 				opts.Encoding,
-				// Valid encodings:
-				// solana.EncodingJSON, // TODO
-				solana.EncodingJSONParsed, // TODO
 				solana.EncodingBase58,
 				solana.EncodingBase64,
 				solana.EncodingBase64Zstd,
+				solana.EncodingJSONParsed,
 			) {
 				return nil, fmt.Errorf("provided encoding is not supported: %s", opts.Encoding)
 			}
@@ -126,16 +150,13 @@ func (cl *Client) BlockSubscribe(
 			params = append(params, obj)
 		}
 	}
+
 	genSub, err := cl.subscribe(
 		params,
 		nil,
 		"blockSubscribe",
 		"blockUnsubscribe",
-		func(msg []byte) (any, error) {
-			var res BlockResult
-			err := decodeResponseFromMessage(msg, &res)
-			return &res, err
-		},
+		decodeBlockNotification(isParsed),
 	)
 	if err != nil {
 		return nil, err
@@ -143,6 +164,42 @@ func (cl *Client) BlockSubscribe(
 	return &BlockSubscription{
 		sub: genSub,
 	}, nil
+}
+
+// decodeBlockNotification returns a frame decoder that lands the block
+// either in BlockResultValue.Block (binary) or .ParsedBlock (jsonParsed).
+// Unexported but package-local so tests can exercise both branches
+// without a live server.
+func decodeBlockNotification(isParsed bool) func([]byte) (any, error) {
+	return func(msg []byte) (any, error) {
+		if isParsed {
+			var tmp struct {
+				Context RPCResponseContext `json:"context"`
+				Value   struct {
+					Slot  uint64                    `json:"slot"`
+					Err   any                       `json:"err,omitempty"`
+					Block *rpc.GetParsedBlockResult `json:"block,omitempty"`
+				} `json:"value"`
+			}
+			if err := decodeResponseFromMessage(msg, &tmp); err != nil {
+				return nil, err
+			}
+			return &BlockResult{
+				Context: tmp.Context,
+				Value: BlockResultValue{
+					Slot:        tmp.Value.Slot,
+					Err:         tmp.Value.Err,
+					ParsedBlock: tmp.Value.Block,
+				},
+			}, nil
+		}
+
+		var res BlockResult
+		if err := decodeResponseFromMessage(msg, &res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
 }
 
 type BlockSubscription struct {

--- a/rpc/ws/examples/blockSubscribe/blockSubscribe.go
+++ b/rpc/ws/examples/blockSubscribe/blockSubscribe.go
@@ -1,0 +1,88 @@
+// Copyright 2022 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// blockSubscribe streams whole blocks. BlockSubscribe accepts every
+// encoding the RPC does — base58, base64, base64+zstd, and jsonParsed.
+// BlockResult.Value is a union: binary encodings populate Block
+// (*rpc.GetBlockResult); jsonParsed populates ParsedBlock
+// (*rpc.GetParsedBlockResult).
+//
+// Public Solana RPC endpoints do NOT expose block subscriptions by
+// default — the validator must be started with
+// `--rpc-pubsub-enable-block-subscription`. Point this at your own
+// endpoint, or at a provider that enables it (e.g. Helius, Triton).
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/ws"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := ws.Connect(ctx, rpc.MainNetBeta_WS)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	maxVersion := uint64(0)
+	rewards := false
+
+	// Switch to solana.EncodingJSONParsed to receive human-readable,
+	// parsed transactions via BlockResult.Value.ParsedBlock instead.
+	sub, err := client.BlockSubscribe(
+		ws.NewBlockSubscribeFilterAll(),
+		&ws.BlockSubscribeOpts{
+			Commitment:                     rpc.CommitmentConfirmed,
+			Encoding:                       solana.EncodingBase64,
+			TransactionDetails:             rpc.TransactionDetailsFull,
+			Rewards:                        &rewards,
+			MaxSupportedTransactionVersion: &maxVersion,
+		},
+	)
+	if err != nil {
+		panic(fmt.Errorf("subscribe: %w", err))
+	}
+	defer sub.Unsubscribe()
+
+	for {
+		got, err := sub.Recv(ctx)
+		if err != nil {
+			panic(err)
+		}
+
+		// Exactly one of Block / ParsedBlock is set, depending on the
+		// Encoding requested above.
+		switch {
+		case got.Value.Block != nil:
+			fmt.Printf("slot=%d  txs=%d (binary)\n",
+				got.Value.Slot,
+				len(got.Value.Block.Transactions),
+			)
+		case got.Value.ParsedBlock != nil:
+			fmt.Printf("slot=%d  txs=%d (parsed)\n",
+				got.Value.Slot,
+				len(got.Value.ParsedBlock.Transactions),
+			)
+		default:
+			fmt.Printf("slot=%d  no block payload\n", got.Value.Slot)
+		}
+	}
+}

--- a/rpc/ws/logsSubscribe.go
+++ b/rpc/ws/logsSubscribe.go
@@ -22,10 +22,8 @@ import (
 )
 
 type LogResult struct {
-	Context struct {
-		Slot uint64
-	} `json:"context"`
-	Value struct {
+	Context RPCResponseContext `json:"context"`
+	Value   struct {
 		// The transaction signature.
 		Signature solana.Signature `json:"signature"`
 		// Error if transaction failed, null if transaction succeeded.

--- a/rpc/ws/parsedBlockSubscribe.go
+++ b/rpc/ws/parsedBlockSubscribe.go
@@ -16,16 +16,15 @@ package ws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
 
 type ParsedBlockResult struct {
-	Context struct {
-		Slot uint64
-	} `json:"context"`
-	Value struct {
+	Context RPCResponseContext `json:"context"`
+	Value   struct {
 		Slot  uint64                    `json:"slot"`
 		Err   any                       `json:"err,omitempty"`
 		Block *rpc.GetParsedBlockResult `json:"block,omitempty"`
@@ -39,6 +38,10 @@ type ParsedBlockResult struct {
 // **This subscription is unstable and only available if the validator was started
 // with the `--rpc-pubsub-enable-block-subscription` flag. The format of this
 // subscription may change in the future**
+//
+// Deprecated: BlockSubscribe now accepts EncodingJSONParsed and will
+// populate BlockResult.Value.ParsedBlock. Prefer that single method so
+// callers do not have to branch on encoding at the call site.
 func (cl *Client) ParsedBlockSubscribe(
 	filter BlockSubscribeFilter,
 	opts *BlockSubscribeOpts,
@@ -53,6 +56,12 @@ func (cl *Client) ParsedBlockSubscribe(
 		}
 	}
 	if opts != nil {
+		if opts.Encoding != "" && opts.Encoding != solana.EncodingJSONParsed {
+			return nil, fmt.Errorf(
+				"ParsedBlockSubscribe always uses %s encoding; got opts.Encoding=%s",
+				solana.EncodingJSONParsed, opts.Encoding,
+			)
+		}
 		obj := make(rpc.M)
 		if opts.Commitment != "" {
 			obj["commitment"] = opts.Commitment

--- a/rpc/ws/parsedBlockSubscribe_test.go
+++ b/rpc/ws/parsedBlockSubscribe_test.go
@@ -1,0 +1,190 @@
+// Copyright 2022 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// parsedBlockFrame is the shared jsonParsed blockNotification fixture
+// exercised by the tests below. It reproduces the shape originally
+// reported in issue #291.
+const parsedBlockFrame = `{
+  "jsonrpc":"2.0",
+  "method":"blockNotification",
+  "params":{
+    "subscription":1,
+    "result":{
+      "context":{"slot":1234567},
+      "value":{
+        "slot":1234567,
+        "err":null,
+        "block":{
+          "blockhash":"6TScP1N3f4n23Y5f1cZ1YmLMgwYyb6PTvQQjoNn4XDFz",
+          "previousBlockhash":"11111111111111111111111111111111",
+          "parentSlot":1234566,
+          "blockTime":1700000000,
+          "blockHeight":123456,
+          "transactions":[{
+            "transaction":{
+              "signatures":["5j7s1QzqC6rA2FvR2gSzRcbfh4PE9eU7mVnxvKnZtWaAD9vqvR2rB8g4SfQ4ZBqS8PyZt7aX8ybX42kVhbZu8P7w"],
+              "message":{
+                "accountKeys":[
+                  {"pubkey":"4ejjNYBbaETZyqaiK8aDj2BWER8LKHgDcCnRrPC22YGg","signer":true,"writable":true},
+                  {"pubkey":"11111111111111111111111111111111","signer":false,"writable":false}
+                ],
+                "recentBlockhash":"6TScP1N3f4n23Y5f1cZ1YmLMgwYyb6PTvQQjoNn4XDFz",
+                "instructions":[{
+                  "program":"system",
+                  "programId":"11111111111111111111111111111111",
+                  "parsed":{"type":"transfer","info":{"source":"4ejjNYBbaETZyqaiK8aDj2BWER8LKHgDcCnRrPC22YGg","destination":"11111111111111111111111111111111","lamports":1000}},
+                  "stackHeight":0
+                }]
+              }
+            },
+            "meta":{
+              "err":null,
+              "fee":5000,
+              "preBalances":[1000000,0],
+              "postBalances":[994000,1000],
+              "innerInstructions":[],
+              "logMessages":["Program 11111111111111111111111111111111 invoke [1]","Program 11111111111111111111111111111111 success"],
+              "preTokenBalances":[],
+              "postTokenBalances":[]
+            }
+          }]
+        }
+      }
+    }
+  }
+}`
+
+// TestParsedBlockResult_Decode verifies that the (deprecated) dedicated
+// ParsedBlockSubscribe path still correctly decodes jsonParsed frames —
+// the decode failure regression tracked by issue #291.
+func TestParsedBlockResult_Decode(t *testing.T) {
+	var got ParsedBlockResult
+	err := decodeResponseFromMessage([]byte(parsedBlockFrame), &got)
+	require.NoError(t, err, "jsonParsed block must decode into ParsedBlockResult (regression for #291)")
+
+	require.Equal(t, uint64(1234567), got.Value.Slot)
+	require.NotNil(t, got.Value.Block)
+	require.Equal(t, uint64(1234566), got.Value.Block.ParentSlot)
+	require.Len(t, got.Value.Block.Transactions, 1)
+
+	tx := got.Value.Block.Transactions[0]
+	require.NotNil(t, tx.Transaction)
+	require.Len(t, tx.Transaction.Signatures, 1)
+	require.Len(t, tx.Transaction.Message.Instructions, 1)
+
+	ix := tx.Transaction.Message.Instructions[0]
+	require.Equal(t, "system", ix.Program)
+	require.NotNil(t, ix.Parsed)
+	require.NotNil(t, tx.Meta)
+	require.Equal(t, uint64(5000), tx.Meta.Fee)
+}
+
+// TestBlockSubscribe_ParsedRoute verifies that BlockSubscribe now routes
+// jsonParsed frames into BlockResultValue.ParsedBlock instead of
+// erroring out. This is the unified-encoding path that closes #291 at
+// the API level — callers no longer need to branch between BlockSubscribe
+// and ParsedBlockSubscribe.
+func TestBlockSubscribe_ParsedRoute(t *testing.T) {
+	decoder := decodeBlockNotification(true)
+	out, err := decoder([]byte(parsedBlockFrame))
+	require.NoError(t, err)
+	got := out.(*BlockResult)
+
+	require.Equal(t, uint64(1234567), got.Value.Slot)
+	require.Nil(t, got.Value.Block, "binary path must stay nil when jsonParsed was requested")
+	require.NotNil(t, got.Value.ParsedBlock)
+	require.Equal(t, uint64(1234566), got.Value.ParsedBlock.ParentSlot)
+	require.Len(t, got.Value.ParsedBlock.Transactions, 1)
+	require.Equal(t, "system", got.Value.ParsedBlock.Transactions[0].Transaction.Message.Instructions[0].Program)
+}
+
+// TestBlockSubscribe_BinaryRoute verifies the base64 path decodes into
+// BlockResultValue.Block (with ParsedBlock nil) so existing callers
+// don't regress. Also covers the "Encoding unset" default path, which
+// falls into the same isParsed=false branch. The transaction uses the
+// [data, "base64"] 2-array shape — the distinguishing feature of the
+// binary encoding — so this test would fail if the decoder were
+// accidentally rewired to expect the jsonParsed object shape.
+func TestBlockSubscribe_BinaryRoute(t *testing.T) {
+	frame := []byte(`{
+      "jsonrpc":"2.0",
+      "method":"blockNotification",
+      "params":{
+        "subscription":1,
+        "result":{
+          "context":{"slot":9},
+          "value":{
+            "slot":9,
+            "err":null,
+            "block":{
+              "blockhash":"6TScP1N3f4n23Y5f1cZ1YmLMgwYyb6PTvQQjoNn4XDFz",
+              "previousBlockhash":"11111111111111111111111111111111",
+              "parentSlot":8,
+              "blockTime":1700000000,
+              "blockHeight":10,
+              "transactions":[{
+                "transaction":["AQAAAAAAAAA=","base64"],
+                "meta":{
+                  "err":null,
+                  "fee":5000,
+                  "preBalances":[1000000,0],
+                  "postBalances":[995000,0],
+                  "innerInstructions":[],
+                  "logMessages":["Program log: noop"],
+                  "preTokenBalances":[],
+                  "postTokenBalances":[]
+                },
+                "version":"legacy"
+              }]
+            }
+          }
+        }
+      }
+    }`)
+	decoder := decodeBlockNotification(false)
+	out, err := decoder(frame)
+	require.NoError(t, err)
+	got := out.(*BlockResult)
+	require.NotNil(t, got.Value.Block)
+	require.Nil(t, got.Value.ParsedBlock, "jsonParsed field must stay nil when binary path was requested")
+	require.Equal(t, uint64(8), got.Value.Block.ParentSlot)
+	require.Len(t, got.Value.Block.Transactions, 1)
+
+	tx := got.Value.Block.Transactions[0]
+	require.NotNil(t, tx.Transaction, "transaction is the [blob, 'base64'] 2-array shape")
+	require.NotNil(t, tx.Meta)
+	require.Equal(t, uint64(5000), tx.Meta.Fee)
+}
+
+// TestParsedBlockSubscribe_RejectsWrongEncoding keeps the guard rail on
+// the (deprecated) parsed-only entry point: passing a non-jsonParsed
+// encoding is a user bug, since ParsedBlockSubscribe hardcodes
+// jsonParsed internally.
+func TestParsedBlockSubscribe_RejectsWrongEncoding(t *testing.T) {
+	cl := &Client{}
+	_, err := cl.ParsedBlockSubscribe(
+		NewBlockSubscribeFilterAll(),
+		&BlockSubscribeOpts{Encoding: "base64"},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "jsonParsed")
+}

--- a/rpc/ws/programSubscribe.go
+++ b/rpc/ws/programSubscribe.go
@@ -22,52 +22,93 @@ import (
 )
 
 type ProgramResult struct {
-	Context struct {
-		Slot uint64
-	} `json:"context"`
-	Value rpc.KeyedAccount `json:"value"`
+	Context RPCResponseContext `json:"context"`
+	Value   rpc.KeyedAccount   `json:"value"`
+}
+
+// ProgramSubscribeConfig matches Agave's RpcProgramAccountsConfig. All
+// encoding types supported by getProgramAccounts are supported here too
+// (base58, base64, base64+zstd, jsonParsed) — the per-account data
+// decodes via rpc.KeyedAccount.Account.Data (a DataBytesOrJSON union).
+type ProgramSubscribeConfig struct {
+	Commitment     rpc.CommitmentType
+	Encoding       solana.EncodingType
+	DataSlice      *rpc.DataSlice
+	Filters        []rpc.RPCFilter
+	MinContextSlot *uint64
+	WithContext    *bool
+	SortResults    *bool
+}
+
+// params converts the config to the JSON-RPC params object the
+// programSubscribe method expects. Missing options are omitted so the
+// wire format matches Agave's serde(skip_serializing_if) behavior.
+func (c *ProgramSubscribeConfig) params() map[string]any {
+	conf := map[string]any{"encoding": solana.EncodingBase64}
+	if c == nil {
+		return conf
+	}
+	if c.Commitment != "" {
+		conf["commitment"] = c.Commitment
+	}
+	if c.Encoding != "" {
+		conf["encoding"] = c.Encoding
+	}
+	if c.DataSlice != nil {
+		conf["dataSlice"] = c.DataSlice
+	}
+	if len(c.Filters) > 0 {
+		conf["filters"] = c.Filters
+	}
+	if c.MinContextSlot != nil {
+		conf["minContextSlot"] = *c.MinContextSlot
+	}
+	if c.WithContext != nil {
+		conf["withContext"] = *c.WithContext
+	}
+	if c.SortResults != nil {
+		conf["sortResults"] = *c.SortResults
+	}
+	return conf
 }
 
 // ProgramSubscribe subscribes to a program to receive notifications
-// when the lamports or data for a given account owned by the program changes.
+// when the lamports or data for any account owned by the program change.
 func (cl *Client) ProgramSubscribe(
 	programID solana.PublicKey,
 	commitment rpc.CommitmentType,
 ) (*ProgramSubscription, error) {
-	return cl.ProgramSubscribeWithOpts(
-		programID,
-		commitment,
-		"",
-		nil,
-	)
+	return cl.ProgramSubscribeWithOpts(programID, commitment, "", nil)
 }
 
-// ProgramSubscribe subscribes to a program to receive notifications
-// when the lamports or data for a given account owned by the program changes.
+// ProgramSubscribeWithOpts is the simple variant that accepts bare
+// commitment, encoding, and filters.
+//
+// Deprecated: use ProgramSubscribeWithConfig for the full option set
+// (dataSlice, minContextSlot, withContext, sortResults) exposed by
+// Agave's RpcProgramAccountsConfig.
 func (cl *Client) ProgramSubscribeWithOpts(
 	programID solana.PublicKey,
 	commitment rpc.CommitmentType,
 	encoding solana.EncodingType,
 	filters []rpc.RPCFilter,
 ) (*ProgramSubscription, error) {
+	return cl.ProgramSubscribeWithConfig(programID, &ProgramSubscribeConfig{
+		Commitment: commitment,
+		Encoding:   encoding,
+		Filters:    filters,
+	})
+}
 
-	params := []any{programID.String()}
-	conf := map[string]any{
-		"encoding": "base64",
-	}
-	if commitment != "" {
-		conf["commitment"] = commitment
-	}
-	if encoding != "" {
-		conf["encoding"] = encoding
-	}
-	if len(filters) > 0 {
-		conf["filters"] = filters
-	}
-
+// ProgramSubscribeWithConfig mirrors the full RpcProgramAccountsConfig
+// option surface of the underlying programSubscribe RPC.
+func (cl *Client) ProgramSubscribeWithConfig(
+	programID solana.PublicKey,
+	config *ProgramSubscribeConfig,
+) (*ProgramSubscription, error) {
 	genSub, err := cl.subscribe(
-		params,
-		conf,
+		[]any{programID.String()},
+		config.params(),
 		"programSubscribe",
 		"programUnsubscribe",
 		func(msg []byte) (any, error) {
@@ -79,9 +120,7 @@ func (cl *Client) ProgramSubscribeWithOpts(
 	if err != nil {
 		return nil, err
 	}
-	return &ProgramSubscription{
-		sub: genSub,
-	}, nil
+	return &ProgramSubscription{sub: genSub}, nil
 }
 
 type ProgramSubscription struct {

--- a/rpc/ws/signatureSubscribe.go
+++ b/rpc/ws/signatureSubscribe.go
@@ -16,36 +16,126 @@ package ws
 
 import (
 	"context"
+	stdjson "encoding/json"
+	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
 
-type SignatureResult struct {
-	Context struct {
-		Slot uint64
-	} `json:"context"`
-	Value struct {
-		Err any `json:"err"`
-	} `json:"value"`
+// SignatureSubscribeConfig matches Agave's RpcSignatureSubscribeConfig.
+// When EnableReceivedNotification is true, the subscription also emits
+// a "receivedSignature" notification the moment the transaction is first
+// received by the node — before confirmation. Callers must check
+// SignatureResult.Value.IsReceived / .Processed to disambiguate.
+type SignatureSubscribeConfig struct {
+	Commitment                 rpc.CommitmentType
+	EnableReceivedNotification *bool
 }
 
-// SignatureSubscribe subscribes to a transaction signature to receive
-// notification when the transaction is confirmed On signatureNotification,
-// the subscription is automatically canceled
-func (cl *Client) SignatureSubscribe(
-	signature solana.Signature, // Transaction Signature.
-	commitment rpc.CommitmentType, // (optional)
-) (*SignatureSubscription, error) {
-	params := []any{signature.String()}
-	conf := map[string]any{}
-	if commitment != "" {
-		conf["commitment"] = commitment
+// params converts the config to the JSON-RPC params object the
+// signatureSubscribe method expects. Missing options are omitted so the
+// wire format matches Agave's serde(skip_serializing_if) behavior.
+func (c *SignatureSubscribeConfig) params() map[string]any {
+	conf := make(map[string]any)
+	if c == nil {
+		return conf
 	}
+	if c.Commitment != "" {
+		conf["commitment"] = c.Commitment
+	}
+	if c.EnableReceivedNotification != nil {
+		conf["enableReceivedNotification"] = *c.EnableReceivedNotification
+	}
+	return conf
+}
 
+// SignatureResult is the notification payload for signatureSubscribe.
+// The shape of .Value depends on which subscription mode is active:
+//   - standard: {"err": ...}  → Value.Processed is set, IsReceived is false.
+//   - received (EnableReceivedNotification=true): the raw string
+//     "receivedSignature" → IsReceived is true, Processed is nil.
+type SignatureResult struct {
+	Context RPCResponseContext   `json:"context"`
+	Value   SignatureResultValue `json:"value"`
+}
+
+// RPCResponseContext mirrors Agave's RpcResponseContext.
+type RPCResponseContext struct {
+	Slot       uint64  `json:"slot"`
+	APIVersion *string `json:"apiVersion,omitempty"`
+}
+
+// SignatureResultValue is a Go-friendly projection of Agave's untagged
+// RpcSignatureResult enum (ProcessedSignature | ReceivedSignature).
+type SignatureResultValue struct {
+	// IsReceived is true when the notification signals that the tx has
+	// been received by the node (pre-confirmation). Only populated when
+	// the subscription was created with EnableReceivedNotification=true.
+	IsReceived bool
+	// Processed is non-nil for the standard (post-processing) notification.
+	Processed *ProcessedSignatureResult
+}
+
+// ProcessedSignatureResult matches Agave's ProcessedSignatureResult.
+// Err is nil on success; on failure it mirrors the RPC JSON (typically
+// a map or a string identifying the TransactionError).
+type ProcessedSignatureResult struct {
+	Err any `json:"err"`
+}
+
+// receivedSignatureTag is the single string variant emitted by
+// Agave's ReceivedSignatureResult enum.
+const receivedSignatureTag = "receivedSignature"
+
+// UnmarshalJSON decodes either the object form ({"err":...}) or the
+// string form ("receivedSignature") returned by Solana.
+func (v *SignatureResultValue) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	switch data[0] {
+	case '"':
+		var s string
+		if err := stdjson.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("SignatureResultValue: %w", err)
+		}
+		if s != receivedSignatureTag {
+			return fmt.Errorf("SignatureResultValue: unknown string variant %q", s)
+		}
+		v.IsReceived = true
+		return nil
+	case '{':
+		var p ProcessedSignatureResult
+		if err := stdjson.Unmarshal(data, &p); err != nil {
+			return fmt.Errorf("SignatureResultValue: %w", err)
+		}
+		v.Processed = &p
+		return nil
+	}
+	return fmt.Errorf("SignatureResultValue: unexpected JSON %s", string(data))
+}
+
+// SignatureSubscribe subscribes to confirmation notifications for a
+// single transaction signature. The subscription is cancelled by the
+// server once the notification fires.
+func (cl *Client) SignatureSubscribe(
+	signature solana.Signature,
+	commitment rpc.CommitmentType, // optional
+) (*SignatureSubscription, error) {
+	return cl.SignatureSubscribeWithOpts(signature, &SignatureSubscribeConfig{Commitment: commitment})
+}
+
+// SignatureSubscribeWithOpts mirrors signatureSubscribe + full config.
+// Pass EnableReceivedNotification=&true to also receive a
+// "receivedSignature" event as soon as the node sees the tx.
+func (cl *Client) SignatureSubscribeWithOpts(
+	signature solana.Signature,
+	config *SignatureSubscribeConfig,
+) (*SignatureSubscription, error) {
 	genSub, err := cl.subscribe(
-		params,
-		conf,
+		[]any{signature.String()},
+		config.params(),
 		"signatureSubscribe",
 		"signatureUnsubscribe",
 		func(msg []byte) (any, error) {
@@ -57,9 +147,7 @@ func (cl *Client) SignatureSubscribe(
 	if err != nil {
 		return nil, err
 	}
-	return &SignatureSubscription{
-		sub: genSub,
-	}, nil
+	return &SignatureSubscription{sub: genSub}, nil
 }
 
 type SignatureSubscription struct {

--- a/rpc/ws/signatureSubscribe.go
+++ b/rpc/ws/signatureSubscribe.go
@@ -117,7 +117,7 @@ func (v *SignatureResultValue) UnmarshalJSON(data []byte) error {
 }
 
 // SignatureSubscribe subscribes to confirmation notifications for a
-// single transaction signature. The subscription is cancelled by the
+// single transaction signature. The subscription is canceled by the
 // server once the notification fires.
 func (cl *Client) SignatureSubscribe(
 	signature solana.Signature,

--- a/rpc/ws/slotsUpdatesSubscribe.go
+++ b/rpc/ws/slotsUpdatesSubscribe.go
@@ -20,17 +20,33 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+// SlotsUpdatesResult is a Go projection of Agave's SlotUpdate tagged
+// union (rename_all="camelCase", tag="type"). All variants carry
+// Slot and Timestamp; the rest of the fields are populated only for
+// the variants where they apply:
+//
+//	Type                        Extra fields
+//	-----------------------------------------
+//	firstShredReceived          (none)
+//	completed                   (none)
+//	createdBank                 Parent
+//	frozen                      Stats
+//	dead                        Err
+//	optimisticConfirmation      (none)
+//	root                        (none)
 type SlotsUpdatesResult struct {
-	// The parent slot.
-	Parent uint64 `json:"parent"`
+	// The update type (discriminator).
+	Type SlotsUpdatesType `json:"type"`
 	// The newly updated slot.
 	Slot uint64 `json:"slot"`
-	// The Unix timestamp of the update.
+	// The Unix timestamp of the update (milliseconds).
 	Timestamp *solana.UnixTimeMilliseconds `json:"timestamp"`
-	// The update type.
-	Type SlotsUpdatesType `json:"type"`
-	// Extra stats provided when a bank is frozen.
-	Stats *BankStats `json:"stats"`
+	// The parent slot. Populated only for type=createdBank.
+	Parent uint64 `json:"parent,omitempty"`
+	// Extra stats. Populated only for type=frozen.
+	Stats *BankStats `json:"stats,omitempty"`
+	// Error message. Populated only for type=dead.
+	Err string `json:"err,omitempty"`
 }
 
 type BankStats struct {

--- a/rpc/ws/subscriptions_test.go
+++ b/rpc/ws/subscriptions_test.go
@@ -330,7 +330,7 @@ func TestConfigParams_Wire(t *testing.T) {
 		require.NotNil(t, got["dataSlice"])
 		require.Equal(t, uint64(100), got["minContextSlot"])
 		// MinContextSlot is written as a plain uint64, not as a pointer,
-		// so JSON marshalling lands on a number (matching Agave).
+		// so JSON marshaling lands on a number (matching Agave).
 		require.IsType(t, uint64(0), got["minContextSlot"])
 	})
 

--- a/rpc/ws/subscriptions_test.go
+++ b/rpc/ws/subscriptions_test.go
@@ -1,0 +1,378 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ws
+
+import (
+	stdjson "encoding/json"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+// notification wraps a notification result in the jsonrpc envelope that
+// decodeResponseFromMessage expects (matching Agave's wire format, see
+// agave/rpc/src/rpc_subscriptions.rs tests).
+func notification(method string, result string) []byte {
+	return []byte(`{"jsonrpc":"2.0","method":"` + method +
+		`","params":{"subscription":0,"result":` + result + `}}`)
+}
+
+// ----- accountSubscribe -----
+
+func TestAccountResult_Decode(t *testing.T) {
+	t.Run("base64", func(t *testing.T) {
+		frame := notification("accountNotification", `{
+          "context":{"slot":42},
+          "value":{
+            "lamports":1000000,
+            "data":["SGVsbG8=","base64"],
+            "owner":"11111111111111111111111111111111",
+            "executable":false,
+            "rentEpoch":18446744073709551615,
+            "space":5
+          }
+        }`)
+		var got AccountResult
+		require.NoError(t, decodeResponseFromMessage(frame, &got))
+		require.Equal(t, uint64(42), got.Context.Slot)
+		require.NotNil(t, got.Value)
+		require.Equal(t, uint64(1000000), got.Value.Lamports)
+		require.Equal(t, solana.SystemProgramID, got.Value.Owner)
+		require.False(t, got.Value.Executable)
+		require.NotNil(t, got.Value.Data)
+		require.Equal(t, []byte("Hello"), got.Value.Data.GetBinary())
+	})
+
+	t.Run("jsonParsed", func(t *testing.T) {
+		frame := notification("accountNotification", `{
+          "context":{"slot":7},
+          "value":{
+            "lamports":2039280,
+            "data":{"program":"spl-token","parsed":{"type":"account","info":{"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}},"space":165},
+            "owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "executable":false,
+            "rentEpoch":0
+          }
+        }`)
+		var got AccountResult
+		require.NoError(t, decodeResponseFromMessage(frame, &got))
+		require.NotNil(t, got.Value)
+		require.NotNil(t, got.Value.Data)
+		// Raw JSON path is preserved verbatim via DataBytesOrJSON.
+		var asMap map[string]any
+		raw, err := got.Value.Data.MarshalJSON()
+		require.NoError(t, err)
+		require.NoError(t, stdjson.Unmarshal(raw, &asMap))
+		require.Equal(t, "spl-token", asMap["program"])
+	})
+}
+
+// ----- programSubscribe -----
+
+func TestProgramResult_Decode(t *testing.T) {
+	frame := notification("programNotification", `{
+      "context":{"slot":100},
+      "value":{
+        "pubkey":"4ejjNYBbaETZyqaiK8aDj2BWER8LKHgDcCnRrPC22YGg",
+        "account":{
+          "lamports":500,
+          "data":["",  "base64"],
+          "owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "executable":false,
+          "rentEpoch":0
+        }
+      }
+    }`)
+	var got ProgramResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.Equal(t, uint64(100), got.Context.Slot)
+	require.Equal(t, "4ejjNYBbaETZyqaiK8aDj2BWER8LKHgDcCnRrPC22YGg", got.Value.Pubkey.String())
+	require.Equal(t, uint64(500), got.Value.Account.Lamports)
+}
+
+// ----- signatureSubscribe -----
+
+func TestSignatureResult_Decode_Processed(t *testing.T) {
+	frame := notification("signatureNotification", `{"context":{"slot":1},"value":{"err":null}}`)
+	var got SignatureResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.Equal(t, uint64(1), got.Context.Slot)
+	require.False(t, got.Value.IsReceived)
+	require.NotNil(t, got.Value.Processed)
+	require.Nil(t, got.Value.Processed.Err)
+}
+
+func TestSignatureResult_Decode_ProcessedWithErr(t *testing.T) {
+	frame := notification("signatureNotification",
+		`{"context":{"slot":2},"value":{"err":{"InstructionError":[0,"InvalidAccountData"]}}}`)
+	var got SignatureResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.NotNil(t, got.Value.Processed)
+	require.NotNil(t, got.Value.Processed.Err)
+}
+
+func TestSignatureResult_Decode_Received(t *testing.T) {
+	frame := notification("signatureNotification",
+		`{"context":{"slot":3},"value":"receivedSignature"}`)
+	var got SignatureResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.True(t, got.Value.IsReceived, "untagged enum variant ReceivedSignature should map to IsReceived=true")
+	require.Nil(t, got.Value.Processed)
+}
+
+// ----- logsSubscribe -----
+
+func TestLogResult_Decode(t *testing.T) {
+	frame := notification("logsNotification", `{
+      "context":{"slot":5},
+      "value":{
+        "signature":"5j7s1QzqC6rA2FvR2gSzRcbfh4PE9eU7mVnxvKnZtWaAD9vqvR2rB8g4SfQ4ZBqS8PyZt7aX8ybX42kVhbZu8P7w",
+        "err":null,
+        "logs":["Program 11111111111111111111111111111111 invoke [1]","Program 11111111111111111111111111111111 success"]
+      }
+    }`)
+	var got LogResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.Equal(t, uint64(5), got.Context.Slot)
+	require.Len(t, got.Value.Logs, 2)
+	require.Nil(t, got.Value.Err)
+}
+
+// ----- voteSubscribe -----
+
+func TestVoteResult_Decode(t *testing.T) {
+	frame := notification("voteNotification", `{
+      "votePubkey":"4ejjNYBbaETZyqaiK8aDj2BWER8LKHgDcCnRrPC22YGg",
+      "slots":[100,101,102],
+      "hash":"6TScP1N3f4n23Y5f1cZ1YmLMgwYyb6PTvQQjoNn4XDFz",
+      "timestamp":1700000000,
+      "signature":"5j7s1QzqC6rA2FvR2gSzRcbfh4PE9eU7mVnxvKnZtWaAD9vqvR2rB8g4SfQ4ZBqS8PyZt7aX8ybX42kVhbZu8P7w"
+    }`)
+	var got VoteResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.Equal(t, "4ejjNYBbaETZyqaiK8aDj2BWER8LKHgDcCnRrPC22YGg", got.VotePubkey.String())
+	require.Equal(t, []uint64{100, 101, 102}, got.Slots)
+	require.Equal(t, "6TScP1N3f4n23Y5f1cZ1YmLMgwYyb6PTvQQjoNn4XDFz", got.Hash.String())
+	require.Equal(t, "5j7s1QzqC6rA2FvR2gSzRcbfh4PE9eU7mVnxvKnZtWaAD9vqvR2rB8g4SfQ4ZBqS8PyZt7aX8ybX42kVhbZu8P7w", got.Signature.String())
+}
+
+// ----- slotSubscribe -----
+
+func TestSlotResult_Decode(t *testing.T) {
+	frame := notification("slotNotification", `{"slot":42,"parent":41,"root":40}`)
+	var got SlotResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.Equal(t, uint64(42), got.Slot)
+	require.Equal(t, uint64(41), got.Parent)
+	require.Equal(t, uint64(40), got.Root)
+}
+
+// ----- rootSubscribe -----
+
+func TestRootResult_Decode(t *testing.T) {
+	frame := notification("rootNotification", `123456`)
+	var got RootResult
+	require.NoError(t, decodeResponseFromMessage(frame, &got))
+	require.Equal(t, RootResult(123456), got)
+}
+
+// ----- slotsUpdatesSubscribe -----
+
+// Covers every SlotUpdate variant in agave/rpc-client-types/src/response.rs.
+func TestSlotsUpdatesResult_Decode(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  string
+		assertFn func(*testing.T, *SlotsUpdatesResult)
+	}{
+		{
+			name:    "firstShredReceived",
+			payload: `{"type":"firstShredReceived","slot":1,"timestamp":1700000000}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesFirstShredReceived, r.Type)
+			},
+		},
+		{
+			name:    "createdBank",
+			payload: `{"type":"createdBank","slot":10,"parent":9,"timestamp":1700000001}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesCreatedBank, r.Type)
+				require.Equal(t, uint64(9), r.Parent)
+			},
+		},
+		{
+			name:    "frozen",
+			payload: `{"type":"frozen","slot":11,"timestamp":1700000002,"stats":{"numTransactionEntries":3,"numSuccessfulTransactions":2,"numFailedTransactions":1,"maxTransactionsPerEntry":64}}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesFrozen, r.Type)
+				require.NotNil(t, r.Stats)
+				require.Equal(t, uint64(3), r.Stats.NumTransactionEntries)
+				require.Equal(t, uint64(2), r.Stats.NumSuccessfulTransactions)
+				require.Equal(t, uint64(1), r.Stats.NumFailedTransactions)
+				require.Equal(t, uint64(64), r.Stats.MaxTransactionsPerEntry)
+			},
+		},
+		{
+			name:    "dead",
+			payload: `{"type":"dead","slot":12,"timestamp":1700000003,"err":"ProducedSame"}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesDead, r.Type)
+				require.Equal(t, "ProducedSame", r.Err)
+			},
+		},
+		{
+			name:    "optimisticConfirmation",
+			payload: `{"type":"optimisticConfirmation","slot":13,"timestamp":1700000004}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesOptimisticConfirmation, r.Type)
+			},
+		},
+		{
+			name:    "root",
+			payload: `{"type":"root","slot":14,"timestamp":1700000005}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesRoot, r.Type)
+			},
+		},
+		{
+			name:    "completed",
+			payload: `{"type":"completed","slot":15,"timestamp":1700000006}`,
+			assertFn: func(t *testing.T, r *SlotsUpdatesResult) {
+				require.Equal(t, SlotsUpdatesCompleted, r.Type)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			frame := notification("slotsUpdatesNotification", c.payload)
+			var got SlotsUpdatesResult
+			require.NoError(t, decodeResponseFromMessage(frame, &got))
+			c.assertFn(t, &got)
+		})
+	}
+}
+
+// TestConfigSurfaceParity intentionally uses `_ = zero.Field` to assert
+// at compile time that each Config struct still carries every option
+// from the matching Agave config. A field rename or removal will fail
+// to build — do not "simplify" these assignments away.
+func TestConfigSurfaceParity(t *testing.T) {
+	t.Run("AccountSubscribeConfig", func(t *testing.T) {
+		zero := AccountSubscribeConfig{}
+		_ = zero.Commitment
+		_ = zero.Encoding
+		_ = zero.DataSlice
+		_ = zero.MinContextSlot
+	})
+	t.Run("ProgramSubscribeConfig", func(t *testing.T) {
+		zero := ProgramSubscribeConfig{}
+		_ = zero.Commitment
+		_ = zero.Encoding
+		_ = zero.DataSlice
+		_ = zero.Filters
+		_ = zero.MinContextSlot
+		_ = zero.WithContext
+		_ = zero.SortResults
+	})
+	t.Run("SignatureSubscribeConfig", func(t *testing.T) {
+		zero := SignatureSubscribeConfig{}
+		_ = zero.Commitment
+		_ = zero.EnableReceivedNotification
+	})
+	t.Run("BlockSubscribeOpts", func(t *testing.T) {
+		zero := BlockSubscribeOpts{}
+		_ = zero.Commitment
+		_ = zero.Encoding
+		_ = zero.TransactionDetails
+		_ = zero.Rewards
+		_ = zero.MaxSupportedTransactionVersion
+	})
+}
+
+// TestConfigParams_Wire verifies that each Config's params() emits the
+// exact camelCase key set that Agave's RpcXxxConfig expects, with
+// unset options omitted (matching serde(skip_serializing_if="Option::is_none")).
+func TestConfigParams_Wire(t *testing.T) {
+	ptrU64 := func(v uint64) *uint64 { return &v }
+	ptrBool := func(v bool) *bool { return &v }
+
+	t.Run("AccountSubscribeConfig nil defaults to base64 encoding", func(t *testing.T) {
+		var c *AccountSubscribeConfig
+		got := c.params()
+		require.Equal(t, solana.EncodingBase64, got["encoding"])
+		require.Len(t, got, 1)
+	})
+	t.Run("AccountSubscribeConfig full", func(t *testing.T) {
+		c := &AccountSubscribeConfig{
+			Commitment:     rpc.CommitmentConfirmed,
+			Encoding:       solana.EncodingJSONParsed,
+			DataSlice:      &rpc.DataSlice{Offset: ptrU64(0), Length: ptrU64(64)},
+			MinContextSlot: ptrU64(100),
+		}
+		got := c.params()
+		require.Equal(t, rpc.CommitmentConfirmed, got["commitment"])
+		require.Equal(t, solana.EncodingJSONParsed, got["encoding"])
+		require.NotNil(t, got["dataSlice"])
+		require.Equal(t, uint64(100), got["minContextSlot"])
+		// MinContextSlot is written as a plain uint64, not as a pointer,
+		// so JSON marshalling lands on a number (matching Agave).
+		require.IsType(t, uint64(0), got["minContextSlot"])
+	})
+
+	t.Run("ProgramSubscribeConfig full", func(t *testing.T) {
+		c := &ProgramSubscribeConfig{
+			Commitment:     rpc.CommitmentConfirmed,
+			Encoding:       solana.EncodingBase64Zstd,
+			DataSlice:      &rpc.DataSlice{Offset: ptrU64(0), Length: ptrU64(8)},
+			Filters:        []rpc.RPCFilter{{DataSize: 165}},
+			MinContextSlot: ptrU64(1),
+			WithContext:    ptrBool(true),
+			SortResults:    ptrBool(false),
+		}
+		got := c.params()
+		require.Equal(t, rpc.CommitmentConfirmed, got["commitment"])
+		require.Equal(t, solana.EncodingBase64Zstd, got["encoding"])
+		require.NotNil(t, got["dataSlice"])
+		require.NotNil(t, got["filters"])
+		require.Equal(t, uint64(1), got["minContextSlot"])
+		require.Equal(t, true, got["withContext"])
+		require.Equal(t, false, got["sortResults"])
+	})
+	t.Run("ProgramSubscribeConfig zero omits optional fields", func(t *testing.T) {
+		got := (&ProgramSubscribeConfig{}).params()
+		require.Equal(t, solana.EncodingBase64, got["encoding"])
+		for _, k := range []string{"commitment", "dataSlice", "filters", "minContextSlot", "withContext", "sortResults"} {
+			_, present := got[k]
+			require.False(t, present, "unset %q must be omitted to match Agave wire format", k)
+		}
+	})
+
+	t.Run("SignatureSubscribeConfig full", func(t *testing.T) {
+		c := &SignatureSubscribeConfig{
+			Commitment:                 rpc.CommitmentFinalized,
+			EnableReceivedNotification: ptrBool(true),
+		}
+		got := c.params()
+		require.Equal(t, rpc.CommitmentFinalized, got["commitment"])
+		require.Equal(t, true, got["enableReceivedNotification"])
+	})
+	t.Run("SignatureSubscribeConfig zero emits empty map", func(t *testing.T) {
+		got := (&SignatureSubscribeConfig{}).params()
+		require.Empty(t, got)
+	})
+}

--- a/rpc/ws/voteSubscribe.go
+++ b/rpc/ws/voteSubscribe.go
@@ -20,13 +20,18 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+// VoteResult matches Agave's RpcVote.
 type VoteResult struct {
-	// The vote hash.
-	Hash solana.Hash `json:"hash"`
+	// Vote account address, as base-58 encoded string.
+	VotePubkey solana.PublicKey `json:"votePubkey"`
 	// The slots covered by the vote.
 	Slots []uint64 `json:"slots"`
+	// The vote hash.
+	Hash solana.Hash `json:"hash"`
 	// The timestamp of the vote.
 	Timestamp *solana.UnixTimeSeconds `json:"timestamp,omitempty"`
+	// Signature of the vote transaction.
+	Signature solana.Signature `json:"signature"`
 }
 
 // VoteSubscribe (UNSTABLE, disabled by default) subscribes

--- a/transaction_bench_test.go
+++ b/transaction_bench_test.go
@@ -11,7 +11,8 @@ import (
 //
 // numInstructions: how many instructions in the transaction.
 // accountsPerIx:   how many AccountMeta entries each instruction references.
-//                  (first is always a signer; second is always writable; rest readonly)
+//
+//	(first is always a signer; second is always writable; rest readonly)
 func buildBenchInstructions(numInstructions, accountsPerIx int) ([]Instruction, Hash) {
 	// Pre-generate a pool of unique accounts so instructions share some accounts
 	// (realistic — the same fee payer / writable state account appears in many ixs)
@@ -98,9 +99,9 @@ func buildBenchInstructionsWithLookups(numInstructions, accountsPerIx int) ([]In
 // Upper bound is ~10 instructions / ~30 accounts per ix — beyond that
 // becomes a synthetic stress shape that doesn't represent real traffic.
 var benchTxShapes = []struct {
-	name           string
+	name            string
 	numInstructions int
-	accountsPerIx  int
+	accountsPerIx   int
 }{
 	{"small_2ix_5accts", 2, 5},
 	{"medium_5ix_15accts", 5, 15},


### PR DESCRIPTION
> [!WARNING]
> Breaking Change SHould be merged into 2.0 branch

### Problem

Agave's `pubsub-client` has evolved since this repo's ws package was first written, and the two drifted across several dimensions that made our client either silently wrong or missing features users expect

### Summary of Changes

- actualized "shape" of requests and responses
- implemented all the supported encodings
- ported tests from the original crate + added some mainnet fixtures

closes #291 
closes #286 
closes #208 
closes #196 