### PR TITLE
fix(ws): use uint64 for params.Subscription in incoming notifications

### DIFF
--- a/rpc/ws/types.go
+++ b/rpc/ws/types.go
@@ -68,8 +68,15 @@ type response struct {
 }
 
 type params struct {
-	Result       *stdjson.RawMessage `json:"result"`
-	Subscription int                 `json:"subscription"`
+	Result *stdjson.RawMessage `json:"result"`
+	// Subscription is the validator-assigned subscription id. The validator
+	// emits these as JSON unsigned 64-bit integers, so the field must use
+	// uint64 to round-trip safely. Using int here failed JSON decoding on
+	// 32-bit builds and on any value above math.MaxInt64 (issue #286). The
+	// value is not consumed downstream — the routing key is parsed
+	// separately via getUint64WithOk in handleMessage — but the field is
+	// kept so encoding/json does not error on the incoming notification.
+	Subscription uint64 `json:"subscription"`
 }
 
 type Options struct {

--- a/rpc/ws/types_test.go
+++ b/rpc/ws/types_test.go
@@ -1,6 +1,7 @@
 package ws
 
 import (
+	stdjson "encoding/json"
 	"math"
 	"testing"
 
@@ -31,4 +32,25 @@ func TestGetUint64_AcceptsNumberAndString(t *testing.T) {
 	id, err = getUint64(stringPayload, "id")
 	require.NoError(t, err)
 	require.Equal(t, uint64(3338220398172203928), id)
+}
+
+// TestResponseDecodesLargeSubscriptionID covers issue #286: validator
+// notifications carry the subscription id as a JSON uint64. Before the fix
+// params.Subscription was typed `int`, which fails encoding/json decode on
+// 32-bit builds and on any value above math.MaxInt64. The field must use
+// uint64 to round-trip safely.
+func TestResponseDecodesLargeSubscriptionID(t *testing.T) {
+	// Use the largest JSON-safe-but-still-uint64 value the server might emit.
+	// math.MaxUint64 itself stresses the regression most directly.
+	payload := []byte(`{
+		"jsonrpc": "2.0",
+		"params": {
+			"result": null,
+			"subscription": 18446744073709551615
+		}
+	}`)
+	var r response
+	require.NoError(t, stdjson.Unmarshal(payload, &r))
+	require.NotNil(t, r.Params)
+	require.Equal(t, uint64(math.MaxUint64), r.Params.Subscription)
 }


### PR DESCRIPTION
Closes #286.

## Bug

The websocket pubsub `response` type in `rpc/ws/types.go` was defined as:

```go
type params struct {
    Result       *stdjson.RawMessage `json:"result"`
    Subscription int                 `json:"subscription"`
}
```

The validator emits subscription ids as JSON **unsigned 64-bit integers**. With the field typed as `int` the decode in `decodeResponseFromMessage` fails on 32-bit builds for any id above `math.MaxInt32`, and on 64-bit builds for any id above `math.MaxInt64`. That is exactly the path users hit in [#286](https://github.com/solana-foundation/solana-go/issues/286): `unable to decode client response` from `SlotSubscribe()` (and the same shape for any other ws subscription). The bug was diagnosed in the issue thread by @AliakseiM, who pointed at this exact field.

## Fix

Switch `Subscription` to `uint64`. The field is not consumed downstream — `handleMessage` parses the routing key separately via `getUint64WithOk` — but it has to be present so `encoding/json` does not error on the inbound notification. `uint64` matches what the validator and `handleMessage` already use everywhere, and lines up with the recent #400 work that hardened request ids against the same JSON-safe-integer footgun.

## Tests

`TestResponseDecodesLargeSubscriptionID` (new) decodes a notification with `subscription == math.MaxUint64` to pin the new behavior.

```
$ go test -count=1 ./rpc/ws/... ./rpc/
ok   github.com/gagliardetto/solana-go/rpc/ws   0.325s
ok   github.com/gagliardetto/solana-go/rpc      0.680s
```

## Diff size

```
 rpc/ws/types.go      | +9 -2
 rpc/ws/types_test.go | +22
```