### PR TITLE
perf(transaction): add cap hints and use pk instead of str

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -257,7 +257,11 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 
-	addressLookupKeysMap := make(map[PublicKey]addressTablePubkeyWithIndex) // all accounts from tables as map
+	totalTableEntries := 0
+	for _, t := range options.addressTables {
+		totalTableEntries += len(t)
+	}
+	addressLookupKeysMap := make(map[PublicKey]addressTablePubkeyWithIndex, totalTableEntries) // all accounts from tables as map
 	sortedTableKeys := make(PublicKeySlice, 0, len(options.addressTables))
 	for k := range options.addressTables {
 		sortedTableKeys = append(sortedTableKeys, k)
@@ -284,8 +288,12 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 
-	programIDs := make(PublicKeySlice, 0)
-	accounts := []*AccountMeta{}
+	totalAccounts := 0
+	for _, instruction := range instructions {
+		totalAccounts += len(instruction.Accounts())
+	}
+	programIDs := make(PublicKeySlice, 0, len(instructions))
+	accounts := make([]*AccountMeta, 0, totalAccounts+len(instructions))
 	for _, instruction := range instructions {
 		accounts = append(accounts, instruction.Accounts()...)
 		programIDs.UniqueAppend(instruction.ProgramID())
@@ -315,8 +323,16 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		return 0
 	})
 
-	uniqAccountsMap := map[PublicKey]uint64{}
-	uniqAccounts := []*AccountMeta{}
+	// Hint the map only above a threshold: for small txs, an empty map is
+	// cheaper than a single pre-allocated bucket (~640B for PublicKey keys).
+	// For larger txs, the hint avoids several bucket-grow operations.
+	var uniqAccountsMap map[PublicKey]uint64
+	if len(accounts) > 16 {
+		uniqAccountsMap = make(map[PublicKey]uint64, len(accounts))
+	} else {
+		uniqAccountsMap = map[PublicKey]uint64{}
+	}
+	uniqAccounts := make([]*AccountMeta, 0, len(accounts))
 	for _, acc := range accounts {
 		if index, found := uniqAccountsMap[acc.PublicKey]; found {
 			uniqAccounts[index].IsWritable = uniqAccounts[index].IsWritable || acc.IsWritable
@@ -426,9 +442,14 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		lookups := make([]MessageAddressTableLookup, 0, len(lookupsMap))
 
 		sortedLookupKeys := make(PublicKeySlice, 0, len(lookupsMap))
-		for k := range lookupsMap {
+		var totalWritable, totalReadonly int
+		for k, l := range lookupsMap {
 			sortedLookupKeys = append(sortedLookupKeys, k)
+			totalWritable += len(l.Writable)
+			totalReadonly += len(l.Readonly)
 		}
+		lookupsWritableKeys = make([]PublicKey, 0, totalWritable)
+		lookupsReadOnlyKeys = make([]PublicKey, 0, totalReadonly)
 		slices.SortFunc(sortedLookupKeys, func(a, b PublicKey) int {
 			return bytes.Compare(a[:], b[:])
 		})
@@ -453,17 +474,17 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	}
 
 	var idx uint16
-	accountKeyIndex := make(map[string]uint16, len(message.AccountKeys)+len(lookupsWritableKeys)+len(lookupsReadOnlyKeys))
+	accountKeyIndex := make(map[PublicKey]uint16, len(message.AccountKeys)+len(lookupsWritableKeys)+len(lookupsReadOnlyKeys))
 	for _, acc := range message.AccountKeys {
-		accountKeyIndex[acc.String()] = idx
+		accountKeyIndex[acc] = idx
 		idx++
 	}
 	for _, acc := range lookupsWritableKeys {
-		accountKeyIndex[acc.String()] = idx
+		accountKeyIndex[acc] = idx
 		idx++
 	}
 	for _, acc := range lookupsReadOnlyKeys {
-		accountKeyIndex[acc.String()] = idx
+		accountKeyIndex[acc] = idx
 		idx++
 	}
 
@@ -475,18 +496,19 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		)
 	}
 
+	message.Instructions = make([]CompiledInstruction, 0, len(instructions))
 	for txIdx, instruction := range instructions {
 		accounts = instruction.Accounts()
 		accountIndex := make([]uint16, len(accounts))
 		for idx, acc := range accounts {
-			accountIndex[idx] = accountKeyIndex[acc.PublicKey.String()]
+			accountIndex[idx] = accountKeyIndex[acc.PublicKey]
 		}
 		data, err := instruction.Data()
 		if err != nil {
 			return nil, fmt.Errorf("unable to encode instructions [%d]: %w", txIdx, err)
 		}
 		message.Instructions = append(message.Instructions, CompiledInstruction{
-			ProgramIDIndex: accountKeyIndex[instruction.ProgramID().String()],
+			ProgramIDIndex: accountKeyIndex[instruction.ProgramID()],
 			Accounts:       accountIndex,
 			Data:           data,
 		})
@@ -506,10 +528,11 @@ func (tx *Transaction) MarshalBinary() ([]byte, error) {
 	}
 
 	signatures := tx.Signatures
-	for i := len(signatures); i < int(tx.Message.Header.NumRequiredSignatures); i++ {
-		// append dummy signatures to the transaction, without it serialized transaction will be invalid
+	if missing := int(tx.Message.Header.NumRequiredSignatures) - len(signatures); missing > 0 {
+		// append zero-valued dummy signatures to the transaction, without them
+		// the serialized transaction will be invalid.
 		// reference: https://github.com/solana-labs/solana-web3.js/blob/4e9988cfc561f3ed11f4c5016a29090a61d129a8/src/transaction/versioned.ts#L36
-		signatures = append(signatures, SignatureFromBytes(make([]byte, SignatureLength)))
+		signatures = append(signatures, make([]Signature, missing)...)
 	}
 
 	var signaturesCountBytes []byte
@@ -793,40 +816,16 @@ func countWriteableAccounts(tx *Transaction) (count int) {
 		return count
 	}
 	numStaticKeys := len(tx.Message.AccountKeys)
-	staticKeys := tx.Message.AccountKeys
 	h := tx.Message.Header
-	for _, key := range staticKeys {
-		accIndex, ok := getStaticAccountIndex(tx, key)
-		if !ok {
-			continue
-		}
-		index := int(accIndex)
-		is := false
-		if index >= int(h.NumRequiredSignatures) {
-			// Use int arithmetic to avoid underflow (Rust uses saturating_sub here).
-			numWritableUnsigned := max(numStaticKeys-int(h.NumRequiredSignatures)-int(h.NumReadonlyUnsignedAccounts), 0)
-			is = index-int(h.NumRequiredSignatures) < numWritableUnsigned
-		} else {
-			is = index < max(int(h.NumRequiredSignatures)-int(h.NumReadonlySignedAccounts), 0)
-		}
-		if is {
-			count++
-		}
-	}
+	numSig := int(h.NumRequiredSignatures)
+	numWritableSigned := max(numSig-int(h.NumReadonlySignedAccounts), 0)
+	numWritableUnsigned := max(numStaticKeys-numSig-int(h.NumReadonlyUnsignedAccounts), 0)
+	count += numWritableSigned + numWritableUnsigned
 	if tx.Message.IsResolved() {
 		return count
 	}
 	count += tx.Message.NumWritableLookups()
 	return count
-}
-
-func getStaticAccountIndex(tx *Transaction, key PublicKey) (int, bool) {
-	for idx, a := range tx.Message.AccountKeys {
-		if a.Equals(key) {
-			return (idx), true
-		}
-	}
-	return -1, false
 }
 
 func (tx *Transaction) IsVote() bool {

--- a/transaction_bench_test.go
+++ b/transaction_bench_test.go
@@ -1,0 +1,175 @@
+package solana
+
+import (
+	"testing"
+)
+
+// buildBenchInstructions creates a realistic set of instructions for benchmarking
+// NewTransaction. Each instruction references a distinct program ID and mixes
+// signer/writable/readonly accounts so the builder exercises all header-counting
+// and indexing paths.
+//
+// numInstructions: how many instructions in the transaction.
+// accountsPerIx:   how many AccountMeta entries each instruction references.
+//                  (first is always a signer; second is always writable; rest readonly)
+func buildBenchInstructions(numInstructions, accountsPerIx int) ([]Instruction, Hash) {
+	// Pre-generate a pool of unique accounts so instructions share some accounts
+	// (realistic — the same fee payer / writable state account appears in many ixs)
+	// while still producing a meaningful total.
+	poolSize := numInstructions * accountsPerIx / 2
+	if poolSize < accountsPerIx {
+		poolSize = accountsPerIx
+	}
+	pool := make([]PublicKey, poolSize)
+	for i := range pool {
+		pool[i] = newUniqueKey()
+	}
+
+	feePayer := pool[0]
+
+	instructions := make([]Instruction, numInstructions)
+	for i := 0; i < numInstructions; i++ {
+		accounts := make(AccountMetaSlice, accountsPerIx)
+		for j := 0; j < accountsPerIx; j++ {
+			pk := pool[(i*accountsPerIx+j)%len(pool)]
+			var isSigner, isWritable bool
+			switch j {
+			case 0:
+				// fee payer — signer, writable
+				pk = feePayer
+				isSigner = true
+				isWritable = true
+			case 1:
+				isWritable = true
+			}
+			accounts[j] = &AccountMeta{
+				PublicKey:  pk,
+				IsSigner:   isSigner,
+				IsWritable: isWritable,
+			}
+		}
+		instructions[i] = NewInstruction(
+			newUniqueKey(), // distinct program ID per instruction
+			accounts,
+			[]byte{byte(i), 0xAA, 0xBB, 0xCC},
+		)
+	}
+
+	return instructions, Hash{1, 2, 3, 4, 5}
+}
+
+// buildBenchInstructionsWithLookups is like buildBenchInstructions but also
+// prepares an address-lookup-table so most of the accounts get compiled into
+// ATL lookups instead of the static key list. This stresses the path where
+// lookupsWritableKeys / lookupsReadOnlyKeys are non-empty.
+func buildBenchInstructionsWithLookups(numInstructions, accountsPerIx int) ([]Instruction, Hash, map[PublicKey]PublicKeySlice) {
+	instructions, blockhash := buildBenchInstructions(numInstructions, accountsPerIx)
+
+	// Collect all non-signer, non-program accounts into a single ATL.
+	seen := make(map[PublicKey]struct{})
+	var tableAccounts PublicKeySlice
+	for _, ix := range instructions {
+		for _, am := range ix.Accounts() {
+			if am.IsSigner {
+				continue
+			}
+			if _, ok := seen[am.PublicKey]; ok {
+				continue
+			}
+			seen[am.PublicKey] = struct{}{}
+			tableAccounts = append(tableAccounts, am.PublicKey)
+			if len(tableAccounts) == 256 {
+				break
+			}
+		}
+		if len(tableAccounts) == 256 {
+			break
+		}
+	}
+
+	tableKey := newUniqueKey()
+	tables := map[PublicKey]PublicKeySlice{
+		tableKey: tableAccounts,
+	}
+	return instructions, blockhash, tables
+}
+
+// Realistic transaction shapes for solana-go benchmarks.
+// Upper bound is ~10 instructions / ~30 accounts per ix — beyond that
+// becomes a synthetic stress shape that doesn't represent real traffic.
+var benchTxShapes = []struct {
+	name           string
+	numInstructions int
+	accountsPerIx  int
+}{
+	{"small_2ix_5accts", 2, 5},
+	{"medium_5ix_15accts", 5, 15},
+	{"large_10ix_30accts", 10, 30},
+}
+
+func BenchmarkNewTransaction(b *testing.B) {
+	for _, tc := range benchTxShapes {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			instructions, blockhash := buildBenchInstructions(tc.numInstructions, tc.accountsPerIx)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tx, err := NewTransaction(instructions, blockhash)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = tx
+			}
+		})
+	}
+}
+
+func BenchmarkNewTransaction_WithLookupTable(b *testing.B) {
+	for _, tc := range benchTxShapes {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			instructions, blockhash, tables := buildBenchInstructionsWithLookups(tc.numInstructions, tc.accountsPerIx)
+			opt := TransactionAddressTables(tables)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tx, err := NewTransaction(instructions, blockhash, opt)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = tx
+			}
+		})
+	}
+}
+
+func BenchmarkTransaction_NumWriteableAccounts(b *testing.B) {
+	// Legacy (non-versioned) takes the AccountMetaList path.
+	b.Run("legacy_large", func(b *testing.B) {
+		instructions, blockhash := buildBenchInstructions(10, 30)
+		tx, err := NewTransaction(instructions, blockhash)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = tx.NumWriteableAccounts()
+		}
+	})
+
+	// V0 with ATL takes the static-key-scan path (the O(n^2) candidate).
+	b.Run("v0_large", func(b *testing.B) {
+		instructions, blockhash, tables := buildBenchInstructionsWithLookups(10, 30)
+		tx, err := NewTransaction(instructions, blockhash, TransactionAddressTables(tables))
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = tx.NumWriteableAccounts()
+		}
+	})
+}


### PR DESCRIPTION
### Problem

four classes of waste in `NewTransaction` / `MarshalBinary` / `countWriteableAccounts` (string-keyed map, missing capacity hints, O(n^2) loop, per-sig heap alloc)

### Summary of Changes

- added capacity hints
- reduced per-sig heap alloc
- used pubkey map instead of string
- got rid of expensive  O(n^2) algo

#### Benches


##### Time (sec/op)

| Benchmark                                         |  Before |   After |  Delta |
| ------------------------------------------------- | ------: | ------: | -----: |
| NewTransaction/small_2ix_5accts                   | 882.8ns | 808.1ns |  -8.5% |
| NewTransaction/medium_5ix_15accts                 | 8.688us | 7.534us | -13.3% |
| NewTransaction/large_10ix_30accts                 | 41.20us | 34.09us | -17.2% |
| NewTransaction_WithLookupTable/small_2ix_5accts   | 1.239us | 1.192us |  -3.8% |
| NewTransaction_WithLookupTable/medium_5ix_15accts | 12.09us | 10.09us | -16.6% |
| NewTransaction_WithLookupTable/large_10ix_30accts | 53.08us | 42.50us | -19.9% |

##### Bytes allocated (B/op)

| Benchmark                                         |   Before |    After |  Delta |
| ------------------------------------------------- | -------: | -------: | -----: |
| NewTransaction/small_2ix_5accts                   | 1.328KiB | 1.219KiB |  -8.2% |
| NewTransaction/medium_5ix_15accts                 | 16.22KiB | 14.30KiB | -11.9% |
| NewTransaction/large_10ix_30accts                 | 63.95KiB | 55.82KiB | -12.7% |
| NewTransaction_WithLookupTable/small_2ix_5accts   | 1.547KiB | 1.406KiB |  -9.1% |
| NewTransaction_WithLookupTable/medium_5ix_15accts | 24.68KiB | 19.32KiB | -21.7% |
| NewTransaction_WithLookupTable/large_10ix_30accts | 106.4KiB | 80.78KiB | -24.1% |

##### Allocations (allocs/op)

| Benchmark                                         | Before | After |  Delta |
| ------------------------------------------------- | -----: | ----: | -----: |
| NewTransaction/small_2ix_5accts                   |     18 |    15 | -16.7% |
| NewTransaction/medium_5ix_15accts                 |     46 |    30 | -34.8% |
| NewTransaction/large_10ix_30accts                 |     70 |    45 | -35.7% |
| NewTransaction_WithLookupTable/small_2ix_5accts   |     26 |    22 | -15.4% |
| NewTransaction_WithLookupTable/medium_5ix_15accts |     67 |    47 | -29.9% |
| NewTransaction_WithLookupTable/large_10ix_30accts |    100 |    67 | -33.0% |