### PR TITLE
refactor(base58): replace mr-tron/base58 with in-tree long-division encoder

### DIFF
--- a/base58/base58_test.go
+++ b/base58/base58_test.go
@@ -3,9 +3,9 @@ package base58
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
-	mrtronbase58 "github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,18 +98,22 @@ func TestDecode32_Zeros(t *testing.T) {
 }
 
 func TestRoundtrip32_Random(t *testing.T) {
-	// Cross-check the specialized fixed-size path against mr-tron's
-	// well-tested general-purpose implementation.
+	// Cross-check the specialized fixed-size path against the variable-length
+	// fallback — the two share no code, so disagreement flags a bug.
 	for range 1000 {
 		var src [32]byte
 		rand.Read(src[:])
 
-		encoded := Encode32(&src)
-		assert.Equal(t, mrtronbase58.Encode(src[:]), encoded, "encode mismatch for %x", src)
+		encoded := Encode(src[:])
+		assert.Equal(t, encodeVariable(src[:]), encoded, "encode mismatch for %x", src)
 
 		var decoded [32]byte
 		require.NoError(t, Decode32(encoded, &decoded))
 		assert.Equal(t, src, decoded, "decode mismatch for %s", encoded)
+
+		generic, err := Decode(encoded)
+		require.NoError(t, err)
+		assert.Equal(t, src[:], generic, "generic decode mismatch for %s", encoded)
 	}
 }
 
@@ -118,19 +122,23 @@ func TestRoundtrip64_Random(t *testing.T) {
 		var src [64]byte
 		rand.Read(src[:])
 
-		encoded := Encode64(&src)
-		assert.Equal(t, mrtronbase58.Encode(src[:]), encoded, "encode mismatch for %x", src)
+		encoded := Encode(src[:])
+		assert.Equal(t, encodeVariable(src[:]), encoded, "encode mismatch for %x", src)
 
 		var decoded [64]byte
 		require.NoError(t, Decode64(encoded, &decoded))
 		assert.Equal(t, src, decoded, "decode mismatch for %s", encoded)
+
+		generic, err := Decode(encoded)
+		require.NoError(t, err)
+		assert.Equal(t, src[:], generic, "generic decode mismatch for %s", encoded)
 	}
 }
 
 func TestAppendEncode32_ZeroAlloc(t *testing.T) {
 	var src [32]byte
 	rand.Read(src[:])
-	expected := Encode32(&src)
+	expected := Encode(src[:])
 
 	// Pre-sized buffer: should not allocate.
 	buf := make([]byte, 0, EncodedMaxLen32)
@@ -148,7 +156,7 @@ func TestAppendEncode32_ZeroAlloc(t *testing.T) {
 func TestAppendEncode64_ZeroAlloc(t *testing.T) {
 	var src [64]byte
 	rand.Read(src[:])
-	expected := Encode64(&src)
+	expected := Encode(src[:])
 
 	buf := make([]byte, 0, EncodedMaxLen64)
 	buf = AppendEncode64(buf, &src)
@@ -162,6 +170,105 @@ func TestDecode_InvalidChars(t *testing.T) {
 	assert.Error(t, Decode32("Oinvalid", &dst)) // 'O' is not in base58
 }
 
+// Known vectors for the variable-length API. Cross-validated against
+// Bitcoin Core, bs58, and five8.
+var knownVectorsVar = []struct {
+	hex string
+	b58 string
+}{
+	{"", ""},
+	{"00", "1"},
+	{"0000", "11"},
+	{"00000000", "1111"},
+	{"61", "2g"},
+	{"626262", "a3gV"},
+	{"636363", "aPEr"},
+	{"73696d706c792061206c6f6e6720737472696e67", "2cFupjhnEsSn59qHXstmK2ffpLv2"},
+	{"00eb15231dfceb60925886b67d065299925915aeb172c06647", "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"},
+	// Solana instruction data sample from transaction_test.go.
+	{"020000003930000000000000", "3Bxs4ART6LMJ13T5"},
+}
+
+func TestEncode_KnownVectors(t *testing.T) {
+	for _, tv := range knownVectorsVar {
+		raw, err := hex.DecodeString(tv.hex)
+		require.NoError(t, err)
+		assert.Equal(t, tv.b58, Encode(raw), "hex=%s", tv.hex)
+	}
+}
+
+func TestDecode_KnownVectors(t *testing.T) {
+	for _, tv := range knownVectorsVar {
+		expected, err := hex.DecodeString(tv.hex)
+		require.NoError(t, err)
+		got, err := Decode(tv.b58)
+		require.NoError(t, err, "b58=%s", tv.b58)
+		if expected == nil {
+			expected = []byte{}
+		}
+		assert.Equal(t, expected, got, "b58=%s", tv.b58)
+	}
+}
+
+func TestEncode_Empty(t *testing.T) {
+	assert.Equal(t, "", Encode(nil))
+	assert.Equal(t, "", Encode([]byte{}))
+}
+
+func TestDecode_Empty(t *testing.T) {
+	got, err := Decode("")
+	require.NoError(t, err)
+	assert.Equal(t, []byte{}, got)
+}
+
+func TestRoundtrip_Variable_Random(t *testing.T) {
+	// Cover assorted lengths including ones the fixed-size paths can't handle.
+	for _, n := range []int{1, 5, 12, 31, 33, 63, 65, 100, 250, 1000} {
+		for range 100 {
+			src := make([]byte, n)
+			rand.Read(src)
+
+			encoded := Encode(src)
+			decoded, err := Decode(encoded)
+			require.NoError(t, err, "len=%d", n)
+			assert.Equal(t, src, decoded, "len=%d encoded=%s", n, encoded)
+		}
+	}
+}
+
+func TestRoundtrip_Variable_LeadingZeros(t *testing.T) {
+	// Encoded leading '1's must round-trip to the same number of leading zeros.
+	for zeros := 0; zeros < 10; zeros++ {
+		for tail := 0; tail < 10; tail++ {
+			src := make([]byte, zeros+tail)
+			if tail > 0 {
+				rand.Read(src[zeros:])
+				if src[zeros] == 0 {
+					src[zeros] = 1
+				}
+			}
+			encoded := Encode(src)
+			decoded, err := Decode(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, src, decoded, "zeros=%d tail=%d", zeros, tail)
+		}
+	}
+}
+
+func TestDecode_InvalidChars_Variable(t *testing.T) {
+	for _, in := range []string{"0", "O", "I", "l", "abc!", "abc 123", "\x00"} {
+		_, err := Decode(in)
+		assert.Error(t, err, "expected error for %q", in)
+	}
+}
+
+func BenchmarkBase58_Decode_Variable(b *testing.B) {
+	b.SetBytes(64)
+	for b.Loop() {
+		Decode(benchStr64)
+	}
+}
+
 // Benchmarks
 var (
 	benchSrc32 [32]byte
@@ -173,8 +280,23 @@ var (
 func init() {
 	rand.Read(benchSrc32[:])
 	rand.Read(benchSrc64[:])
-	benchStr32 = Encode32(&benchSrc32)
-	benchStr64 = Encode64(&benchSrc64)
+	benchStr32 = Encode(benchSrc32[:])
+	benchStr64 = Encode(benchSrc64[:])
+}
+
+func BenchmarkBase58_EncodeVariable(b *testing.B) {
+	// Cover lengths that bypass the 32/64 fast paths and exercise the
+	// long-division encoder. Solana instruction data is typically <= 1KB.
+	for _, n := range []int{16, 100, 1000} {
+		src := make([]byte, n)
+		rand.Read(src)
+		b.Run(fmt.Sprintf("len=%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				Encode(src)
+			}
+		})
+	}
 }
 
 func BenchmarkBase58_Encode32(b *testing.B) {

--- a/base58/decode.go
+++ b/base58/decode.go
@@ -12,6 +12,84 @@ var (
 	ErrLeadingZeros  = errors.New("base58: leading '1' count does not match leading zero bytes")
 )
 
+// Decode decodes a base58 string to bytes. Each leading '1' in encoded
+// produces a leading zero byte in the output. Empty input produces an empty
+// (non-nil) slice.
+//
+// Encoded lengths matching a 32 or 64-byte representation — the common Solana
+// sizes — are dispatched to the matrix-multiply fast paths (Decode32 /
+// Decode64), which are ~10x faster than the long-multiplication fallback. A
+// 32-byte value always encodes to 32-44 base58 chars; 64-byte to 64-88. The
+// fast paths reject inputs whose natural byte count differs (via leading-zero
+// validation), so we fall back to long multiplication on error.
+func Decode(encoded string) ([]byte, error) {
+	if len(encoded) == 0 {
+		return []byte{}, nil
+	}
+
+	encLen := len(encoded)
+	if encLen >= 32 && encLen <= EncodedMaxLen32 {
+		var dst [32]byte
+		if err := Decode32(encoded, &dst); err == nil {
+			out := make([]byte, 32)
+			copy(out, dst[:])
+			return out, nil
+		}
+	}
+	if encLen >= 64 && encLen <= EncodedMaxLen64 {
+		var dst [64]byte
+		if err := Decode64(encoded, &dst); err == nil {
+			out := make([]byte, 64)
+			copy(out, dst[:])
+			return out, nil
+		}
+	}
+
+	zeros := 0
+	for zeros < len(encoded) && encoded[zeros] == '1' {
+		zeros++
+	}
+
+	if zeros == len(encoded) {
+		return make([]byte, zeros), nil
+	}
+
+	// Upper bound on byte count of the non-leading-zero portion:
+	// ceil(n * log(58)/log(256)) ~ n * 0.7322. Use 733/1000 + 1 for safety.
+	size := ((len(encoded)-zeros)*733)/1000 + 1
+	work := make([]byte, size)
+
+	for i := zeros; i < len(encoded); i++ {
+		c := encoded[i]
+		if c < '1' || c > 'z' {
+			return nil, ErrInvalidChar
+		}
+		digit := base58Inverse[c-'1']
+		if digit == base58InvalidDigit {
+			return nil, ErrInvalidChar
+		}
+		// work = work * 58 + digit, treating work as a big-endian bigint.
+		carry := uint32(digit)
+		for j := len(work) - 1; j >= 0; j-- {
+			cur := uint32(work[j])*58 + carry
+			work[j] = byte(cur)
+			carry = cur >> 8
+		}
+		if carry != 0 {
+			return nil, ErrValueTooLarge
+		}
+	}
+
+	skip := 0
+	for skip < len(work) && work[skip] == 0 {
+		skip++
+	}
+
+	out := make([]byte, zeros+len(work)-skip)
+	copy(out[zeros:], work[skip:])
+	return out, nil
+}
+
 // Decode32 decodes a base58 string into a 32-byte array.
 func Decode32(encoded string, dst *[32]byte) error {
 	encLen := len(encoded)

--- a/base58/encode.go
+++ b/base58/encode.go
@@ -5,6 +5,74 @@ import (
 	"unsafe"
 )
 
+// Encode encodes a byte slice to a base58 string. Each leading zero byte in
+// src produces a leading '1' in the output. Empty input produces an empty
+// string.
+//
+// Inputs of exactly 32 or 64 bytes — the common Solana sizes (pubkey, hash,
+// signature, private key) — are dispatched to the matrix-multiply fast paths
+// and are ~20x faster than the long-division fallback used for other lengths.
+func Encode(buf []byte) string {
+	switch len(buf) {
+	case 0:
+		return ""
+	case 32:
+		return Encode32((*[32]byte)(buf))
+	case 64:
+		return Encode64((*[64]byte)(buf))
+	default:
+		return encodeVariable(buf)
+	}
+}
+
+// encodeVariable is a long-division base58 encoder for inputs of arbitrary
+// length. Adapted from github.com/mr-tron/base58 (FastBase58Encoding); the
+// output-buffer size is corrected to zcount+size-j (upstream's
+// binsz-zcount+(size-j) panics on all-zero input and over-allocates otherwise,
+// leaving NUL bytes at the tail of the returned string).
+func encodeVariable(bin []byte) string {
+	binsz := len(bin)
+	zcount := 0
+	for zcount < binsz && bin[zcount] == 0 {
+		zcount++
+	}
+
+	// Upper bound on encoded non-zero portion: ceil(n * log(256)/log(58)) ~
+	// n * 1.366. Use 138/100 + 1 for safety.
+	size := (binsz-zcount)*138/100 + 1
+	buf := make([]byte, size)
+
+	high := size - 1
+	for i := zcount; i < binsz; i++ {
+		j := size - 1
+		for carry := uint32(bin[i]); j > high || carry != 0; j-- {
+			carry += 256 * uint32(buf[j])
+			buf[j] = byte(carry % 58)
+			carry /= 58
+			if j == 0 {
+				break
+			}
+		}
+		high = j
+	}
+
+	// Skip leading zero digits in the working buffer.
+	j := 0
+	for j < size && buf[j] == 0 {
+		j++
+	}
+
+	b58 := make([]byte, zcount+size-j)
+	for i := range zcount {
+		b58[i] = base58Chars[0]
+	}
+	for i := zcount; j < size; i++ {
+		b58[i] = base58Chars[buf[j]]
+		j++
+	}
+	return string(b58)
+}
+
 // Encode32 encodes a 32-byte array to a base58 string.
 //
 // Allocates exactly one []byte of the encoded length. For zero-allocation

--- a/base58/fuzz_test.go
+++ b/base58/fuzz_test.go
@@ -3,13 +3,14 @@ package base58
 import (
 	"bytes"
 	"testing"
-
-	mrtronbase58 "github.com/mr-tron/base58"
 )
 
-// --- Encode fuzz: our output must match mr-tron for every input ---
+// --- Encode fuzz: fixed-size paths must agree with the variable-length path ---
+//
+// Encode32/Encode64 use a tuned matrix-multiply that shares no code with
+// encodeVariable. Disagreement between them flags a bug in either path.
 
-func FuzzEncode32_MatchesMrTron(f *testing.F) {
+func FuzzEncode32_MatchesVariable(f *testing.F) {
 	f.Add(make([]byte, 32))                       // all zeros
 	f.Add(bytes.Repeat([]byte{0xff}, 32))         // all 0xFF
 	f.Add(append([]byte{1}, make([]byte, 31)...)) // single leading byte
@@ -22,15 +23,15 @@ func FuzzEncode32_MatchesMrTron(f *testing.F) {
 		var src [32]byte
 		copy(src[:], data)
 
-		ours := Encode32(&src)
-		theirs := mrtronbase58.Encode(src[:])
-		if ours != theirs {
-			t.Fatalf("Encode32 mismatch for %x:\n  ours:   %s\n  theirs: %s", src, ours, theirs)
+		fast := Encode32(&src)
+		generic := encodeVariable(src[:])
+		if fast != generic {
+			t.Fatalf("Encode32 mismatch for %x:\n  fast:    %s\n  generic: %s", src, fast, generic)
 		}
 	})
 }
 
-func FuzzEncode64_MatchesMrTron(f *testing.F) {
+func FuzzEncode64_MatchesVariable(f *testing.F) {
 	f.Add(make([]byte, 64))
 	f.Add(bytes.Repeat([]byte{0xff}, 64))
 	f.Add(append([]byte{1}, make([]byte, 63)...))
@@ -42,17 +43,17 @@ func FuzzEncode64_MatchesMrTron(f *testing.F) {
 		var src [64]byte
 		copy(src[:], data)
 
-		ours := Encode64(&src)
-		theirs := mrtronbase58.Encode(src[:])
-		if ours != theirs {
-			t.Fatalf("Encode64 mismatch for %x:\n  ours:   %s\n  theirs: %s", src, ours, theirs)
+		fast := Encode64(&src)
+		generic := encodeVariable(src[:])
+		if fast != generic {
+			t.Fatalf("Encode64 mismatch for %x:\n  fast:    %s\n  generic: %s", src, fast, generic)
 		}
 	})
 }
 
-// --- Decode fuzz: round-trip through mr-tron must agree ---
+// --- Decode fuzz: fixed-size and variable-length paths must agree ---
 
-func FuzzDecode32_MatchesMrTron(f *testing.F) {
+func FuzzDecode32_MatchesVariable(f *testing.F) {
 	f.Add("11111111111111111111111111111111")
 	f.Add("11111111111111111111111111111112")
 	f.Add("4cHoJNmLed5PBgFBezHmJkMJLEZrcTvr3aopjnYBRxUb")
@@ -61,33 +62,32 @@ func FuzzDecode32_MatchesMrTron(f *testing.F) {
 		var dst [32]byte
 		err := Decode32(encoded, &dst)
 		if err != nil {
-			// We're stricter than mr-tron (fixed size, leading-zero
-			// validation). Just verify we don't panic.
+			// We're stricter than the variable-length decoder (fixed size,
+			// leading-zero validation). Just verify we don't panic.
 			return
 		}
 
-		// If we accepted it, mr-tron must decode to the same bytes.
-		theirBytes, theirErr := mrtronbase58.Decode(encoded)
-		if theirErr != nil {
-			t.Fatalf("we accepted %q but mr-tron rejected it: %v", encoded, theirErr)
+		generic, gerr := Decode(encoded)
+		if gerr != nil {
+			t.Fatalf("Decode32 accepted %q but Decode rejected it: %v", encoded, gerr)
 		}
 
-		// mr-tron strips leading zeros; pad to compare.
+		// Decode strips leading zeros; pad to compare.
 		padded := make([]byte, 32)
-		copy(padded[32-len(theirBytes):], theirBytes)
+		copy(padded[32-len(generic):], generic)
 		if !bytes.Equal(dst[:], padded) {
-			t.Fatalf("decode mismatch for %q:\n  ours:   %x\n  theirs: %x", encoded, dst, padded)
+			t.Fatalf("decode mismatch for %q:\n  fixed:   %x\n  generic: %x", encoded, dst, padded)
 		}
 
 		// Re-encode must produce the original string.
-		reEncoded := Encode32(&dst)
+		reEncoded := Encode(dst[:])
 		if reEncoded != encoded {
 			t.Fatalf("round-trip mismatch: %q -> %x -> %q", encoded, dst, reEncoded)
 		}
 	})
 }
 
-func FuzzDecode64_MatchesMrTron(f *testing.F) {
+func FuzzDecode64_MatchesVariable(f *testing.F) {
 	f.Add("5YBLhMBLjhAHnEPnHKLLnVwHSfXGPJMCvKAfNsiaEw2T63edrYxVFHKUxRXfP6KA1HVo7c9JZ3LAJQR72giX7Cb")
 
 	f.Fuzz(func(t *testing.T, encoded string) {
@@ -97,20 +97,41 @@ func FuzzDecode64_MatchesMrTron(f *testing.F) {
 			return
 		}
 
-		theirBytes, theirErr := mrtronbase58.Decode(encoded)
-		if theirErr != nil {
-			t.Fatalf("we accepted %q but mr-tron rejected it: %v", encoded, theirErr)
+		generic, gerr := Decode(encoded)
+		if gerr != nil {
+			t.Fatalf("Decode64 accepted %q but Decode rejected it: %v", encoded, gerr)
 		}
 
 		padded := make([]byte, 64)
-		copy(padded[64-len(theirBytes):], theirBytes)
+		copy(padded[64-len(generic):], generic)
 		if !bytes.Equal(dst[:], padded) {
-			t.Fatalf("decode mismatch for %q:\n  ours:   %x\n  theirs: %x", encoded, dst, padded)
+			t.Fatalf("decode mismatch for %q:\n  fixed:   %x\n  generic: %x", encoded, dst, padded)
 		}
 
-		reEncoded := Encode64(&dst)
+		reEncoded := Encode(dst[:])
 		if reEncoded != encoded {
 			t.Fatalf("round-trip mismatch: %q -> %x -> %q", encoded, dst, reEncoded)
+		}
+	})
+}
+
+// --- Variable-length round-trip fuzz ---
+
+func FuzzEncodeDecode_RoundTrip(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0})
+	f.Add([]byte{0, 0, 0})
+	f.Add([]byte{1, 2, 3, 4, 5})
+	f.Add(bytes.Repeat([]byte{0xff}, 100))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		encoded := Encode(data)
+		decoded, err := Decode(encoded)
+		if err != nil {
+			t.Fatalf("Decode rejected our own Encode output %q: %v", encoded, err)
+		}
+		if !bytes.Equal(data, decoded) {
+			t.Fatalf("round-trip mismatch for %x:\n  encoded: %s\n  decoded: %x", data, encoded, decoded)
 		}
 	})
 }
@@ -145,5 +166,17 @@ func FuzzDecode64_NoPanic(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var dst [64]byte
 		Decode64(string(data), &dst)
+	})
+}
+
+func FuzzDecode_NoPanic(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("0"))
+	f.Add([]byte("\x00"))
+	f.Add([]byte("\xff"))
+	f.Add(bytes.Repeat([]byte("z"), 200))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		Decode(string(data))
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,38 @@ module github.com/gagliardetto/solana-go
 go 1.24.0
 
 require (
+	github.com/AlekSi/pointer v1.2.0
+	github.com/buger/jsonparser v1.1.2
+	github.com/davecgh/go-spew v1.1.1
+	github.com/fatih/color v1.18.0
 	github.com/gagliardetto/binary v0.8.0
 	github.com/gagliardetto/gofuzz v1.2.2
 	github.com/gagliardetto/treeout v0.1.4
 	github.com/goccy/go-json v0.10.6
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/rpc v1.2.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/json-iterator/go v1.1.12
-	github.com/mr-tron/base58 v1.2.0
+	github.com/klauspost/compress v1.18.0
+	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729
+	github.com/onsi/gomega v1.10.1
+	github.com/pkg/errors v0.9.1
+	github.com/ryanuber/columnize v2.1.2+incompatible
+	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.10
+	github.com/spf13/viper v1.21.0
+	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e
+	github.com/stretchr/testify v1.11.1
 	go.mongodb.org/mongo-driver/v2 v2.5.0
+	go.uber.org/ratelimit v0.3.1
+	go.uber.org/zap v1.27.0
+	golang.org/x/crypto v0.47.0
+	golang.org/x/oauth2 v0.34.0
+	golang.org/x/time v0.11.0
+	google.golang.org/api v0.233.0
 )
 
 require (
@@ -52,6 +75,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
@@ -59,32 +83,4 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-require (
-	github.com/AlekSi/pointer v1.2.0
-	github.com/buger/jsonparser v1.1.2
-	github.com/davecgh/go-spew v1.1.1
-	github.com/fatih/color v1.18.0
-	github.com/google/go-cmp v0.7.0
-	github.com/gorilla/rpc v1.2.1
-	github.com/gorilla/websocket v1.5.3
-	github.com/klauspost/compress v1.18.0
-	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1
-	github.com/onsi/gomega v1.10.1
-	github.com/pkg/errors v0.9.1
-	github.com/ryanuber/columnize v2.1.2+incompatible
-	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.10
-	github.com/spf13/viper v1.21.0
-	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e
-	github.com/stretchr/testify v1.11.1
-	go.uber.org/ratelimit v0.3.1
-	go.uber.org/zap v1.27.0
-	golang.org/x/crypto v0.47.0
-	golang.org/x/oauth2 v0.34.0
-	golang.org/x/term v0.39.0 // indirect
-	golang.org/x/time v0.11.0
-	google.golang.org/api v0.233.0
 )

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 h1:mPMvm6X6tf4w8y7j9YIt6V9jfWhL6QlbEc7CCmeQlWk=
 github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1/go.mod h1:ye2e/VUEtE2BHE+G/QcKkcLQVAEJoYRFj5VUOQatCRE=
-github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
-github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 h1:yfQ2sO9WJXUAIUR+g7NUkxJSKCAFJcR5sUDu+ZmjTZI=

--- a/keys.go
+++ b/keys.go
@@ -29,7 +29,6 @@ import (
 	"sort"
 
 	"github.com/gagliardetto/solana-go/base58"
-	mrtronbase58 "github.com/mr-tron/base58"
 	"github.com/oasisprotocol/curve25519-voi/curve"
 	voied25519 "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -57,11 +56,10 @@ func MustPrivateKeyFromBase58(in string) PrivateKey {
 }
 
 func PrivateKeyFromBase58(privkey string) (PrivateKey, error) {
-	res, err := mrtronbase58.Decode(privkey)
+	res, err := base58.Decode(privkey)
 	if err != nil {
 		return nil, err
 	}
-	// validate
 	if _, err := ValidatePrivateKey(res); err != nil {
 		return nil, err
 	}
@@ -110,7 +108,7 @@ func PrivateKeyFromSolanaKeygenFileBytes(content []byte) (PrivateKey, error) {
 }
 
 func (k PrivateKey) String() string {
-	return mrtronbase58.Encode(k)
+	return base58.Encode(k)
 }
 
 func NewRandomPrivateKey() (PrivateKey, error) {
@@ -199,7 +197,7 @@ func PublicKeyFromBase58(in string) (out PublicKey, err error) {
 	if err = base58.Decode32(in, (*[32]byte)(&out)); err != nil {
 		// Fall back to the variable-length decoder to produce a more
 		// informative error when the input decodes to a wrong-length value.
-		val, decErr := mrtronbase58.Decode(in)
+		val, decErr := base58.Decode(in)
 		if decErr != nil {
 			return out, fmt.Errorf("decode: %w", decErr)
 		}
@@ -326,7 +324,7 @@ func (p *PublicKey) Set(s string) (err error) {
 }
 
 func (p PublicKey) String() string {
-	return base58.Encode32((*[32]byte)(&p))
+	return base58.Encode(p[:])
 }
 
 // Short returns a shortened pubkey string,

--- a/nativetype_test.go
+++ b/nativetype_test.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/mr-tron/base58"
+	"github.com/gagliardetto/solana-go/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/nativetypes.go
+++ b/nativetypes.go
@@ -27,7 +27,6 @@ import (
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go/base58"
 	"github.com/mostynb/zstdpool-freelist"
-	mrtronbase58 "github.com/mr-tron/base58"
 )
 
 type Padding []byte
@@ -103,7 +102,7 @@ func (ha Hash) IsZero() bool {
 }
 
 func (ha Hash) String() string {
-	return base58.Encode32((*[32]byte)(&ha))
+	return base58.Encode(ha[:])
 }
 
 type Signature [64]byte
@@ -191,7 +190,7 @@ func (s Signature) Verify(pubkey PublicKey, msg []byte) bool {
 }
 
 func (p Signature) String() string {
-	return base58.Encode64((*[64]byte)(&p))
+	return base58.Encode(p[:])
 }
 
 type Base64 []byte
@@ -219,7 +218,7 @@ func (t *Base64) UnmarshalJSON(data []byte) (err error) {
 type Base58 []byte
 
 func (t Base58) MarshalJSON() ([]byte, error) {
-	return json.Marshal(mrtronbase58.Encode(t))
+	return json.Marshal(base58.Encode(t))
 }
 
 func (t *Base58) UnmarshalJSON(data []byte) (err error) {
@@ -234,12 +233,12 @@ func (t *Base58) UnmarshalJSON(data []byte) (err error) {
 		return nil
 	}
 
-	*t, err = mrtronbase58.Decode(s)
+	*t, err = base58.Decode(s)
 	return
 }
 
 func (t Base58) String() string {
-	return mrtronbase58.Encode(t)
+	return base58.Encode(t)
 }
 
 type Data struct {
@@ -279,7 +278,7 @@ func (t *Data) UnmarshalJSON(data []byte) (err error) {
 	switch t.Encoding {
 	case EncodingBase58:
 		var err error
-		t.Content, err = mrtronbase58.Decode(contentString)
+		t.Content, err = base58.Decode(contentString)
 		if err != nil {
 			return err
 		}
@@ -315,7 +314,7 @@ var zstdEncoderPool = zstdpool.NewEncoderPool()
 func (t Data) String() string {
 	switch EncodingType(t.Encoding) {
 	case EncodingBase58:
-		return mrtronbase58.Encode(t.Content)
+		return base58.Encode(t.Content)
 	case EncodingBase64:
 		return base64.StdEncoding.EncodeToString(t.Content)
 	case EncodingBase64Zstd:

--- a/transaction.go
+++ b/transaction.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go/base58"
 	"github.com/gagliardetto/solana-go/text"
 	"github.com/gagliardetto/treeout"
-	"github.com/mr-tron/base58"
 	"go.uber.org/zap"
 )
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	bin "github.com/gagliardetto/binary"
-	"github.com/mr-tron/base58"
+	"github.com/gagliardetto/solana-go/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"


### PR DESCRIPTION
### Problem

the `base58` package's fast paths only covered 32/64-byte inputs, so every other length (instruction data, Base58.MarshalJSON, Data.String) had to go through the external `github.com/mr-tron/base58` module - a needless dependency, and one with a latent buffer-sizing bug that panics on all-zero input
this change pulls the long-division algorithm in-tree behind a unified `base58.Encode` entry point and drops the external dependency

### Summary of Changes

- add `base58.Encode(buf []byte) string` dispatcher: 32/64-byte fast paths + vendored long-division fallback (encodeVariable) with the mr-tron buffer-sizing bug fixed
- drop the `mr-tron/base58` module dependency; rewire all callers (Base58, Data, Hash, Signature, PublicKey, PrivateKey) to `base58.Encode`
- update tests/fuzzers to cross-validate the matrix-multiply fast paths against the in-tree encodeVariable - no existing exported signatures changed (gorelease -> v1.20.0, additive only)