### PR TITLE
fix(ws): reject EncodingJSONParsed in BlockSubscribe

### DIFF
--- a/rpc/ws/blockSubscribe.go
+++ b/rpc/ws/blockSubscribe.go
@@ -61,7 +61,13 @@ func NewBlockSubscribeFilterMentionsAccountOrProgram(pubkey solana.PublicKey) *B
 
 type BlockSubscribeOpts struct {
 	Commitment rpc.CommitmentType
-	Encoding   solana.EncodingType `json:"encoding,omitempty"`
+	// Encoding controls how transactions inside each block are returned.
+	//
+	// Supported values: EncodingBase58, EncodingBase64, EncodingBase64Zstd.
+	// EncodingJSONParsed is NOT supported here because BlockResult is shaped
+	// for the non-parsed transaction layout. Use Client.ParsedBlockSubscribe
+	// instead when parsed JSON output is needed.
+	Encoding solana.EncodingType `json:"encoding,omitempty"`
 
 	// Level of transaction detail to return.
 	TransactionDetails rpc.TransactionDetailsType
@@ -100,11 +106,18 @@ func (cl *Client) BlockSubscribe(
 			obj["commitment"] = opts.Commitment
 		}
 		if opts.Encoding != "" {
+			// EncodingJSONParsed cannot decode through BlockResult: the
+			// response shape uses *rpc.GetBlockResult, which models the
+			// non-parsed transaction layout. Reject it up front with a
+			// pointer to ParsedBlockSubscribe rather than letting the
+			// request go out and fail at decode time.
+			if opts.Encoding == solana.EncodingJSONParsed {
+				return nil, fmt.Errorf("encoding %s is not supported by BlockSubscribe; use ParsedBlockSubscribe instead", opts.Encoding)
+			}
 			if !solana.IsAnyOfEncodingType(
 				opts.Encoding,
 				// Valid encodings:
 				// solana.EncodingJSON, // TODO
-				solana.EncodingJSONParsed, // TODO
 				solana.EncodingBase58,
 				solana.EncodingBase64,
 				solana.EncodingBase64Zstd,

--- a/rpc/ws/blockSubscribe_test.go
+++ b/rpc/ws/blockSubscribe_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockSubscribeRejectsJSONParsedEncoding verifies that BlockSubscribe
+// fails fast when the caller asks for EncodingJSONParsed. The response struct
+// (BlockResult) models the non-parsed transaction layout; letting the request
+// go out anyway only surfaces as a confusing decode error on the first
+// notification (issue #291). The rejection should also point the caller at
+// ParsedBlockSubscribe so the fix is obvious.
+func TestBlockSubscribeRejectsJSONParsedEncoding(t *testing.T) {
+	cl := &Client{}
+	_, err := cl.BlockSubscribe(NewBlockSubscribeFilterAll(), &BlockSubscribeOpts{
+		Encoding: solana.EncodingJSONParsed,
+	})
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "ParsedBlockSubscribe") {
+		t.Fatalf("error should mention ParsedBlockSubscribe, got: %v", err)
+	}
+}
+
+// TestBlockSubscribeRejectsUnsupportedEncoding verifies the existing
+// "unsupported encoding" rejection path is unchanged for arbitrary values.
+func TestBlockSubscribeRejectsUnsupportedEncoding(t *testing.T) {
+	cl := &Client{}
+	_, err := cl.BlockSubscribe(NewBlockSubscribeFilterAll(), &BlockSubscribeOpts{
+		Encoding: solana.EncodingType("not-a-real-encoding"),
+	})
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("error should describe an unsupported encoding, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #291.

## Bug

`BlockSubscribe` currently lists `solana.EncodingJSONParsed` as a valid value for `opts.Encoding`, but `BlockResult` embeds `*rpc.GetBlockResult` — the non-parsed transaction layout. When a caller passes `EncodingJSONParsed` the request goes out fine and only fails on the first notification:

```
unable to decode client response:
ws.BlockResult.Value: Block: rpc.GetBlockResult.Transactions ...
```

The repro from the linked issue reproduces this verbatim.

## Fix

A sibling `Client.ParsedBlockSubscribe` already exists for the parsed case and uses `*rpc.GetParsedBlockResult`, so the right move is to fail fast when `EncodingJSONParsed` is requested through `BlockSubscribe` and steer the caller at the correct helper.

- Drop `solana.EncodingJSONParsed` from the `IsAnyOfEncodingType` allow-list in `BlockSubscribe` (keeping the `// TODO` line for `EncodingJSON` untouched — that gap is a separate piece of work).
- Add an explicit check above the generic check that returns a targeted error mentioning `ParsedBlockSubscribe`, so the user immediately sees what to do.
- Update the `BlockSubscribeOpts.Encoding` doc to enumerate the supported encodings and steer parsed-output users at `ParsedBlockSubscribe`.

## Tests

`rpc/ws/blockSubscribe_test.go` (new):

- `TestBlockSubscribeRejectsJSONParsedEncoding` — asserts the new rejection path fires and the error mentions `ParsedBlockSubscribe`.
- `TestBlockSubscribeRejectsUnsupportedEncoding` — pins the existing rejection path for arbitrary garbage.

Both tests use a zero-value `Client{}` so they don't need a live websocket.

```
$ go test -count=1 ./rpc/ws/... ./rpc/
ok   github.com/gagliardetto/solana-go/rpc/ws   0.341s
ok   github.com/gagliardetto/solana-go/rpc      0.513s
```

## Diff size

```
 rpc/ws/blockSubscribe.go      | +17 -2
 rpc/ws/blockSubscribe_test.go | +51   (new)
```