### PR TITLE
fix(token,token-2022): per-instruction ProgramID override (closes #254)

### DIFF
--- a/programs/token-2022/instructions.go
+++ b/programs/token-2022/instructions.go
@@ -303,6 +303,22 @@ func InstructionIDToName(id uint8) string {
 
 type Instruction struct {
 	ag_binary.BaseVariant
+
+	// programIDOverride, when non-nil, replaces the package-level ProgramID
+	// for this instruction only. Lets callers issue SPL Token and SPL
+	// Token-2022 instructions in the same process without flipping the
+	// package-level ProgramID via SetProgramID — that mutation is not
+	// safe across goroutines.
+	programIDOverride *ag_solanago.PublicKey
+}
+
+// SetProgramID overrides the program ID used by this instruction only,
+// leaving the package-level ProgramID untouched. Use this to keep SPL
+// Token-2022 instructions independent from any other concurrent caller
+// that may have flipped the package ProgramID.
+func (inst *Instruction) SetProgramID(id ag_solanago.PublicKey) *Instruction {
+	inst.programIDOverride = &id
+	return inst
 }
 
 func (inst *Instruction) EncodeToTree(parent ag_treeout.Branches) {
@@ -461,6 +477,9 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 )
 
 func (inst *Instruction) ProgramID() ag_solanago.PublicKey {
+	if inst.programIDOverride != nil {
+		return *inst.programIDOverride
+	}
 	return ProgramID
 }
 

--- a/programs/token-2022/program_id_override_test.go
+++ b/programs/token-2022/program_id_override_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstruction_SetProgramID_DefaultMatchesPackage ensures an
+// instruction built without an override falls back to the package
+// ProgramID, so existing callers see no behaviour change.
+func TestInstruction_SetProgramID_DefaultMatchesPackage(t *testing.T) {
+	inst := NewTransferInstructionBuilder().
+		SetAmount(1).
+		SetSourceAccount(solana.MustPublicKeyFromBase58("11111111111111111111111111111112")).
+		SetDestinationAccount(solana.MustPublicKeyFromBase58("11111111111111111111111111111113")).
+		SetOwnerAccount(solana.MustPublicKeyFromBase58("11111111111111111111111111111114")).
+		Build()
+
+	require.Equal(t, ProgramID, inst.ProgramID())
+}
+
+// TestInstruction_SetProgramID_OverrideIsPerInstance verifies that
+// SetProgramID only affects the receiver and does not leak into either
+// the package ProgramID or a sibling instruction.
+func TestInstruction_SetProgramID_OverrideIsPerInstance(t *testing.T) {
+	originalProgramID := ProgramID
+	t.Cleanup(func() { ProgramID = originalProgramID })
+
+	customID := solana.MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	defaultInst := NewTransferInstructionBuilder().
+		SetAmount(1).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build()
+
+	overriddenInst := NewTransferInstructionBuilder().
+		SetAmount(2).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build().
+		SetProgramID(customID)
+
+	require.Equal(t, ProgramID, defaultInst.ProgramID(),
+		"default instruction must read the package ProgramID")
+	require.Equal(t, customID, overriddenInst.ProgramID(),
+		"overridden instruction must read its own ProgramID")
+	require.Equal(t, originalProgramID, ProgramID,
+		"SetProgramID on an instruction must not mutate the package ProgramID")
+}
+
+// TestInstruction_SetProgramID_ConcurrentBuildersDoNotRace covers the
+// motivating case from issue #254: building Token-2022 instructions in
+// parallel with a different-program override must not require a
+// process-wide mutex on the package ProgramID. Run under `-race`.
+func TestInstruction_SetProgramID_ConcurrentBuildersDoNotRace(t *testing.T) {
+	originalProgramID := ProgramID
+	t.Cleanup(func() { ProgramID = originalProgramID })
+
+	customID := solana.MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+
+			inst := NewTransferInstructionBuilder().
+				SetAmount(uint64(i + 1)).
+				SetSourceAccount(src).
+				SetDestinationAccount(dst).
+				SetOwnerAccount(owner).
+				Build()
+
+			if i%2 == 0 {
+				inst.SetProgramID(customID)
+				if inst.ProgramID() != customID {
+					t.Errorf("goroutine %d: expected customID, got %s", i, inst.ProgramID())
+				}
+			} else {
+				if inst.ProgramID() != ProgramID {
+					t.Errorf("goroutine %d: expected package ProgramID, got %s", i, inst.ProgramID())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, originalProgramID, ProgramID,
+		"package ProgramID must be unchanged after concurrent builders")
+}

--- a/programs/token-2022/program_id_override_test.go
+++ b/programs/token-2022/program_id_override_test.go
@@ -24,7 +24,7 @@ import (
 
 // TestInstruction_SetProgramID_DefaultMatchesPackage ensures an
 // instruction built without an override falls back to the package
-// ProgramID, so existing callers see no behaviour change.
+// ProgramID, so existing callers see no behavior change.
 func TestInstruction_SetProgramID_DefaultMatchesPackage(t *testing.T) {
 	inst := NewTransferInstructionBuilder().
 		SetAmount(1).

--- a/programs/token/instructions.go
+++ b/programs/token/instructions.go
@@ -227,6 +227,32 @@ func InstructionIDToName(id uint8) string {
 
 type Instruction struct {
 	ag_binary.BaseVariant
+
+	// programIDOverride, when non-nil, replaces the package-level ProgramID
+	// for this instruction only. Lets callers issue SPL Token and SPL
+	// Token-2022 instructions in the same process without flipping the
+	// package-level ProgramID via SetProgramID — that mutation is not
+	// safe across goroutines.
+	programIDOverride *ag_solanago.PublicKey
+}
+
+// SetProgramID overrides the program ID used by this instruction only,
+// leaving the package-level ProgramID untouched. Use this to keep SPL
+// Token and SPL Token-2022 (or any custom-deployed Token-compatible
+// program) instructions independent across concurrent goroutines.
+//
+// The receiver is returned so the call can be chained on a Build():
+//
+//	inst := token.NewTransferInstructionBuilder().
+//	    SetAmount(1).
+//	    SetSourceAccount(src).
+//	    SetDestinationAccount(dst).
+//	    SetOwnerAccount(owner).
+//	    Build().
+//	    SetProgramID(solana.Token2022ProgramID)
+func (inst *Instruction) SetProgramID(id ag_solanago.PublicKey) *Instruction {
+	inst.programIDOverride = &id
+	return inst
 }
 
 func (inst *Instruction) EncodeToTree(parent ag_treeout.Branches) {
@@ -307,6 +333,9 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 )
 
 func (inst *Instruction) ProgramID() ag_solanago.PublicKey {
+	if inst.programIDOverride != nil {
+		return *inst.programIDOverride
+	}
 	return ProgramID
 }
 

--- a/programs/token/program_id_override_test.go
+++ b/programs/token/program_id_override_test.go
@@ -24,7 +24,7 @@ import (
 
 // TestInstruction_SetProgramID_DefaultMatchesPackage ensures that an
 // instruction built without an override falls back to the package-level
-// ProgramID, preserving prior behaviour for the default code path.
+// ProgramID, preserving prior behavior for the default code path.
 func TestInstruction_SetProgramID_DefaultMatchesPackage(t *testing.T) {
 	inst := NewTransferInstructionBuilder().
 		SetAmount(1).

--- a/programs/token/program_id_override_test.go
+++ b/programs/token/program_id_override_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstruction_SetProgramID_DefaultMatchesPackage ensures that an
+// instruction built without an override falls back to the package-level
+// ProgramID, preserving prior behaviour for the default code path.
+func TestInstruction_SetProgramID_DefaultMatchesPackage(t *testing.T) {
+	inst := NewTransferInstructionBuilder().
+		SetAmount(1).
+		SetSourceAccount(solana.MustPublicKeyFromBase58("11111111111111111111111111111112")).
+		SetDestinationAccount(solana.MustPublicKeyFromBase58("11111111111111111111111111111113")).
+		SetOwnerAccount(solana.MustPublicKeyFromBase58("11111111111111111111111111111114")).
+		Build()
+
+	require.Equal(t, ProgramID, inst.ProgramID())
+}
+
+// TestInstruction_SetProgramID_OverrideIsPerInstance verifies that
+// SetProgramID only affects the receiver and does not leak into either
+// the package-level ProgramID or a sibling instruction built off the
+// same builder package.
+func TestInstruction_SetProgramID_OverrideIsPerInstance(t *testing.T) {
+	originalProgramID := ProgramID
+	t.Cleanup(func() { ProgramID = originalProgramID })
+
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	defaultInst := NewTransferInstructionBuilder().
+		SetAmount(1).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build()
+
+	overriddenInst := NewTransferInstructionBuilder().
+		SetAmount(2).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build().
+		SetProgramID(solana.Token2022ProgramID)
+
+	require.Equal(t, ProgramID, defaultInst.ProgramID(),
+		"default instruction must read the package ProgramID")
+	require.Equal(t, solana.Token2022ProgramID, overriddenInst.ProgramID(),
+		"overridden instruction must read its own ProgramID")
+	require.Equal(t, originalProgramID, ProgramID,
+		"SetProgramID on an instruction must not mutate the package ProgramID")
+}
+
+// TestInstruction_SetProgramID_ConcurrentBuildersDoNotRace covers the
+// motivating case from issue #254: building SPL Token and SPL Token-2022
+// instructions in parallel must not require a process-wide mutex around
+// the package-level ProgramID. Run under `-race`.
+func TestInstruction_SetProgramID_ConcurrentBuildersDoNotRace(t *testing.T) {
+	originalProgramID := ProgramID
+	t.Cleanup(func() { ProgramID = originalProgramID })
+
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+
+			// Alternate between the default program ID and the Token-2022
+			// override so both code paths are exercised under -race.
+			inst := NewTransferInstructionBuilder().
+				SetAmount(uint64(i + 1)).
+				SetSourceAccount(src).
+				SetDestinationAccount(dst).
+				SetOwnerAccount(owner).
+				Build()
+
+			if i%2 == 0 {
+				inst.SetProgramID(solana.Token2022ProgramID)
+				if inst.ProgramID() != solana.Token2022ProgramID {
+					t.Errorf("goroutine %d: expected Token2022ProgramID, got %s", i, inst.ProgramID())
+				}
+			} else {
+				if inst.ProgramID() != ProgramID {
+					t.Errorf("goroutine %d: expected package ProgramID, got %s", i, inst.ProgramID())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, originalProgramID, ProgramID,
+		"package ProgramID must be unchanged after concurrent builders")
+}


### PR DESCRIPTION
## Why

The package-level `ProgramID` in `programs/token` and `programs/token-2022` is read on every `(*Instruction).ProgramID()` call. To mix SPL Token and SPL Token-2022 instructions in the same process, callers today have to flip the package ProgramID via `SetProgramID` around each call — a mutation that is not safe across goroutines.

Issue [#254](https://github.com/solana-foundation/solana-go/issues/254) describes this exact pain.

## What

Add an optional per-instance override. `ProgramID()` prefers the override and falls back to the package ProgramID, so existing callers see no behaviour change:

```go
inst := token.NewTransferInstructionBuilder().
    SetAmount(1).
    SetSourceAccount(src).
    SetDestinationAccount(dst).
    SetOwnerAccount(owner).
    Build().
    SetProgramID(solana.Token2022ProgramID)
```

`SetProgramID` is added on `*Instruction` in both `programs/token` and `programs/token-2022`.

## Tests

Each package gets three tests, both runnable under `-race`:

- `TestInstruction_SetProgramID_DefaultMatchesPackage` — no override returns the package ProgramID.
- `TestInstruction_SetProgramID_OverrideIsPerInstance` — override does not leak to a sibling instruction or to the package ProgramID.
- `TestInstruction_SetProgramID_ConcurrentBuildersDoNotRace` — 32 goroutines mixing default + override with no shared mutex; package ProgramID is unchanged at the end.

```
$ go test -race ./programs/token/... ./programs/token-2022/...
ok      github.com/gagliardetto/solana-go/programs/token        1.7s
ok      github.com/gagliardetto/solana-go/programs/token-2022   1.7s
```

Full `go test ./...` is green.

## Notes

- No exported API removed or repurposed; the new field is unexported and the new method is purely additive.
- The package-level `SetProgramID` still works and still mutates the global, so callers that rely on it are unaffected.