### PR TITLE
chore(lint): apply linter to newly merged changes

### DIFF
--- a/message.go
+++ b/message.go
@@ -23,7 +23,7 @@ import (
 
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/treeout"
-	jsoniter "github.com/json-iterator/go"
+	gojson "github.com/goccy/go-json"
 
 	"github.com/gagliardetto/solana-go/text"
 )
@@ -242,7 +242,7 @@ func (mx *Message) UnmarshalJSON(data []byte) error {
 		Header              MessageHeader         `json:"header"`
 		RecentBlockhash     Hash                  `json:"recentBlockhash"`
 		Instructions        []CompiledInstruction `json:"instructions"`
-		AddressTableLookups *jsoniter.RawMessage  `json:"addressTableLookups"`
+		AddressTableLookups *gojson.RawMessage    `json:"addressTableLookups"`
 	}{}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err

--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 
 	"github.com/davecgh/go-spew/spew"
-	stdjson "github.com/goccy/go-json"
 	gojson "github.com/goccy/go-json"
+	stdjson "github.com/goccy/go-json"
 	"github.com/google/uuid"
 )
 

--- a/rpc/util_test.go
+++ b/rpc/util_test.go
@@ -11,19 +11,21 @@ import (
 // Layout references for the test data below:
 //
 // SPL Token (solana-program/token):
-//   Mint::LEN    = 82
-//   Account::LEN = 165
+//
+//	Mint::LEN    = 82
+//	Account::LEN = 165
 //
 // Token-2022 (solana-program/token-2022):
-//   Extended records place a 1-byte AccountType discriminator at offset
-//   Account::LEN (= 165). Mint base (82 bytes) is padded with 83 zeros so
-//   Mint and Account share the discriminator offset.
 //
-//   AccountType::Uninitialized = 0
-//   AccountType::Mint          = 1
-//   AccountType::Account       = 2
+//	Extended records place a 1-byte AccountType discriminator at offset
+//	Account::LEN (= 165). Mint base (82 bytes) is padded with 83 zeros so
+//	Mint and Account share the discriminator offset.
 //
-//   Extensions follow as TLV: [u16 LE type][u16 LE length][value...].
+//	AccountType::Uninitialized = 0
+//	AccountType::Mint          = 1
+//	AccountType::Account       = 2
+//
+//	Extensions follow as TLV: [u16 LE type][u16 LE length][value...].
 const (
 	testAccountTypeUninitialized uint8 = 0
 	testAccountTypeMint          uint8 = 1

--- a/transaction_bench_test.go
+++ b/transaction_bench_test.go
@@ -11,7 +11,8 @@ import (
 //
 // numInstructions: how many instructions in the transaction.
 // accountsPerIx:   how many AccountMeta entries each instruction references.
-//                  (first is always a signer; second is always writable; rest readonly)
+//
+//	(first is always a signer; second is always writable; rest readonly)
 func buildBenchInstructions(numInstructions, accountsPerIx int) ([]Instruction, Hash) {
 	// Pre-generate a pool of unique accounts so instructions share some accounts
 	// (realistic — the same fee payer / writable state account appears in many ixs)
@@ -98,9 +99,9 @@ func buildBenchInstructionsWithLookups(numInstructions, accountsPerIx int) ([]In
 // Upper bound is ~10 instructions / ~30 accounts per ix — beyond that
 // becomes a synthetic stress shape that doesn't represent real traffic.
 var benchTxShapes = []struct {
-	name           string
+	name            string
 	numInstructions int
-	accountsPerIx  int
+	accountsPerIx   int
 }{
 	{"small_2ix_5accts", 2, 5},
 	{"medium_5ix_15accts", 5, 15},


### PR DESCRIPTION
### Problem

latest changes that were merged are not linted, that's why CI step fails

### Solution

run golangci lint and apply fixes to the findings