### PR TITLE
feat(rpc): add NewWithCommitment / NewWithTimeout / NewWithTimeoutAndCommitment (#414)

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -35,8 +35,9 @@ var (
 )
 
 type Client struct {
-	rpcURL    string
-	rpcClient JSONRPCClient
+	rpcURL            string
+	rpcClient         JSONRPCClient
+	defaultCommitment CommitmentType
 }
 
 type JSONRPCClient interface {
@@ -65,6 +66,51 @@ func NewWithHeaders(rpcEndpoint string, headers map[string]string) *Client {
 	}
 	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts)
 	return NewWithCustomRPCClient(rpcClient)
+}
+
+// NewWithCommitment creates a new Solana JSON RPC client and pins a default
+// CommitmentType on the returned Client. Methods that take an explicit
+// CommitmentType still receive whatever the caller passes; the stored
+// commitment is exposed via Client.DefaultCommitment so callers can fall
+// back to it without threading the value through every call site
+// themselves. Mirrors the rust-sdk RpcClient::new_with_commitment ergonomics.
+func NewWithCommitment(rpcEndpoint string, commitment CommitmentType) *Client {
+	cl := New(rpcEndpoint)
+	cl.defaultCommitment = commitment
+	return cl
+}
+
+// NewWithTimeout creates a new Solana JSON RPC client with a custom HTTP
+// timeout. The default 5-minute timeout used by New is replaced with the
+// supplied value on the underlying *http.Client; the same value is also
+// applied to the dialer and idle connection timeout so long-haul reads,
+// connect, and pool eviction stay aligned.
+func NewWithTimeout(rpcEndpoint string, timeout time.Duration) *Client {
+	opts := &jsonrpc.RPCClientOpts{
+		HTTPClient: newHTTPWithTimeout(timeout),
+	}
+	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts)
+	return NewWithCustomRPCClient(rpcClient)
+}
+
+// NewWithTimeoutAndCommitment combines NewWithTimeout and NewWithCommitment.
+// Mirrors the rust-sdk RpcClient::new_with_timeout_and_commitment
+// constructor.
+func NewWithTimeoutAndCommitment(
+	rpcEndpoint string,
+	timeout time.Duration,
+	commitment CommitmentType,
+) *Client {
+	cl := NewWithTimeout(rpcEndpoint, timeout)
+	cl.defaultCommitment = commitment
+	return cl
+}
+
+// DefaultCommitment returns the CommitmentType pinned on this Client at
+// construction time via NewWithCommitment / NewWithTimeoutAndCommitment.
+// Returns the empty CommitmentType when no default was configured.
+func (cl *Client) DefaultCommitment() CommitmentType {
+	return cl.defaultCommitment
 }
 
 // Close closes the client.
@@ -113,10 +159,29 @@ func newHTTPTransport() *http.Transport {
 // newHTTP returns a new Client from the provided config.
 // Client is safe for concurrent use by multiple goroutines.
 func newHTTP() *http.Client {
-	tr := newHTTPTransport()
+	return newHTTPWithTimeout(defaultTimeout)
+}
 
+// newHTTPWithTimeout returns a new *http.Client whose request timeout, dial
+// timeout, and idle connection timeout are all bound to the supplied value.
+// Used by NewWithTimeout / NewWithTimeoutAndCommitment so callers can lift
+// the hardcoded 5-minute ceiling without dropping into newHTTPTransport.
+func newHTTPWithTimeout(timeout time.Duration) *http.Client {
+	tr := &http.Transport{
+		IdleConnTimeout:     timeout,
+		MaxConnsPerHost:     defaultMaxIdleConnsPerHost,
+		MaxIdleConnsPerHost: defaultMaxIdleConnsPerHost,
+		Proxy:               http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   timeout,
+			KeepAlive: defaultKeepAlive,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:   true,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
 	return &http.Client{
-		Timeout:   defaultTimeout,
+		Timeout:   timeout,
 		Transport: gzhttp.Transport(tr),
 	}
 }

--- a/rpc/client_constructors_test.go
+++ b/rpc/client_constructors_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package rpc
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// Cover the constructor variants requested in #414: a default commitment can
+// be pinned at construction time and read back without callers having to
+// thread it through every method, and the HTTP timeout is no longer
+// hard-wired to the 5-minute default.
+
+func TestNew_DefaultCommitment_EmptyByDefault(t *testing.T) {
+	cl := New("http://localhost:8899")
+	if cl.DefaultCommitment() != "" {
+		t.Fatalf("expected empty default commitment, got %q", cl.DefaultCommitment())
+	}
+}
+
+func TestNewWithCommitment_StoresDefault(t *testing.T) {
+	cl := NewWithCommitment("http://localhost:8899", CommitmentFinalized)
+	if cl.DefaultCommitment() != CommitmentFinalized {
+		t.Fatalf("expected %q, got %q", CommitmentFinalized, cl.DefaultCommitment())
+	}
+}
+
+func TestNewWithTimeout_HonorsTimeoutOnHTTPClient(t *testing.T) {
+	timeout := 17 * time.Second
+	cl := NewWithTimeout("http://localhost:8899", timeout)
+	httpClient := extractHTTPClient(t, cl)
+	if httpClient.Timeout != timeout {
+		t.Fatalf("expected http.Client.Timeout=%s, got %s", timeout, httpClient.Timeout)
+	}
+}
+
+func TestNewWithTimeout_DefaultCommitmentEmpty(t *testing.T) {
+	cl := NewWithTimeout("http://localhost:8899", 30*time.Second)
+	if cl.DefaultCommitment() != "" {
+		t.Fatalf("expected empty default commitment, got %q", cl.DefaultCommitment())
+	}
+}
+
+func TestNewWithTimeoutAndCommitment_StoresBoth(t *testing.T) {
+	timeout := 7 * time.Second
+	cl := NewWithTimeoutAndCommitment("http://localhost:8899", timeout, CommitmentConfirmed)
+	if cl.DefaultCommitment() != CommitmentConfirmed {
+		t.Fatalf("expected %q, got %q", CommitmentConfirmed, cl.DefaultCommitment())
+	}
+	httpClient := extractHTTPClient(t, cl)
+	if httpClient.Timeout != timeout {
+		t.Fatalf("expected http.Client.Timeout=%s, got %s", timeout, httpClient.Timeout)
+	}
+}
+
+// extractHTTPClient pulls the *http.Client back out of the underlying
+// jsonrpc.RPCClient so the constructor's timeout choice can be asserted
+// without exporting new fields. The reflective access is scoped to this
+// test file.
+func extractHTTPClient(t *testing.T, cl *Client) *http.Client {
+	t.Helper()
+	rpcClient := cl.rpcClient
+	if rpcClient == nil {
+		t.Fatal("rpc client is nil")
+	}
+	v := reflect.ValueOf(rpcClient)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	field := v.FieldByName("httpClient")
+	if !field.IsValid() {
+		t.Fatalf("rpcClient %T has no httpClient field", rpcClient)
+	}
+	if field.IsNil() {
+		t.Fatal("httpClient field is nil")
+	}
+	httpClient, ok := reflect.NewAt(field.Type(), field.Addr().UnsafePointer()).Elem().Interface().(*http.Client)
+	if !ok {
+		t.Fatalf("httpClient field is not *http.Client (%v)", field.Type())
+	}
+	return httpClient
+}


### PR DESCRIPTION
## Description

Fixes #414. Adds the three `rpc.Client` constructor variants the issue asks for, plus a `DefaultCommitment()` accessor so callers can read the pinned commitment back without exporting a new field.

- `NewWithCommitment(url, commitment)` pins a `CommitmentType` on the returned `*Client`. Methods that take an explicit commitment continue to honor whatever the caller passes; the stored value is exposed through `Client.DefaultCommitment` so consumers can use it as a fallback rather than threading it through every call site themselves.
- `NewWithTimeout(url, timeout)` lifts the hardcoded `http.Client` timeout. The same value is also bound to the dialer's connect timeout and the transport's idle connection timeout so long-haul reads, connect, and pool eviction stay aligned.
- `NewWithTimeoutAndCommitment(url, timeout, commitment)` is the combined variant, mirroring the rust-sdk `RpcClient::new_with_timeout_and_commitment` ergonomics.

The new constructors compose `New` / a small `newHTTPWithTimeout` helper, leaving the existing 5-minute default for callers using `New` unchanged. No behavior change for existing call sites.

## Tests

Added `rpc/client_constructors_test.go` covering:

- `New` returns an empty default commitment.
- `NewWithCommitment` stores the pinned `CommitmentFinalized` value.
- `NewWithTimeout` propagates the timeout to the underlying `http.Client.Timeout`.
- `NewWithTimeout` does not pin a commitment.
- `NewWithTimeoutAndCommitment` stores both the commitment and the timeout.

```bash
$ go test ./rpc/ -run "TestNew_DefaultCommitment_EmptyByDefault|TestNewWithCommitment_StoresDefault|TestNewWithTimeout_HonorsTimeoutOnHTTPClient|TestNewWithTimeout_DefaultCommitmentEmpty|TestNewWithTimeoutAndCommitment_StoresBoth" -v
PASS
ok      github.com/gagliardetto/solana-go/rpc   0.599s
```
