### PR TITLE
Add rpc/client2.go implementing a second-generation Solana JSON RPC c…

### DIFF
--- a/rpc/client2.go
+++ b/rpc/client2.go
@@ -1,0 +1,130 @@
+package rpc
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+	"golang.org/x/time/rate"
+)
+
+type OptionFuncs []func(*RPCClientOpts)
+
+type RPCClientOpts struct {
+	*jsonrpc.RPCClientOpts
+	limiter *rate.Limiter
+}
+
+// New creates a new Solana JSON RPC client.
+// Client is safe for concurrent use by multiple goroutines.
+//
+// Use WithHTTPClient to set a custom HTTP client on the client.
+// Use WithCustomHeaders to set custom headers on the client.
+// Use WithLimiter to set a rate limiter on the client.
+//
+// Examples:
+//
+// client := rpc.New2("https://api.mainnet-beta.solana.com")
+// client := rpc.New2("https://api.mainnet-beta.solana.com", rpc.WithHTTPClient(http.DefaultClient))
+// client := rpc.New2("https://api.mainnet-beta.solana.com", rpc.WithHTTPClient(http.DefaultClient), rpc.WithLimiter(rate.Every(time.Second), 1))
+func New2(rpcEndpoint string, fns ...func(*RPCClientOpts)) JSONRPCClient {
+	opts := &RPCClientOpts{
+		RPCClientOpts: &jsonrpc.RPCClientOpts{
+			HTTPClient: newHTTP(),
+		},
+	}
+
+	for _, f := range fns {
+		f(opts)
+	}
+
+	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts.RPCClientOpts)
+
+	return &client2{
+		rpcClient: rpcClient,
+		limiter:   opts.limiter,
+	}
+}
+
+func WithHTTPClient(
+	client *http.Client,
+) func(*RPCClientOpts) {
+	return func(opts *RPCClientOpts) {
+		opts.HTTPClient = client
+	}
+}
+
+func WithCustomHeaders(
+	headers map[string]string,
+) func(*RPCClientOpts) {
+	return func(opts *RPCClientOpts) {
+		opts.CustomHeaders = headers
+	}
+}
+
+func WithLimiter(
+	every rate.Limit, // time frame
+	b int, // number of requests per time frame
+) func(*RPCClientOpts) {
+	return func(opts *RPCClientOpts) {
+		opts.limiter = rate.NewLimiter(every, b)
+	}
+}
+
+type client2 struct {
+	rpcClient jsonrpc.RPCClient
+	limiter   *rate.Limiter
+}
+
+func (cl *client2) CallForInto(
+	ctx context.Context,
+	out any,
+	method string,
+	params []any,
+) error {
+	if cl.limiter == nil {
+		return cl.rpcClient.CallForInto(ctx, out, method, params)
+	}
+	if err := cl.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return cl.rpcClient.CallForInto(ctx, &out, method, params)
+}
+
+func (cl *client2) CallWithCallback(
+	ctx context.Context,
+	method string,
+	params []any,
+	callback func(*http.Request, *http.Response) error,
+) error {
+	if cl.limiter == nil {
+		return cl.rpcClient.CallWithCallback(ctx, method, params, callback)
+	}
+	if err := cl.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return cl.rpcClient.CallWithCallback(ctx, method, params, callback)
+}
+
+func (cl *client2) CallBatch(
+	ctx context.Context,
+	requests jsonrpc.RPCRequests,
+) (jsonrpc.RPCResponses, error) {
+	if cl.limiter == nil {
+		return cl.rpcClient.CallBatch(ctx, requests)
+	}
+
+	if err := cl.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+	return cl.rpcClient.CallBatch(ctx, requests)
+}
+
+// Close closes.
+func (cl *client2) Close() error {
+	if c, ok := cl.rpcClient.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/rpc/client2.go
+++ b/rpc/client2.go
@@ -55,11 +55,11 @@ func WithHTTPClient(
 	}
 }
 
-func WithCustomHeaders(
-	headers map[string]string,
+func WithCustomHeader(
+	customHeader http.Header,
 ) func(*RPCClientOpts) {
 	return func(opts *RPCClientOpts) {
-		opts.CustomHeaders = headers
+		opts.CustomHeader = customHeader
 	}
 }
 

--- a/rpc/client2.go
+++ b/rpc/client2.go
@@ -28,7 +28,7 @@ type RPCClientOpts struct {
 // client := rpc.New2("https://api.mainnet-beta.solana.com")
 // client := rpc.New2("https://api.mainnet-beta.solana.com", rpc.WithHTTPClient(http.DefaultClient))
 // client := rpc.New2("https://api.mainnet-beta.solana.com", rpc.WithHTTPClient(http.DefaultClient), rpc.WithLimiter(rate.Every(time.Second), 1))
-func New2(rpcEndpoint string, fns ...func(*RPCClientOpts)) JSONRPCClient {
+func New2(rpcEndpoint string, fns OptionFuncs) *Client2 {
 	opts := &RPCClientOpts{
 		RPCClientOpts: &jsonrpc.RPCClientOpts{
 			HTTPClient: newHTTP(),
@@ -41,7 +41,7 @@ func New2(rpcEndpoint string, fns ...func(*RPCClientOpts)) JSONRPCClient {
 
 	rpcClient := jsonrpc.NewClientWithOpts(rpcEndpoint, opts.RPCClientOpts)
 
-	return &client2{
+	return &Client2{
 		rpcClient: rpcClient,
 		limiter:   opts.limiter,
 	}
@@ -64,7 +64,7 @@ func WithCustomHeaders(
 }
 
 func WithLimiter(
-	every rate.Limit, // time frame
+	every rate.Limit, // requests per second; use rate.Every(d) to convert a duration
 	b int, // number of requests per time frame
 ) func(*RPCClientOpts) {
 	return func(opts *RPCClientOpts) {
@@ -72,12 +72,12 @@ func WithLimiter(
 	}
 }
 
-type client2 struct {
+type Client2 struct {
 	rpcClient jsonrpc.RPCClient
 	limiter   *rate.Limiter
 }
 
-func (cl *client2) CallForInto(
+func (cl *Client2) CallForInto(
 	ctx context.Context,
 	out any,
 	method string,
@@ -89,10 +89,10 @@ func (cl *client2) CallForInto(
 	if err := cl.limiter.Wait(ctx); err != nil {
 		return err
 	}
-	return cl.rpcClient.CallForInto(ctx, &out, method, params)
+	return cl.rpcClient.CallForInto(ctx, out, method, params)
 }
 
-func (cl *client2) CallWithCallback(
+func (cl *Client2) CallWithCallback(
 	ctx context.Context,
 	method string,
 	params []any,
@@ -107,7 +107,7 @@ func (cl *client2) CallWithCallback(
 	return cl.rpcClient.CallWithCallback(ctx, method, params, callback)
 }
 
-func (cl *client2) CallBatch(
+func (cl *Client2) CallBatch(
 	ctx context.Context,
 	requests jsonrpc.RPCRequests,
 ) (jsonrpc.RPCResponses, error) {
@@ -122,7 +122,7 @@ func (cl *client2) CallBatch(
 }
 
 // Close closes.
-func (cl *client2) Close() error {
+func (cl *Client2) Close() error {
 	if c, ok := cl.rpcClient.(io.Closer); ok {
 		return c.Close()
 	}


### PR DESCRIPTION
…lient.

Supports configuring custom HTTP clients, request headers, and rate limiters via options, with automatic rate limit checks before each request.