### PR TITLE
feat(rpc): forward MinContextSlot in getProgramAccounts and getTokenAccounts

### DIFF
--- a/rpc/getMinContextSlot_test.go
+++ b/rpc/getMinContextSlot_test.go
@@ -1,0 +1,138 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	stdjson "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClient_GetProgramAccountsWithOpts_MinContextSlot pins that the
+// minContextSlot opt is forwarded into the params object.
+func TestClient_GetProgramAccountsWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `[{"account":{"data":["dGVzdA==","base64"],"executable":true,"lamports":2039280,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":206},"pubkey":"7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"}]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	minSlot := uint64(123456789)
+	_, err := client.GetProgramAccountsWithOpts(
+		context.Background(),
+		pubKey,
+		&GetProgramAccountsOpts{
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getProgramAccounts",
+			"params": []any{
+				pubkeyString,
+				map[string]any{
+					"encoding":       "base64",
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetTokenAccountsByOwner_MinContextSlot pins that the
+// minContextSlot opt is forwarded into the params object for the owner variant.
+func TestClient_GetTokenAccountsByOwner_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":[]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	ownerString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	owner := solana.MustPublicKeyFromBase58(ownerString)
+	programIDString := "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+	programID := solana.MustPublicKeyFromBase58(programIDString)
+
+	minSlot := uint64(987654321)
+	_, err := client.GetTokenAccountsByOwner(
+		context.Background(),
+		owner,
+		&GetTokenAccountsConfig{ProgramId: &programID},
+		&GetTokenAccountsOpts{MinContextSlot: &minSlot},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getTokenAccountsByOwner",
+			"params": []any{
+				ownerString,
+				map[string]any{"programId": programIDString},
+				map[string]any{
+					"encoding":       "base64",
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetTokenAccountsByDelegate_MinContextSlot pins the same for the
+// delegate variant.
+func TestClient_GetTokenAccountsByDelegate_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":[]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	delegateString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	delegate := solana.MustPublicKeyFromBase58(delegateString)
+	programIDString := "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+	programID := solana.MustPublicKeyFromBase58(programIDString)
+
+	minSlot := uint64(42)
+	_, err := client.GetTokenAccountsByDelegate(
+		context.Background(),
+		delegate,
+		&GetTokenAccountsConfig{ProgramId: &programID},
+		&GetTokenAccountsOpts{MinContextSlot: &minSlot},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getTokenAccountsByDelegate",
+			"params": []any{
+				delegateString,
+				map[string]any{"programId": programIDString},
+				map[string]any{
+					"encoding":       "base64",
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}

--- a/rpc/getProgramAccounts.go
+++ b/rpc/getProgramAccounts.go
@@ -90,6 +90,9 @@ func buildGetProgramAccountsParams(publicKey solana.PublicKey, opts *GetProgramA
 		if opts.SortResults != nil {
 			obj["sortResults"] = *opts.SortResults
 		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
 	}
 	return []any{publicKey, obj}
 }

--- a/rpc/getTokenAccountsByDelegate.go
+++ b/rpc/getTokenAccountsByDelegate.go
@@ -37,6 +37,9 @@ type GetTokenAccountsOpts struct {
 	Encoding solana.EncodingType `json:"encoding,omitempty"`
 
 	DataSlice *DataSlice `json:"dataSlice,omitempty"`
+
+	// The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64 `json:"minContextSlot,omitempty"`
 }
 
 // GetTokenAccountsByDelegate returns all SPL Token accounts by approved Delegate.
@@ -86,6 +89,9 @@ func (cl *Client) GetTokenAccountsByDelegate(
 				if opts.Encoding == solana.EncodingJSONParsed {
 					return nil, errors.New("cannot use dataSlice with EncodingJSONParsed")
 				}
+			}
+			if opts.MinContextSlot != nil {
+				optsObj["minContextSlot"] = *opts.MinContextSlot
 			}
 			if len(optsObj) > 0 {
 				params = append(params, optsObj)

--- a/rpc/getTokenAccountsByOwner.go
+++ b/rpc/getTokenAccountsByOwner.go
@@ -69,6 +69,9 @@ func (cl *Client) GetTokenAccountsByOwner(
 					return nil, errors.New("cannot use dataSlice with EncodingJSONParsed")
 				}
 			}
+			if opts.MinContextSlot != nil {
+				optsObj["minContextSlot"] = *opts.MinContextSlot
+			}
 			if len(optsObj) > 0 {
 				params = append(params, optsObj)
 			}

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -466,6 +466,9 @@ type GetProgramAccountsOpts struct {
 
 	// Sort the results (useful for deterministic pagination).
 	SortResults *bool `json:"sortResults,omitempty"`
+
+	// The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64 `json:"minContextSlot,omitempty"`
 }
 
 type GetProgramAccountsResult []*KeyedAccount


### PR DESCRIPTION
Follow-up to #245.

## Gap

The Solana RPC spec lists `minContextSlot` as an optional param on `getProgramAccounts`, `getTokenAccountsByOwner`, and `getTokenAccountsByDelegate`, but the Go bindings drop it on the floor — there is no way to pin these reads to a minimum slot.

Without it, callers on lagging RPC nodes can read state from a slot older than what they have already observed downstream, which breaks read-your-own-writes and slot-pinned pagination flows. The other account-reading methods (`getAccountInfo`, `getMultipleAccounts`, `getSignaturesForAddress`, `simulateTransaction`) already accept the field — this PR closes the parity gap.

## Change

Purely additive — the pattern matches #245 (`GetMultipleAccountsWithOpts`):

- `GetProgramAccountsOpts.MinContextSlot *uint64` (forwarded in `buildGetProgramAccountsParams`)
- `GetTokenAccountsOpts.MinContextSlot *uint64` (forwarded in both `GetTokenAccountsByOwner` and `GetTokenAccountsByDelegate`)

The opts structs are public and additive; no existing call sites need changes. When `MinContextSlot` is nil, the wire shape is byte-identical to before.

## Tests

`rpc/getMinContextSlot_test.go` (new) — three tests using the in-tree `mockJSONRPC` harness pin the exact `params` wire shape for each method:

- `TestClient_GetProgramAccountsWithOpts_MinContextSlot`
- `TestClient_GetTokenAccountsByOwner_MinContextSlot`
- `TestClient_GetTokenAccountsByDelegate_MinContextSlot`

```
$ go test -count=1 ./...
ok   github.com/gagliardetto/solana-go             0.553s
ok   github.com/gagliardetto/solana-go/rpc         1.537s
ok   github.com/gagliardetto/solana-go/rpc/ws      1.483s
... (all packages pass)
```

## Diff size

```
 rpc/types.go                       | +3
 rpc/getProgramAccounts.go          | +3
 rpc/getTokenAccountsByDelegate.go  | +6
 rpc/getTokenAccountsByOwner.go     | +3
 rpc/getMinContextSlot_test.go      | +138   (new)
```