### PR TITLE
feat(zk): add ElGamal & AES key derivation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gagliardetto/solana-go
 go 1.24.0
 
 require (
+	filippo.io/edwards25519 v1.2.0
 	github.com/AlekSi/pointer v1.2.0
 	github.com/buger/jsonparser v1.1.2
 	github.com/davecgh/go-spew v1.1.1
@@ -28,6 +29,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e
 	github.com/stretchr/testify v1.11.1
+	github.com/tyler-smith/go-bip39 v1.1.0
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	go.uber.org/ratelimit v0.3.1
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/AlekSi/pointer v1.2.0 h1:glcy/gc4h8HnG2Z3ZECSzZ1IX1x2JxRVuDzaJwQE0+w=
 github.com/AlekSi/pointer v1.2.0/go.mod h1:gZGfd3dpW4vEc/UlyfKKi1roIqcCgwOIvb0tSNSBle0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -151,6 +153,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
+github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
+github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -189,6 +193,7 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=

--- a/programs/token-2022/zkencryption/ae_key.go
+++ b/programs/token-2022/zkencryption/ae_key.go
@@ -1,0 +1,80 @@
+package zkencryption
+
+import (
+	"crypto/sha3"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// AeKeyLen is the byte length of an authenticated-encryption key (AES-128-GCM-SIV).
+const AeKeyLen = 16
+
+// aeSigningDomain is the domain-separation prefix prepended to the public
+// seed before signing. It must match b"AeKey" in solana-zk-sdk.
+const aeSigningDomain = "AeKey"
+
+// minAeSeedLen / maxAeSeedLen mirror the bounds enforced in solana-zk-sdk's
+// SeedDerivable::from_seed implementation for AeKey.
+const (
+	minAeSeedLen = AeKeyLen
+	maxAeSeedLen = 65535
+)
+
+// AeKey is a 128-bit authenticated-encryption key used by the Token-2022
+// confidential-transfer extension to encrypt u64 amounts under AES-128-GCM-SIV.
+type AeKey [AeKeyLen]byte
+
+// AeKeyFromSeed derives an AeKey from an entropy seed by hashing the seed with
+// SHA3-512 and taking the first 16 bytes, matching SeedDerivable::from_seed in
+// solana-zk-sdk.
+func AeKeyFromSeed(seed []byte) (AeKey, error) {
+	if len(seed) < minAeSeedLen {
+		return AeKey{}, ErrSeedTooShort
+	}
+	if len(seed) > maxAeSeedLen {
+		return AeKey{}, ErrSeedTooLong
+	}
+	h := sha3.Sum512(seed)
+	var out AeKey
+	copy(out[:], h[:AeKeyLen])
+	return out, nil
+}
+
+// AeKeyFromSignature derives an AeKey from an ed25519 signature by using
+// SHA3-512(signature) as the seed. Mirrors AeKey::seed_from_signature +
+// from_seed in solana-zk-sdk. No default-signature check is performed here;
+// use AeKeyFromSigner if the signature originates from a local signer.
+func AeKeyFromSignature(sig solana.Signature) (AeKey, error) {
+	h := sha3.Sum512(sig[:])
+	return AeKeyFromSeed(h[:])
+}
+
+// AeKeyFromSigner deterministically derives an AeKey from a Solana signer and
+// a public seed. The signer signs b"AeKey" || publicSeed; the signature is
+// then hashed with SHA3-512 and the result fed into AeKeyFromSeed. An
+// all-zero (default) signature is rejected, matching the Rust implementation.
+func AeKeyFromSigner(signer Signer, publicSeed []byte) (AeKey, error) {
+	msg := make([]byte, 0, len(aeSigningDomain)+len(publicSeed))
+	msg = append(msg, aeSigningDomain...)
+	msg = append(msg, publicSeed...)
+
+	sig, err := signer.Sign(msg)
+	if err != nil {
+		return AeKey{}, fmt.Errorf("zkencryption: sign AeKey public seed: %w", err)
+	}
+	if sig == (solana.Signature{}) {
+		return AeKey{}, ErrDefaultSignature
+	}
+	return AeKeyFromSignature(sig)
+}
+
+// AeKeyFromSeedPhraseAndPassphrase derives an AeKey from a BIP39 mnemonic and
+// an optional passphrase using the standard BIP39 PBKDF2-HMAC-SHA512 seed
+// derivation (2048 iterations, 64-byte output), matching
+// solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase. Solana
+// does not validate the mnemonic checksum at this layer, and neither do we.
+func AeKeyFromSeedPhraseAndPassphrase(mnemonic, passphrase string) (AeKey, error) {
+	return AeKeyFromSeed(bip39.NewSeed(mnemonic, passphrase))
+}

--- a/programs/token-2022/zkencryption/doc.go
+++ b/programs/token-2022/zkencryption/doc.go
@@ -1,0 +1,13 @@
+// Package zkencryption ports the deterministic key-derivation functions from
+// solana-zk-sdk (zk-sdk/src/encryption) to Go. It produces byte-for-byte
+// identical ElGamal secret keys and authenticated-encryption (AeKey) keys to
+// the Rust and JS/WASM reference implementations, so the same signer and
+// public seed derive the same key material across all three SDKs.
+//
+// Scope: key derivation only. Encryption, decryption, Pedersen commitments,
+// and zero-knowledge proof generation are not in this package; callers that
+// need a full confidential-transfer flow must still produce proofs via an
+// external source (Rust solana-zk-sdk or JS @solana/zk-sdk WASM).
+//
+// Reference: https://github.com/solana-program/zk-elgamal-proof
+package zkencryption

--- a/programs/token-2022/zkencryption/elgamal_secret.go
+++ b/programs/token-2022/zkencryption/elgamal_secret.go
@@ -1,0 +1,92 @@
+package zkencryption
+
+import (
+	"crypto/sha3"
+	"fmt"
+
+	"filippo.io/edwards25519"
+	"github.com/gagliardetto/solana-go"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// ElGamalSecretKeyLen is the canonical length of an ElGamal secret scalar
+// encoded in little-endian form (matches curve25519-dalek Scalar::as_bytes).
+const ElGamalSecretKeyLen = 32
+
+// elGamalSigningDomain is the domain-separation prefix prepended to the
+// public seed before signing. It must match b"ElGamalSecretKey" in
+// solana-zk-sdk.
+const elGamalSigningDomain = "ElGamalSecretKey"
+
+// minElGamalSeedLen / maxElGamalSeedLen mirror the bounds enforced in
+// solana-zk-sdk's ElGamalSecretKey::from_seed implementation.
+const (
+	minElGamalSeedLen = ElGamalSecretKeyLen
+	maxElGamalSeedLen = 65535
+)
+
+// ElGamalSecretKey is a canonical little-endian encoding of a Ristretto/Ed25519
+// scalar mod ell. It is the Token-2022 confidential-transfer ElGamal private
+// key; byte-for-byte equivalent to ElGamalSecretKey::as_bytes in solana-zk-sdk.
+type ElGamalSecretKey [ElGamalSecretKeyLen]byte
+
+// ElGamalSecretKeyFromSeed derives an ElGamal secret key from an entropy seed
+// by computing Scalar::from_bytes_mod_order_wide(SHA3-512(seed)), matching
+// curve25519-dalek's Scalar::hash_from_bytes::<Sha3_512>.
+func ElGamalSecretKeyFromSeed(seed []byte) (ElGamalSecretKey, error) {
+	if len(seed) < minElGamalSeedLen {
+		return ElGamalSecretKey{}, ErrSeedTooShort
+	}
+	if len(seed) > maxElGamalSeedLen {
+		return ElGamalSecretKey{}, ErrSeedTooLong
+	}
+
+	h := sha3.Sum512(seed)
+	// SetUniformBytes only errors on wrong input length; Sum512 always
+	// returns 64 bytes, so this branch is unreachable in practice but kept
+	// to avoid an implicit panic if the upstream contract ever changes.
+	s, err := edwards25519.NewScalar().SetUniformBytes(h[:])
+	if err != nil {
+		return ElGamalSecretKey{}, ErrInvalidScalarEncoding
+	}
+
+	var out ElGamalSecretKey
+	copy(out[:], s.Bytes())
+	return out, nil
+}
+
+// ElGamalSecretKeyFromSignature derives an ElGamal secret key from an ed25519
+// signature by using SHA3-512(signature) as the seed. Mirrors
+// ElGamalSecretKey::seed_from_signature + from_seed in solana-zk-sdk.
+func ElGamalSecretKeyFromSignature(sig solana.Signature) (ElGamalSecretKey, error) {
+	h := sha3.Sum512(sig[:])
+	return ElGamalSecretKeyFromSeed(h[:])
+}
+
+// ElGamalSecretKeyFromSigner deterministically derives an ElGamal secret key
+// from a Solana signer and a public seed. The signer signs
+// b"ElGamalSecretKey" || publicSeed; the signature is hashed with SHA3-512
+// and fed into ElGamalSecretKeyFromSeed. An all-zero (default) signature is
+// rejected to match the Rust implementation.
+func ElGamalSecretKeyFromSigner(signer Signer, publicSeed []byte) (ElGamalSecretKey, error) {
+	msg := make([]byte, 0, len(elGamalSigningDomain)+len(publicSeed))
+	msg = append(msg, elGamalSigningDomain...)
+	msg = append(msg, publicSeed...)
+
+	sig, err := signer.Sign(msg)
+	if err != nil {
+		return ElGamalSecretKey{}, fmt.Errorf("zkencryption: sign ElGamalSecretKey public seed: %w", err)
+	}
+	if sig == (solana.Signature{}) {
+		return ElGamalSecretKey{}, ErrDefaultSignature
+	}
+	return ElGamalSecretKeyFromSignature(sig)
+}
+
+// ElGamalSecretKeyFromSeedPhraseAndPassphrase derives an ElGamal secret key
+// from a BIP39 mnemonic and an optional passphrase, matching
+// solana_seed_phrase's PBKDF2-HMAC-SHA512 derivation. Solana does not
+// validate the mnemonic checksum at this layer, and neither do we.
+func ElGamalSecretKeyFromSeedPhraseAndPassphrase(mnemonic, passphrase string) (ElGamalSecretKey, error) {
+	return ElGamalSecretKeyFromSeed(bip39.NewSeed(mnemonic, passphrase))
+}

--- a/programs/token-2022/zkencryption/errors.go
+++ b/programs/token-2022/zkencryption/errors.go
@@ -1,0 +1,10 @@
+package zkencryption
+
+import "errors"
+
+var (
+	ErrSeedTooShort          = errors.New("zkencryption: seed is too short")
+	ErrSeedTooLong           = errors.New("zkencryption: seed is too long")
+	ErrDefaultSignature      = errors.New("zkencryption: refusing to derive key from default (all-zero) signature")
+	ErrInvalidScalarEncoding = errors.New("zkencryption: scalar wide-reduction failed")
+)

--- a/programs/token-2022/zkencryption/examples/deriveKeys/deriveKeys.go
+++ b/programs/token-2022/zkencryption/examples/deriveKeys/deriveKeys.go
@@ -1,0 +1,70 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command deriveKeys shows how to deterministically derive the two key
+// materials used by the Token-2022 confidential-transfer extension from a
+// Solana signer: the ElGamal secret key and the AES (AeKey) key.
+//
+// This is the primary derivation path used by wallets: the same signer and
+// public seed always derive the same keys, so a user can recover their
+// confidential-transfer keys from their wallet alone, with nothing stored
+// on-chain or off-chain. The keys produced here are byte-for-byte identical
+// to those from the Rust solana-zk-sdk and the JS/WASM @solana/zk-sdk, given
+// the same signer and seed.
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/token-2022/zkencryption"
+)
+
+func main() {
+	// In a real application this is the user's wallet key (or a hardware
+	// wallet / remote signer implementing zkencryption.Signer). solana.PrivateKey
+	// already satisfies the Signer interface. We use a fixed seed here only so
+	// the example output is reproducible.
+	wallet := solana.NewWallet().PrivateKey
+
+	// The public seed scopes the derived keys. For confidential transfers this
+	// is conventionally the token account (ATA) address whose balance the keys
+	// protect, so distinct accounts owned by the same wallet get distinct keys.
+	tokenAccount := solana.NewWallet().PublicKey()
+	publicSeed := tokenAccount.Bytes()
+
+	elgamal, err := zkencryption.ElGamalSecretKeyFromSigner(wallet, publicSeed)
+	if err != nil {
+		panic(err)
+	}
+
+	aeKey, err := zkencryption.AeKeyFromSigner(wallet, publicSeed)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("wallet:            ", wallet.PublicKey())
+	fmt.Println("token account:     ", tokenAccount)
+	fmt.Println("ElGamal secret key:", hex.EncodeToString(elgamal[:]))
+	fmt.Println("AeKey:             ", hex.EncodeToString(aeKey[:]))
+
+	// Derivation is deterministic: signer + public seed always yield the same
+	// keys, which is what lets a wallet recover them on demand.
+	again, err := zkencryption.ElGamalSecretKeyFromSigner(wallet, publicSeed)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("deterministic:     ", elgamal == again)
+}

--- a/programs/token-2022/zkencryption/kdf_test.go
+++ b/programs/token-2022/zkencryption/kdf_test.go
@@ -1,0 +1,262 @@
+package zkencryption_test
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/token-2022/zkencryption"
+)
+
+type fromSeedVec struct {
+	Name             string `json:"name"`
+	SeedHex          string `json:"seed_hex"`
+	AeKeyHex         string `json:"ae_key_hex"`
+	ElGamalSecretHex string `json:"elgamal_secret_hex"`
+}
+
+type fromSignatureVec struct {
+	Name             string `json:"name"`
+	SignatureHex     string `json:"signature_hex"`
+	AeKeyHex         string `json:"ae_key_hex"`
+	ElGamalSecretHex string `json:"elgamal_secret_hex"`
+}
+
+type fromSignerVec struct {
+	Name             string `json:"name"`
+	KeypairSecretHex string `json:"keypair_secret_hex"`
+	PublicSeedHex    string `json:"public_seed_hex"`
+	AeKeyHex         string `json:"ae_key_hex"`
+	ElGamalSecretHex string `json:"elgamal_secret_hex"`
+}
+
+type fromMnemonicVec struct {
+	Name             string `json:"name"`
+	Mnemonic         string `json:"mnemonic"`
+	Passphrase       string `json:"passphrase"`
+	AeKeyHex         string `json:"ae_key_hex"`
+	ElGamalSecretHex string `json:"elgamal_secret_hex"`
+}
+
+type vectors struct {
+	FromSeed      []fromSeedVec      `json:"from_seed"`
+	FromSignature []fromSignatureVec `json:"from_signature"`
+	FromSigner    []fromSignerVec    `json:"from_signer"`
+	FromMnemonic  []fromMnemonicVec  `json:"from_mnemonic"`
+}
+
+func loadVectors(t *testing.T) vectors {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "kdf_vectors.json"))
+	if err != nil {
+		t.Fatalf("read test vectors: %v", err)
+	}
+	var v vectors
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("decode test vectors: %v", err)
+	}
+	return v
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode hex %q: %v", s, err)
+	}
+	return b
+}
+
+func TestFromSeed_MatchesRust(t *testing.T) {
+	t.Parallel()
+	for _, v := range loadVectors(t).FromSeed {
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+			seed := mustHex(t, v.SeedHex)
+
+			ae, err := zkencryption.AeKeyFromSeed(seed)
+			if err != nil {
+				t.Fatalf("AeKeyFromSeed: %v", err)
+			}
+			if got := hex.EncodeToString(ae[:]); got != v.AeKeyHex {
+				t.Errorf("AeKey mismatch: got %s want %s", got, v.AeKeyHex)
+			}
+
+			el, err := zkencryption.ElGamalSecretKeyFromSeed(seed)
+			if err != nil {
+				t.Fatalf("ElGamalSecretKeyFromSeed: %v", err)
+			}
+			if got := hex.EncodeToString(el[:]); got != v.ElGamalSecretHex {
+				t.Errorf("ElGamalSecretKey mismatch: got %s want %s", got, v.ElGamalSecretHex)
+			}
+		})
+	}
+}
+
+func TestFromSignature_MatchesRust(t *testing.T) {
+	t.Parallel()
+	for _, v := range loadVectors(t).FromSignature {
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+			raw := mustHex(t, v.SignatureHex)
+			var sig solana.Signature
+			copy(sig[:], raw)
+
+			ae, err := zkencryption.AeKeyFromSignature(sig)
+			if err != nil {
+				t.Fatalf("AeKeyFromSignature: %v", err)
+			}
+			if got := hex.EncodeToString(ae[:]); got != v.AeKeyHex {
+				t.Errorf("AeKey mismatch: got %s want %s", got, v.AeKeyHex)
+			}
+
+			el, err := zkencryption.ElGamalSecretKeyFromSignature(sig)
+			if err != nil {
+				t.Fatalf("ElGamalSecretKeyFromSignature: %v", err)
+			}
+			if got := hex.EncodeToString(el[:]); got != v.ElGamalSecretHex {
+				t.Errorf("ElGamalSecretKey mismatch: got %s want %s", got, v.ElGamalSecretHex)
+			}
+		})
+	}
+}
+
+func TestFromSigner_MatchesRust(t *testing.T) {
+	t.Parallel()
+	for _, v := range loadVectors(t).FromSigner {
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+			seed32 := mustHex(t, v.KeypairSecretHex)
+			if len(seed32) != ed25519.SeedSize {
+				t.Fatalf("keypair seed is %d bytes, want %d", len(seed32), ed25519.SeedSize)
+			}
+			// solana.PrivateKey matches ed25519.PrivateKey layout: seed || pubkey.
+			priv := solana.PrivateKey(ed25519.NewKeyFromSeed(seed32))
+			publicSeed := mustHex(t, v.PublicSeedHex)
+
+			ae, err := zkencryption.AeKeyFromSigner(priv, publicSeed)
+			if err != nil {
+				t.Fatalf("AeKeyFromSigner: %v", err)
+			}
+			if got := hex.EncodeToString(ae[:]); got != v.AeKeyHex {
+				t.Errorf("AeKey mismatch: got %s want %s", got, v.AeKeyHex)
+			}
+
+			el, err := zkencryption.ElGamalSecretKeyFromSigner(priv, publicSeed)
+			if err != nil {
+				t.Fatalf("ElGamalSecretKeyFromSigner: %v", err)
+			}
+			if got := hex.EncodeToString(el[:]); got != v.ElGamalSecretHex {
+				t.Errorf("ElGamalSecretKey mismatch: got %s want %s", got, v.ElGamalSecretHex)
+			}
+		})
+	}
+}
+
+func TestFromSeedPhraseAndPassphrase_MatchesRust(t *testing.T) {
+	t.Parallel()
+	for _, v := range loadVectors(t).FromMnemonic {
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+			ae, err := zkencryption.AeKeyFromSeedPhraseAndPassphrase(v.Mnemonic, v.Passphrase)
+			if err != nil {
+				t.Fatalf("AeKeyFromSeedPhraseAndPassphrase: %v", err)
+			}
+			if got := hex.EncodeToString(ae[:]); got != v.AeKeyHex {
+				t.Errorf("AeKey mismatch: got %s want %s", got, v.AeKeyHex)
+			}
+
+			el, err := zkencryption.ElGamalSecretKeyFromSeedPhraseAndPassphrase(v.Mnemonic, v.Passphrase)
+			if err != nil {
+				t.Fatalf("ElGamalSecretKeyFromSeedPhraseAndPassphrase: %v", err)
+			}
+			if got := hex.EncodeToString(el[:]); got != v.ElGamalSecretHex {
+				t.Errorf("ElGamalSecretKey mismatch: got %s want %s", got, v.ElGamalSecretHex)
+			}
+		})
+	}
+}
+
+func TestSeedLengthBounds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		run     func() error
+		wantErr error
+	}{
+		{
+			"ae_too_short",
+			func() error { _, err := zkencryption.AeKeyFromSeed(make([]byte, 15)); return err },
+			zkencryption.ErrSeedTooShort,
+		},
+		{
+			"ae_at_minimum",
+			func() error { _, err := zkencryption.AeKeyFromSeed(make([]byte, 16)); return err },
+			nil,
+		},
+		{
+			"ae_too_long",
+			func() error { _, err := zkencryption.AeKeyFromSeed(make([]byte, 65536)); return err },
+			zkencryption.ErrSeedTooLong,
+		},
+		{
+			"elgamal_too_short",
+			func() error { _, err := zkencryption.ElGamalSecretKeyFromSeed(make([]byte, 31)); return err },
+			zkencryption.ErrSeedTooShort,
+		},
+		{
+			"elgamal_at_minimum",
+			func() error { _, err := zkencryption.ElGamalSecretKeyFromSeed(make([]byte, 32)); return err },
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.run()
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// stubSigner implements zkencryption.Signer with a fixed signature, for
+// exercising error paths (notably the default-signature rejection) without
+// needing a specially crafted ed25519 keypair.
+type stubSigner struct {
+	sig solana.Signature
+	err error
+}
+
+func (s stubSigner) Sign(_ []byte) (solana.Signature, error) { return s.sig, s.err }
+
+func TestFromSigner_RejectsDefaultSignature(t *testing.T) {
+	t.Parallel()
+	signer := stubSigner{} // zero-valued Signature
+
+	if _, err := zkencryption.AeKeyFromSigner(signer, []byte("seed")); !errors.Is(err, zkencryption.ErrDefaultSignature) {
+		t.Fatalf("AeKeyFromSigner: err = %v, want ErrDefaultSignature", err)
+	}
+	if _, err := zkencryption.ElGamalSecretKeyFromSigner(signer, []byte("seed")); !errors.Is(err, zkencryption.ErrDefaultSignature) {
+		t.Fatalf("ElGamalSecretKeyFromSigner: err = %v, want ErrDefaultSignature", err)
+	}
+}
+
+func TestFromSigner_WrapsSignerError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("hsm unreachable")
+	signer := stubSigner{err: sentinel}
+
+	if _, err := zkencryption.AeKeyFromSigner(signer, nil); !errors.Is(err, sentinel) {
+		t.Fatalf("AeKeyFromSigner: err = %v, want wrapped sentinel", err)
+	}
+	if _, err := zkencryption.ElGamalSecretKeyFromSigner(signer, nil); !errors.Is(err, sentinel) {
+		t.Fatalf("ElGamalSecretKeyFromSigner: err = %v, want wrapped sentinel", err)
+	}
+}

--- a/programs/token-2022/zkencryption/kdf_test.go
+++ b/programs/token-2022/zkencryption/kdf_test.go
@@ -214,6 +214,11 @@ func TestSeedLengthBounds(t *testing.T) {
 			func() error { _, err := zkencryption.ElGamalSecretKeyFromSeed(make([]byte, 32)); return err },
 			nil,
 		},
+		{
+			"elgamal_too_long",
+			func() error { _, err := zkencryption.ElGamalSecretKeyFromSeed(make([]byte, 65536)); return err },
+			zkencryption.ErrSeedTooLong,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/programs/token-2022/zkencryption/signer.go
+++ b/programs/token-2022/zkencryption/signer.go
@@ -1,0 +1,12 @@
+package zkencryption
+
+import "github.com/gagliardetto/solana-go"
+
+// Signer is the minimal signing contract needed to derive confidential-transfer
+// keys from a Solana signer. It is satisfied by solana.PrivateKey out of the
+// box, and can be implemented by hardware wallets, remote signing services,
+// or any other custody that can sign an arbitrary byte message and return a
+// deterministic ed25519 signature.
+type Signer interface {
+	Sign(message []byte) (solana.Signature, error)
+}

--- a/programs/token-2022/zkencryption/testdata/README.md
+++ b/programs/token-2022/zkencryption/testdata/README.md
@@ -1,0 +1,234 @@
+# Cross-language KDF test vectors
+
+`kdf_vectors.json` holds the authoritative byte-for-byte outputs of the
+Rust `solana-zk-sdk` key-derivation functions for a fixed set of inputs.
+The Go tests in the parent package load this file and assert equality,
+which is how we guarantee our Go KDF stays aligned with the Rust / JS /
+WASM SDKs.
+
+The fixture is static. Regeneration is only needed if `solana-zk-sdk`
+ships a breaking change to the KDF (historically stable).
+
+## What the vectors cover
+
+- `from_seed`: `AeKey::from_seed` / `ElGamalSecretKey::from_seed` on a set
+  of fixed-length entropy seeds (32, 48, 64 bytes).
+- `from_signature`: `new_from_signature` on deterministic signature byte
+  patterns (no signer involvement).
+- `from_signer`: `new_from_signer` using fixed ed25519 keypairs and a
+  range of public-seed values (empty, short, long).
+- `from_mnemonic`: `from_seed_phrase_and_passphrase` on the official
+  Trezor/BIP39 mnemonics with and without a passphrase.
+
+## Regenerating
+
+Requires a working Rust toolchain. Create a throwaway cargo project and
+run the harness below; replace the existing `kdf_vectors.json` with its
+stdout.
+
+`Cargo.toml`:
+
+```toml
+[package]
+name = "kdf-vector-gen"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+solana-zk-sdk = "6.0.1"
+solana-signature = "3.1.0"
+solana-signer = "3.0.0"
+solana-keypair = "3.0.1"
+solana-seed-derivable = "3.0.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+hex = "0.4"
+```
+
+`src/main.rs`:
+
+```rust
+use serde::Serialize;
+use solana_keypair::Keypair;
+use solana_seed_derivable::SeedDerivable;
+use solana_signature::Signature;
+use solana_zk_sdk::encryption::auth_encryption::AeKey;
+use solana_zk_sdk::encryption::elgamal::ElGamalSecretKey;
+
+#[derive(Serialize)]
+struct FromSeedVector {
+    name: String,
+    seed_hex: String,
+    ae_key_hex: String,
+    elgamal_secret_hex: String,
+}
+
+#[derive(Serialize)]
+struct FromSignatureVector {
+    name: String,
+    signature_hex: String,
+    ae_key_hex: String,
+    elgamal_secret_hex: String,
+}
+
+#[derive(Serialize)]
+struct FromSignerVector {
+    name: String,
+    keypair_secret_hex: String,
+    public_seed_hex: String,
+    ae_key_hex: String,
+    elgamal_secret_hex: String,
+}
+
+#[derive(Serialize)]
+struct FromMnemonicVector {
+    name: String,
+    mnemonic: String,
+    passphrase: String,
+    ae_key_hex: String,
+    elgamal_secret_hex: String,
+}
+
+#[derive(Serialize)]
+struct Vectors {
+    from_seed: Vec<FromSeedVector>,
+    from_signature: Vec<FromSignatureVector>,
+    from_signer: Vec<FromSignerVector>,
+    from_mnemonic: Vec<FromMnemonicVector>,
+}
+
+fn ae_bytes(key: &AeKey) -> [u8; 16] {
+    key.clone().into()
+}
+
+fn derive_from_seed(name: &str, seed: &[u8]) -> FromSeedVector {
+    let ae = AeKey::from_seed(seed).unwrap();
+    let el = ElGamalSecretKey::from_seed(seed).unwrap();
+    FromSeedVector {
+        name: name.into(),
+        seed_hex: hex::encode(seed),
+        ae_key_hex: hex::encode(ae_bytes(&ae)),
+        elgamal_secret_hex: hex::encode(el.as_bytes()),
+    }
+}
+
+fn derive_from_signature(name: &str, bytes: [u8; 64]) -> FromSignatureVector {
+    let sig = Signature::from(bytes);
+    let ae = AeKey::new_from_signature(&sig).unwrap();
+    let el = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+    FromSignatureVector {
+        name: name.into(),
+        signature_hex: hex::encode(bytes),
+        ae_key_hex: hex::encode(ae_bytes(&ae)),
+        elgamal_secret_hex: hex::encode(el.as_bytes()),
+    }
+}
+
+fn derive_from_signer(name: &str, seed32: &[u8; 32], public_seed: &[u8]) -> FromSignerVector {
+    let kp = Keypair::new_from_array(*seed32);
+    let ae = AeKey::new_from_signer(&kp, public_seed).unwrap();
+    let el = ElGamalSecretKey::new_from_signer(&kp, public_seed).unwrap();
+    FromSignerVector {
+        name: name.into(),
+        keypair_secret_hex: hex::encode(seed32),
+        public_seed_hex: hex::encode(public_seed),
+        ae_key_hex: hex::encode(ae_bytes(&ae)),
+        elgamal_secret_hex: hex::encode(el.as_bytes()),
+    }
+}
+
+fn derive_from_mnemonic(name: &str, mnemonic: &str, passphrase: &str) -> FromMnemonicVector {
+    let ae = AeKey::from_seed_phrase_and_passphrase(mnemonic, passphrase).unwrap();
+    let el = ElGamalSecretKey::from_seed_phrase_and_passphrase(mnemonic, passphrase).unwrap();
+    FromMnemonicVector {
+        name: name.into(),
+        mnemonic: mnemonic.into(),
+        passphrase: passphrase.into(),
+        ae_key_hex: hex::encode(ae_bytes(&ae)),
+        elgamal_secret_hex: hex::encode(el.as_bytes()),
+    }
+}
+
+fn main() {
+    let from_seed = vec![
+        derive_from_seed("all_zero_32", &[0u8; 32]),
+        derive_from_seed("all_one_32", &[0x11u8; 32]),
+        derive_from_seed("ascending_64", &(0u8..64).collect::<Vec<u8>>()),
+        derive_from_seed(
+            "mixed_48",
+            &hex::decode(
+                "0102030405060708090a0b0c0d0e0f101112131415161718\
+                 191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30",
+            )
+            .unwrap(),
+        ),
+    ];
+
+    let from_signature = vec![
+        derive_from_signature("sig_deadbeef", {
+            let mut s = [0u8; 64];
+            for (i, b) in s.iter_mut().enumerate() {
+                *b = ((i as u16 * 7 + 0xde) & 0xff) as u8;
+            }
+            s
+        }),
+        derive_from_signature("sig_increment", {
+            let mut s = [0u8; 64];
+            for (i, b) in s.iter_mut().enumerate() {
+                *b = i as u8;
+            }
+            s
+        }),
+    ];
+
+    let kp_seed_a: [u8; 32] = [
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+        0xff, 0x00,
+    ];
+    let kp_seed_b: [u8; 32] = [
+        0x7e, 0x57, 0x7e, 0x57, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44,
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33,
+        0x44, 0x55,
+    ];
+
+    let from_signer = vec![
+        derive_from_signer("keypair_a_empty_seed", &kp_seed_a, &[]),
+        derive_from_signer("keypair_a_mint_seed", &kp_seed_a, b"some-mint-pubkey"),
+        derive_from_signer("keypair_b_mint_seed", &kp_seed_b, b"some-mint-pubkey"),
+        derive_from_signer(
+            "keypair_b_long_seed",
+            &kp_seed_b,
+            b"a-rather-longer-public-seed-used-for-domain-separation",
+        ),
+    ];
+
+    let from_mnemonic = vec![
+        derive_from_mnemonic(
+            "trezor_all_abandon_no_passphrase",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "",
+        ),
+        derive_from_mnemonic(
+            "trezor_all_abandon_trezor_passphrase",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "TREZOR",
+        ),
+        derive_from_mnemonic(
+            "legal_winner_trezor",
+            "legal winner thank year wave sausage worth useful legal winner thank yellow",
+            "TREZOR",
+        ),
+    ];
+
+    let out = Vectors { from_seed, from_signature, from_signer, from_mnemonic };
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
+}
+```
+
+Then:
+
+```
+cargo run --release > path/to/kdf_vectors.json
+```

--- a/programs/token-2022/zkencryption/testdata/kdf_vectors.json
+++ b/programs/token-2022/zkencryption/testdata/kdf_vectors.json
@@ -1,0 +1,95 @@
+{
+  "from_seed": [
+    {
+      "name": "all_zero_32",
+      "seed_hex": "0000000000000000000000000000000000000000000000000000000000000000",
+      "ae_key_hex": "ad56c35cab5063b9e7ea568314ec81c4",
+      "elgamal_secret_hex": "97e676b07bfa0d85006fc9c443428e90083a83a61116e65ccc2ba760ea66ab04"
+    },
+    {
+      "name": "all_one_32",
+      "seed_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+      "ae_key_hex": "0c96e4cfe1285f5c2b9033c3ef50bbca",
+      "elgamal_secret_hex": "23c6e7a2a3eeb66e823d6d8d113100f816b90467aabaf2244758c4e0a4882d06"
+    },
+    {
+      "name": "ascending_64",
+      "seed_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+      "ae_key_hex": "cb29601efbee71f4dfbb7f1c2bdaeafd",
+      "elgamal_secret_hex": "ac5aeea5fc28ef2541a9ee1805f7f3e530c290139f82cbd426b50cc9ce4c670e"
+    },
+    {
+      "name": "mixed_48",
+      "seed_hex": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30",
+      "ae_key_hex": "5e2771d81531881122aaf5b0e03541cc",
+      "elgamal_secret_hex": "65aa89be80a1a2bd7a57c7f826fa55db8000f33f4b071575bfa915e6b1484a0f"
+    }
+  ],
+  "from_signature": [
+    {
+      "name": "sig_deadbeef",
+      "signature_hex": "dee5ecf3fa01080f161d242b323940474e555c636a71787f868d949ba2a9b0b7bec5ccd3dae1e8eff6fd040b121920272e353c434a51585f666d747b82899097",
+      "ae_key_hex": "83d76b6e585202327352f43cb937f222",
+      "elgamal_secret_hex": "d971ca8cfb4fe603c38d0994284eafc783f7a79fd834246f012cc27715333405"
+    },
+    {
+      "name": "sig_increment",
+      "signature_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+      "ae_key_hex": "10de808f82059adfa2992d0cdaa845df",
+      "elgamal_secret_hex": "d4a09f7c774de4c629e8cce1c8943709c95026a54c079ed63ee98cd15307610f"
+    }
+  ],
+  "from_signer": [
+    {
+      "name": "keypair_a_empty_seed",
+      "keypair_secret_hex": "112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00",
+      "public_seed_hex": "",
+      "ae_key_hex": "c22f9bd211f5f0758517a316d99c7842",
+      "elgamal_secret_hex": "1c39bd311012f04bff07474a87fe32dd240e9dc53c5f0e50c81cda1b972f9d08"
+    },
+    {
+      "name": "keypair_a_mint_seed",
+      "keypair_secret_hex": "112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00",
+      "public_seed_hex": "736f6d652d6d696e742d7075626b6579",
+      "ae_key_hex": "4d844c1ca59daf8547106b218e612b26",
+      "elgamal_secret_hex": "2b1de3492590211b779acba99048339c845e5c7cf5c95f2bf1d4352ff105d50c"
+    },
+    {
+      "name": "keypair_b_mint_seed",
+      "keypair_secret_hex": "7e577e57aabbccddeeff00112233445566778899aabbccddeeff001122334455",
+      "public_seed_hex": "736f6d652d6d696e742d7075626b6579",
+      "ae_key_hex": "15715bd1aa276dd1653c9dd28e780971",
+      "elgamal_secret_hex": "8d3a6cb60be0b4a01c1cfab479487c2a701c3e71d28ad9cf422f9262d06aef04"
+    },
+    {
+      "name": "keypair_b_long_seed",
+      "keypair_secret_hex": "7e577e57aabbccddeeff00112233445566778899aabbccddeeff001122334455",
+      "public_seed_hex": "612d7261746865722d6c6f6e6765722d7075626c69632d736565642d757365642d666f722d646f6d61696e2d73657061726174696f6e",
+      "ae_key_hex": "2da6c7bc25bd3b82b19b2cfba74d6e0d",
+      "elgamal_secret_hex": "a529aef3895d534e2140e06a6b558bbb20b6a124d548c01385de9f3a90272300"
+    }
+  ],
+  "from_mnemonic": [
+    {
+      "name": "trezor_all_abandon_no_passphrase",
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "passphrase": "",
+      "ae_key_hex": "23f20b9df0405b4675fd27d682bb2a30",
+      "elgamal_secret_hex": "55def0e683cd64d0918c93672835def6253d8ba5bee85df27c4daa34abeb5e03"
+    },
+    {
+      "name": "trezor_all_abandon_trezor_passphrase",
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "passphrase": "TREZOR",
+      "ae_key_hex": "c7cca7af94c37e320752a00aef3425cb",
+      "elgamal_secret_hex": "3297e41ec815c1d17368a20c925d0f4d786967fa8e96f1179b2dcd646ffa6905"
+    },
+    {
+      "name": "legal_winner_trezor",
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank yellow",
+      "passphrase": "TREZOR",
+      "ae_key_hex": "da372f904b8542269d20d80fec8c4188",
+      "elgamal_secret_hex": "f2fb947e011587f12047631c94e80777177486437c12b1db93d146f4a2823b0b"
+    }
+  ]
+}


### PR DESCRIPTION
### Problem

`solana-go` has no Token-2022 confidential-transfer key-derivation support #412. Rust solana-zk-sdk and JS `@solana/zk-sdk` ship deterministic KDFs that turn a Solana signer + public seed into an ElGamal secret scalar and an AES-128-GCM-SIV key;
Go users currently have to call into Rust or JS/WASM just to produce the key material a confidential transfer needs.
First step of the port is the KDF itself, byte-for-byte compatible with the reference SDKs.

### Summary of Changes

- AeKey (16 bytes, AES-128-GCM-SIV key): AeKeyFromSeed, AeKeyFromSignature, AeKeyFromSigner, AeKeyFromSeedPhraseAndPassphrase
- ElGamalSecretKey (32 bytes, canonical Ristretto/Ed25519 scalar mod ell): ElGamalSecretKeyFromSeed, ElGamalSecretKeyFromSignature, ElGamalSecretKeyFromSigner, ElGamalSecretKeyFromSeedPhraseAndPassphrase
- Signer interface (minimal: Sign(message) -> solana.Signature, error);  `solana.PrivateKey` satisfies it; hardware wallets and remote signers can plug in without changes.
- Seed-length bounds and default-signature rejection mirror the Rust implementation (ErrSeedTooShort, ErrSeedTooLong, ErrDefaultSignature).


related to https://github.com/solana-foundation/solana-go/issues/412