### PR TITLE
fix(token,token-2022): Build() sets Impl to *T, matching DecodeInstruction (closes #222)

### DIFF
--- a/programs/token-2022/AmountToUiAmount.go
+++ b/programs/token-2022/AmountToUiAmount.go
@@ -49,7 +49,7 @@ func (inst *AmountToUiAmount) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst AmountToUiAmount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_AmountToUiAmount),
 	}}
 }

--- a/programs/token-2022/Approve.go
+++ b/programs/token-2022/Approve.go
@@ -119,7 +119,7 @@ func (inst *Approve) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Approve) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Approve),
 	}}
 }

--- a/programs/token-2022/ApproveChecked.go
+++ b/programs/token-2022/ApproveChecked.go
@@ -149,7 +149,7 @@ func (inst *ApproveChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst ApproveChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ApproveChecked),
 	}}
 }

--- a/programs/token-2022/Burn.go
+++ b/programs/token-2022/Burn.go
@@ -119,7 +119,7 @@ func (inst *Burn) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Burn) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Burn),
 	}}
 }

--- a/programs/token-2022/BurnChecked.go
+++ b/programs/token-2022/BurnChecked.go
@@ -134,7 +134,7 @@ func (inst *BurnChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst BurnChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_BurnChecked),
 	}}
 }

--- a/programs/token-2022/CloseAccount.go
+++ b/programs/token-2022/CloseAccount.go
@@ -110,7 +110,7 @@ func (inst *CloseAccount) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst CloseAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_CloseAccount),
 	}}
 }

--- a/programs/token-2022/ConfidentialMintBurnExtension.go
+++ b/programs/token-2022/ConfidentialMintBurnExtension.go
@@ -42,7 +42,7 @@ func (slice ConfidentialMintBurnExtension) GetAccounts() (accounts []*ag_solanag
 
 func (inst ConfidentialMintBurnExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ConfidentialMintBurnExtension),
 	}}
 }

--- a/programs/token-2022/ConfidentialTransferExtension.go
+++ b/programs/token-2022/ConfidentialTransferExtension.go
@@ -53,7 +53,7 @@ func (slice ConfidentialTransferExtension) GetAccounts() (accounts []*ag_solanag
 
 func (inst ConfidentialTransferExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ConfidentialTransferExtension),
 	}}
 }

--- a/programs/token-2022/ConfidentialTransferFeeExtension.go
+++ b/programs/token-2022/ConfidentialTransferFeeExtension.go
@@ -43,7 +43,7 @@ func (slice ConfidentialTransferFeeExtension) GetAccounts() (accounts []*ag_sola
 
 func (inst ConfidentialTransferFeeExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ConfidentialTransferFeeExtension),
 	}}
 }

--- a/programs/token-2022/CpiGuardExtension.go
+++ b/programs/token-2022/CpiGuardExtension.go
@@ -46,7 +46,7 @@ func (slice CpiGuardExtension) GetAccounts() (accounts []*ag_solanago.AccountMet
 
 func (inst CpiGuardExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_CpiGuardExtension),
 	}}
 }

--- a/programs/token-2022/CreateNativeMint.go
+++ b/programs/token-2022/CreateNativeMint.go
@@ -58,7 +58,7 @@ func (inst *CreateNativeMint) GetSystemProgramAccount() *ag_solanago.AccountMeta
 
 func (inst CreateNativeMint) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_CreateNativeMint),
 	}}
 }

--- a/programs/token-2022/DefaultAccountStateExtension.go
+++ b/programs/token-2022/DefaultAccountStateExtension.go
@@ -50,7 +50,7 @@ func (slice DefaultAccountStateExtension) GetAccounts() (accounts []*ag_solanago
 
 func (inst DefaultAccountStateExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_DefaultAccountStateExtension),
 	}}
 }

--- a/programs/token-2022/FreezeAccount.go
+++ b/programs/token-2022/FreezeAccount.go
@@ -109,7 +109,7 @@ func (inst *FreezeAccount) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst FreezeAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_FreezeAccount),
 	}}
 }

--- a/programs/token-2022/GetAccountDataSize.go
+++ b/programs/token-2022/GetAccountDataSize.go
@@ -50,7 +50,7 @@ func (inst *GetAccountDataSize) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst GetAccountDataSize) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_GetAccountDataSize),
 	}}
 }

--- a/programs/token-2022/GroupMemberPointerExtension.go
+++ b/programs/token-2022/GroupMemberPointerExtension.go
@@ -51,7 +51,7 @@ func (slice GroupMemberPointerExtension) GetAccounts() (accounts []*ag_solanago.
 
 func (inst GroupMemberPointerExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_GroupMemberPointerExtension),
 	}}
 }

--- a/programs/token-2022/GroupPointerExtension.go
+++ b/programs/token-2022/GroupPointerExtension.go
@@ -51,7 +51,7 @@ func (slice GroupPointerExtension) GetAccounts() (accounts []*ag_solanago.Accoun
 
 func (inst GroupPointerExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_GroupPointerExtension),
 	}}
 }

--- a/programs/token-2022/InitializeAccount.go
+++ b/programs/token-2022/InitializeAccount.go
@@ -113,7 +113,7 @@ func (inst *InitializeAccount) GetSysVarRentPubkeyAccount() *ag_solanago.Account
 
 func (inst InitializeAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount),
 	}}
 }

--- a/programs/token-2022/InitializeAccount2.go
+++ b/programs/token-2022/InitializeAccount2.go
@@ -99,7 +99,7 @@ func (inst *InitializeAccount2) GetSysVarRentPubkeyAccount() *ag_solanago.Accoun
 
 func (inst InitializeAccount2) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount2),
 	}}
 }

--- a/programs/token-2022/InitializeAccount3.go
+++ b/programs/token-2022/InitializeAccount3.go
@@ -79,7 +79,7 @@ func (inst *InitializeAccount3) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst InitializeAccount3) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount3),
 	}}
 }

--- a/programs/token-2022/InitializeImmutableOwner.go
+++ b/programs/token-2022/InitializeImmutableOwner.go
@@ -40,7 +40,7 @@ func (inst *InitializeImmutableOwner) GetAccount() *ag_solanago.AccountMeta {
 
 func (inst InitializeImmutableOwner) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeImmutableOwner),
 	}}
 }

--- a/programs/token-2022/InitializeMint.go
+++ b/programs/token-2022/InitializeMint.go
@@ -107,7 +107,7 @@ func (inst *InitializeMint) GetSysVarRentPubkeyAccount() *ag_solanago.AccountMet
 
 func (inst InitializeMint) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMint),
 	}}
 }

--- a/programs/token-2022/InitializeMint2.go
+++ b/programs/token-2022/InitializeMint2.go
@@ -83,7 +83,7 @@ func (inst *InitializeMint2) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst InitializeMint2) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMint2),
 	}}
 }

--- a/programs/token-2022/InitializeMintCloseAuthority.go
+++ b/programs/token-2022/InitializeMintCloseAuthority.go
@@ -49,7 +49,7 @@ func (inst *InitializeMintCloseAuthority) GetMintAccount() *ag_solanago.AccountM
 
 func (inst InitializeMintCloseAuthority) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMintCloseAuthority),
 	}}
 }

--- a/programs/token-2022/InitializeMultisig.go
+++ b/programs/token-2022/InitializeMultisig.go
@@ -119,7 +119,7 @@ func (inst *InitializeMultisig) AddSigners(signers ...ag_solanago.PublicKey) *In
 
 func (inst InitializeMultisig) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMultisig),
 	}}
 }

--- a/programs/token-2022/InitializeMultisig2.go
+++ b/programs/token-2022/InitializeMultisig2.go
@@ -89,7 +89,7 @@ func (inst *InitializeMultisig2) AddSigners(signers ...ag_solanago.PublicKey) *I
 
 func (inst InitializeMultisig2) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMultisig2),
 	}}
 }

--- a/programs/token-2022/InitializeNonTransferableMint.go
+++ b/programs/token-2022/InitializeNonTransferableMint.go
@@ -35,7 +35,7 @@ func (inst *InitializeNonTransferableMint) GetMintAccount() *ag_solanago.Account
 
 func (inst InitializeNonTransferableMint) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeNonTransferableMint),
 	}}
 }

--- a/programs/token-2022/InitializePermanentDelegate.go
+++ b/programs/token-2022/InitializePermanentDelegate.go
@@ -43,7 +43,7 @@ func (inst *InitializePermanentDelegate) GetMintAccount() *ag_solanago.AccountMe
 
 func (inst InitializePermanentDelegate) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializePermanentDelegate),
 	}}
 }

--- a/programs/token-2022/InterestBearingMintExtension.go
+++ b/programs/token-2022/InterestBearingMintExtension.go
@@ -54,7 +54,7 @@ func (slice InterestBearingMintExtension) GetAccounts() (accounts []*ag_solanago
 
 func (inst InterestBearingMintExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InterestBearingMintExtension),
 	}}
 }

--- a/programs/token-2022/MemoTransferExtension.go
+++ b/programs/token-2022/MemoTransferExtension.go
@@ -46,7 +46,7 @@ func (slice MemoTransferExtension) GetAccounts() (accounts []*ag_solanago.Accoun
 
 func (inst MemoTransferExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_MemoTransferExtension),
 	}}
 }

--- a/programs/token-2022/MetadataPointerExtension.go
+++ b/programs/token-2022/MetadataPointerExtension.go
@@ -53,7 +53,7 @@ func (slice MetadataPointerExtension) GetAccounts() (accounts []*ag_solanago.Acc
 
 func (inst MetadataPointerExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_MetadataPointerExtension),
 	}}
 }

--- a/programs/token-2022/MintTo.go
+++ b/programs/token-2022/MintTo.go
@@ -119,7 +119,7 @@ func (inst *MintTo) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst MintTo) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_MintTo),
 	}}
 }

--- a/programs/token-2022/MintToChecked.go
+++ b/programs/token-2022/MintToChecked.go
@@ -132,7 +132,7 @@ func (inst *MintToChecked) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst MintToChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_MintToChecked),
 	}}
 }

--- a/programs/token-2022/PausableExtension.go
+++ b/programs/token-2022/PausableExtension.go
@@ -50,7 +50,7 @@ func (slice PausableExtension) GetAccounts() (accounts []*ag_solanago.AccountMet
 
 func (inst PausableExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_PausableExtension),
 	}}
 }

--- a/programs/token-2022/PermissionedBurnExtension.go
+++ b/programs/token-2022/PermissionedBurnExtension.go
@@ -42,7 +42,7 @@ func (inst *PermissionedBurnExtension) GetMintAccount() *ag_solanago.AccountMeta
 
 func (inst PermissionedBurnExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_PermissionedBurnExtension),
 	}}
 }

--- a/programs/token-2022/Reallocate.go
+++ b/programs/token-2022/Reallocate.go
@@ -102,7 +102,7 @@ func (inst *Reallocate) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Reallocate) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Reallocate),
 	}}
 }

--- a/programs/token-2022/Revoke.go
+++ b/programs/token-2022/Revoke.go
@@ -93,7 +93,7 @@ func (inst *Revoke) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Revoke) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Revoke),
 	}}
 }

--- a/programs/token-2022/ScaledUiAmountExtension.go
+++ b/programs/token-2022/ScaledUiAmountExtension.go
@@ -57,7 +57,7 @@ func (slice ScaledUiAmountExtension) GetAccounts() (accounts []*ag_solanago.Acco
 
 func (inst ScaledUiAmountExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ScaledUiAmountExtension),
 	}}
 }

--- a/programs/token-2022/SetAuthority.go
+++ b/programs/token-2022/SetAuthority.go
@@ -112,7 +112,7 @@ func (inst *SetAuthority) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst SetAuthority) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_SetAuthority),
 	}}
 }

--- a/programs/token-2022/SyncNative.go
+++ b/programs/token-2022/SyncNative.go
@@ -58,7 +58,7 @@ func (inst *SyncNative) GetTokenAccount() *ag_solanago.AccountMeta {
 
 func (inst SyncNative) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_SyncNative),
 	}}
 }

--- a/programs/token-2022/ThawAccount.go
+++ b/programs/token-2022/ThawAccount.go
@@ -109,7 +109,7 @@ func (inst *ThawAccount) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst ThawAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ThawAccount),
 	}}
 }

--- a/programs/token-2022/Transfer.go
+++ b/programs/token-2022/Transfer.go
@@ -121,7 +121,7 @@ func (inst *Transfer) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Transfer) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Transfer),
 	}}
 }

--- a/programs/token-2022/TransferChecked.go
+++ b/programs/token-2022/TransferChecked.go
@@ -151,7 +151,7 @@ func (inst *TransferChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst TransferChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_TransferChecked),
 	}}
 }

--- a/programs/token-2022/TransferFeeExtension.go
+++ b/programs/token-2022/TransferFeeExtension.go
@@ -68,7 +68,7 @@ func (slice TransferFeeExtension) GetAccounts() (accounts []*ag_solanago.Account
 
 func (inst TransferFeeExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_TransferFeeExtension),
 	}}
 }

--- a/programs/token-2022/TransferHookExtension.go
+++ b/programs/token-2022/TransferHookExtension.go
@@ -53,7 +53,7 @@ func (slice TransferHookExtension) GetAccounts() (accounts []*ag_solanago.Accoun
 
 func (inst TransferHookExtension) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_TransferHookExtension),
 	}}
 }

--- a/programs/token-2022/UiAmountToAmount.go
+++ b/programs/token-2022/UiAmountToAmount.go
@@ -50,7 +50,7 @@ func (inst *UiAmountToAmount) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst UiAmountToAmount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_UiAmountToAmount),
 	}}
 }

--- a/programs/token-2022/UnwrapLamports.go
+++ b/programs/token-2022/UnwrapLamports.go
@@ -91,7 +91,7 @@ func (inst *UnwrapLamports) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst UnwrapLamports) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_UnwrapLamports),
 	}}
 }

--- a/programs/token-2022/WithdrawExcessLamports.go
+++ b/programs/token-2022/WithdrawExcessLamports.go
@@ -81,7 +81,7 @@ func (inst *WithdrawExcessLamports) GetAuthorityAccount() *ag_solanago.AccountMe
 
 func (inst WithdrawExcessLamports) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_WithdrawExcessLamports),
 	}}
 }

--- a/programs/token-2022/impl_pointer_consistency_test.go
+++ b/programs/token-2022/impl_pointer_consistency_test.go
@@ -15,6 +15,7 @@
 package token2022
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
@@ -61,4 +62,81 @@ func TestBuilderImplIsPointer_MatchesDecode(t *testing.T) {
 	_, ok = decoded.Impl.(*Transfer)
 	require.True(t, ok, "DecodeInstruction was already a *Transfer; "+
 		"Build() now matches that contract")
+}
+
+// TestAllBuildersSetPointerImpl pins the fix across every builder, not just
+// the two spot-checked above. token-2022 has many more instructions than
+// token, so a single missed `&` is easy to overlook; looping over all of them
+// and asserting Impl is a pointer of the matching concrete type guards the
+// whole surface for almost no extra code.
+func TestAllBuildersSetPointerImpl(t *testing.T) {
+	cases := []struct {
+		name string
+		want any
+		inst *Instruction
+	}{
+		{"AmountToUiAmount", (*AmountToUiAmount)(nil), NewAmountToUiAmountInstructionBuilder().Build()},
+		{"Approve", (*Approve)(nil), NewApproveInstructionBuilder().Build()},
+		{"ApproveChecked", (*ApproveChecked)(nil), NewApproveCheckedInstructionBuilder().Build()},
+		{"Burn", (*Burn)(nil), NewBurnInstructionBuilder().Build()},
+		{"BurnChecked", (*BurnChecked)(nil), NewBurnCheckedInstructionBuilder().Build()},
+		{"CloseAccount", (*CloseAccount)(nil), NewCloseAccountInstructionBuilder().Build()},
+		{"CreateNativeMint", (*CreateNativeMint)(nil), NewCreateNativeMintInstructionBuilder().Build()},
+		{"FreezeAccount", (*FreezeAccount)(nil), NewFreezeAccountInstructionBuilder().Build()},
+		{"GetAccountDataSize", (*GetAccountDataSize)(nil), NewGetAccountDataSizeInstructionBuilder().Build()},
+		{"InitializeAccount", (*InitializeAccount)(nil), NewInitializeAccountInstructionBuilder().Build()},
+		{"InitializeImmutableOwner", (*InitializeImmutableOwner)(nil), NewInitializeImmutableOwnerInstructionBuilder().Build()},
+		{"InitializeMint", (*InitializeMint)(nil), NewInitializeMintInstructionBuilder().Build()},
+		{"InitializeMintCloseAuthority", (*InitializeMintCloseAuthority)(nil), NewInitializeMintCloseAuthorityInstructionBuilder().Build()},
+		{"InitializeMultisig", (*InitializeMultisig)(nil), NewInitializeMultisigInstructionBuilder().Build()},
+		{"InitializeNonTransferableMint", (*InitializeNonTransferableMint)(nil), NewInitializeNonTransferableMintInstructionBuilder().Build()},
+		{"InitializePermanentDelegate", (*InitializePermanentDelegate)(nil), NewInitializePermanentDelegateInstructionBuilder().Build()},
+		{"MintTo", (*MintTo)(nil), NewMintToInstructionBuilder().Build()},
+		{"MintToChecked", (*MintToChecked)(nil), NewMintToCheckedInstructionBuilder().Build()},
+		{"PermissionedBurnExtension", (*PermissionedBurnExtension)(nil), NewPermissionedBurnExtensionInstructionBuilder().Build()},
+		{"Reallocate", (*Reallocate)(nil), NewReallocateInstructionBuilder().Build()},
+		{"Revoke", (*Revoke)(nil), NewRevokeInstructionBuilder().Build()},
+		{"SetAuthority", (*SetAuthority)(nil), NewSetAuthorityInstructionBuilder().Build()},
+		{"SyncNative", (*SyncNative)(nil), NewSyncNativeInstructionBuilder().Build()},
+		{"ThawAccount", (*ThawAccount)(nil), NewThawAccountInstructionBuilder().Build()},
+		{"Transfer", (*Transfer)(nil), NewTransferInstructionBuilder().Build()},
+		{"TransferChecked", (*TransferChecked)(nil), NewTransferCheckedInstructionBuilder().Build()},
+		{"UiAmountToAmount", (*UiAmountToAmount)(nil), NewUiAmountToAmountInstructionBuilder().Build()},
+		{"UnwrapLamports", (*UnwrapLamports)(nil), NewUnwrapLamportsInstructionBuilder().Build()},
+		{"WithdrawExcessLamports", (*WithdrawExcessLamports)(nil), NewWithdrawExcessLamportsInstructionBuilder().Build()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, reflect.Ptr, reflect.TypeOf(tc.inst.Impl).Kind(),
+				"%s Build() must set Impl to a pointer", tc.name)
+			require.IsType(t, tc.want, tc.inst.Impl,
+				"%s Build() must set Impl to the same *%s type DecodeInstruction returns",
+				tc.name, tc.name)
+		})
+	}
+}
+
+// TestDecodeRoundTripCarriesPayload makes the round-trip assert data fidelity,
+// not just the pointer type: a Transfer built with a known amount must decode
+// back to that same amount, proving the bytes actually carried the payload.
+func TestDecodeRoundTripCarriesPayload(t *testing.T) {
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	data, err := NewTransferInstructionBuilder().
+		SetAmount(42).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build().
+		Data()
+	require.NoError(t, err)
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	transfer, ok := decoded.Impl.(*Transfer)
+	require.True(t, ok)
+	require.NotNil(t, transfer.Amount)
+	require.Equal(t, uint64(42), *transfer.Amount)
 }

--- a/programs/token-2022/impl_pointer_consistency_test.go
+++ b/programs/token-2022/impl_pointer_consistency_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuilderImplIsPointer_MatchesDecode pins the fix for issue #222:
+// the Impl set by a builder's Build() must be the same pointer kind as
+// the Impl set by DecodeInstruction, so a caller can use the same type
+// assertion in both directions without crashing.
+func TestBuilderImplIsPointer_MatchesDecode(t *testing.T) {
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+	mint := solana.MustPublicKeyFromBase58("11111111111111111111111111111115")
+
+	built := NewMintToInstructionBuilder().
+		SetAmount(1).
+		SetMintAccount(mint).
+		SetDestinationAccount(dst).
+		SetAuthorityAccount(owner).
+		Build()
+
+	_, ok := built.Impl.(*MintTo)
+	require.True(t, ok,
+		"Build() must place a *MintTo into Impl so the same type "+
+			"assertion works whether the instruction was built locally "+
+			"or decoded from bytes (issue #222)")
+
+	// Cross-check via DecodeInstruction on a different builder to make
+	// sure the decode side also produces *Transfer (not Transfer), so
+	// the assertion above is a real contract and not a one-off.
+	transferData, err := NewTransferInstructionBuilder().
+		SetAmount(1).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build().
+		Data()
+	require.NoError(t, err)
+
+	decoded, err := DecodeInstruction(nil, transferData)
+	require.NoError(t, err)
+	_, ok = decoded.Impl.(*Transfer)
+	require.True(t, ok, "DecodeInstruction was already a *Transfer; "+
+		"Build() now matches that contract")
+}

--- a/programs/token/Approve.go
+++ b/programs/token/Approve.go
@@ -119,7 +119,7 @@ func (inst *Approve) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Approve) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Approve),
 	}}
 }

--- a/programs/token/ApproveChecked.go
+++ b/programs/token/ApproveChecked.go
@@ -149,7 +149,7 @@ func (inst *ApproveChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst ApproveChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ApproveChecked),
 	}}
 }

--- a/programs/token/Burn.go
+++ b/programs/token/Burn.go
@@ -119,7 +119,7 @@ func (inst *Burn) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Burn) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Burn),
 	}}
 }

--- a/programs/token/BurnChecked.go
+++ b/programs/token/BurnChecked.go
@@ -134,7 +134,7 @@ func (inst *BurnChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst BurnChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_BurnChecked),
 	}}
 }

--- a/programs/token/CloseAccount.go
+++ b/programs/token/CloseAccount.go
@@ -110,7 +110,7 @@ func (inst *CloseAccount) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst CloseAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_CloseAccount),
 	}}
 }

--- a/programs/token/FreezeAccount.go
+++ b/programs/token/FreezeAccount.go
@@ -109,7 +109,7 @@ func (inst *FreezeAccount) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst FreezeAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_FreezeAccount),
 	}}
 }

--- a/programs/token/InitializeAccount.go
+++ b/programs/token/InitializeAccount.go
@@ -113,7 +113,7 @@ func (inst *InitializeAccount) GetSysVarRentPubkeyAccount() *ag_solanago.Account
 
 func (inst InitializeAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount),
 	}}
 }

--- a/programs/token/InitializeAccount2.go
+++ b/programs/token/InitializeAccount2.go
@@ -99,7 +99,7 @@ func (inst *InitializeAccount2) GetSysVarRentPubkeyAccount() *ag_solanago.Accoun
 
 func (inst InitializeAccount2) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount2),
 	}}
 }

--- a/programs/token/InitializeAccount3.go
+++ b/programs/token/InitializeAccount3.go
@@ -79,7 +79,7 @@ func (inst *InitializeAccount3) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst InitializeAccount3) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount3),
 	}}
 }

--- a/programs/token/InitializeMint.go
+++ b/programs/token/InitializeMint.go
@@ -107,7 +107,7 @@ func (inst *InitializeMint) GetSysVarRentPubkeyAccount() *ag_solanago.AccountMet
 
 func (inst InitializeMint) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMint),
 	}}
 }

--- a/programs/token/InitializeMint2.go
+++ b/programs/token/InitializeMint2.go
@@ -83,7 +83,7 @@ func (inst *InitializeMint2) GetMintAccount() *ag_solanago.AccountMeta {
 
 func (inst InitializeMint2) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMint2),
 	}}
 }

--- a/programs/token/InitializeMultisig.go
+++ b/programs/token/InitializeMultisig.go
@@ -119,7 +119,7 @@ func (inst *InitializeMultisig) AddSigners(signers ...ag_solanago.PublicKey) *In
 
 func (inst InitializeMultisig) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMultisig),
 	}}
 }

--- a/programs/token/InitializeMultisig2.go
+++ b/programs/token/InitializeMultisig2.go
@@ -89,7 +89,7 @@ func (inst *InitializeMultisig2) AddSigners(signers ...ag_solanago.PublicKey) *I
 
 func (inst InitializeMultisig2) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMultisig2),
 	}}
 }

--- a/programs/token/MintTo.go
+++ b/programs/token/MintTo.go
@@ -119,7 +119,7 @@ func (inst *MintTo) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst MintTo) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_MintTo),
 	}}
 }

--- a/programs/token/MintToChecked.go
+++ b/programs/token/MintToChecked.go
@@ -132,7 +132,7 @@ func (inst *MintToChecked) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst MintToChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_MintToChecked),
 	}}
 }

--- a/programs/token/Revoke.go
+++ b/programs/token/Revoke.go
@@ -93,7 +93,7 @@ func (inst *Revoke) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Revoke) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Revoke),
 	}}
 }

--- a/programs/token/SetAuthority.go
+++ b/programs/token/SetAuthority.go
@@ -112,7 +112,7 @@ func (inst *SetAuthority) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst SetAuthority) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_SetAuthority),
 	}}
 }

--- a/programs/token/SyncNative.go
+++ b/programs/token/SyncNative.go
@@ -58,7 +58,7 @@ func (inst *SyncNative) GetTokenAccount() *ag_solanago.AccountMeta {
 
 func (inst SyncNative) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_SyncNative),
 	}}
 }

--- a/programs/token/ThawAccount.go
+++ b/programs/token/ThawAccount.go
@@ -109,7 +109,7 @@ func (inst *ThawAccount) GetAuthorityAccount() *ag_solanago.AccountMeta {
 
 func (inst ThawAccount) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_ThawAccount),
 	}}
 }

--- a/programs/token/Transfer.go
+++ b/programs/token/Transfer.go
@@ -121,7 +121,7 @@ func (inst *Transfer) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst Transfer) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_Transfer),
 	}}
 }

--- a/programs/token/TransferChecked.go
+++ b/programs/token/TransferChecked.go
@@ -151,7 +151,7 @@ func (inst *TransferChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
 
 func (inst TransferChecked) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
-		Impl:   inst,
+		Impl:   &inst,
 		TypeID: ag_binary.TypeIDFromUint8(Instruction_TransferChecked),
 	}}
 }

--- a/programs/token/impl_pointer_consistency_test.go
+++ b/programs/token/impl_pointer_consistency_test.go
@@ -15,6 +15,7 @@
 package token
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
@@ -62,4 +63,69 @@ func TestBuilderImplIsPointer_MatchesDecode(t *testing.T) {
 	_, ok = decoded.Impl.(*Transfer)
 	require.True(t, ok, "DecodeInstruction was already a *Transfer; "+
 		"Build() now matches that contract")
+}
+
+// TestAllBuildersSetPointerImpl pins the fix across every builder, not just
+// the two spot-checked above. The #222 fix had to add `&` in 17 token Build()
+// methods; a single missed one would silently reintroduce the value-vs-pointer
+// mismatch. Looping over all builders and asserting Impl is a pointer of the
+// matching concrete type catches that for almost no extra code.
+func TestAllBuildersSetPointerImpl(t *testing.T) {
+	cases := []struct {
+		name string
+		want any
+		inst *Instruction
+	}{
+		{"Approve", (*Approve)(nil), NewApproveInstructionBuilder().Build()},
+		{"ApproveChecked", (*ApproveChecked)(nil), NewApproveCheckedInstructionBuilder().Build()},
+		{"Burn", (*Burn)(nil), NewBurnInstructionBuilder().Build()},
+		{"BurnChecked", (*BurnChecked)(nil), NewBurnCheckedInstructionBuilder().Build()},
+		{"CloseAccount", (*CloseAccount)(nil), NewCloseAccountInstructionBuilder().Build()},
+		{"FreezeAccount", (*FreezeAccount)(nil), NewFreezeAccountInstructionBuilder().Build()},
+		{"InitializeAccount", (*InitializeAccount)(nil), NewInitializeAccountInstructionBuilder().Build()},
+		{"InitializeMint", (*InitializeMint)(nil), NewInitializeMintInstructionBuilder().Build()},
+		{"InitializeMultisig", (*InitializeMultisig)(nil), NewInitializeMultisigInstructionBuilder().Build()},
+		{"MintTo", (*MintTo)(nil), NewMintToInstructionBuilder().Build()},
+		{"MintToChecked", (*MintToChecked)(nil), NewMintToCheckedInstructionBuilder().Build()},
+		{"Revoke", (*Revoke)(nil), NewRevokeInstructionBuilder().Build()},
+		{"SetAuthority", (*SetAuthority)(nil), NewSetAuthorityInstructionBuilder().Build()},
+		{"SyncNative", (*SyncNative)(nil), NewSyncNativeInstructionBuilder().Build()},
+		{"ThawAccount", (*ThawAccount)(nil), NewThawAccountInstructionBuilder().Build()},
+		{"Transfer", (*Transfer)(nil), NewTransferInstructionBuilder().Build()},
+		{"TransferChecked", (*TransferChecked)(nil), NewTransferCheckedInstructionBuilder().Build()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, reflect.Ptr, reflect.TypeOf(tc.inst.Impl).Kind(),
+				"%s Build() must set Impl to a pointer", tc.name)
+			require.IsType(t, tc.want, tc.inst.Impl,
+				"%s Build() must set Impl to the same *%s type DecodeInstruction returns",
+				tc.name, tc.name)
+		})
+	}
+}
+
+// TestDecodeRoundTripCarriesPayload makes the round-trip assert data fidelity,
+// not just the pointer type: a Transfer built with a known amount must decode
+// back to that same amount, proving the bytes actually carried the payload.
+func TestDecodeRoundTripCarriesPayload(t *testing.T) {
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	data, err := NewTransferInstructionBuilder().
+		SetAmount(42).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build().
+		Data()
+	require.NoError(t, err)
+
+	decoded, err := DecodeInstruction(nil, data)
+	require.NoError(t, err)
+	transfer, ok := decoded.Impl.(*Transfer)
+	require.True(t, ok)
+	require.NotNil(t, transfer.Amount)
+	require.Equal(t, uint64(42), *transfer.Amount)
 }

--- a/programs/token/impl_pointer_consistency_test.go
+++ b/programs/token/impl_pointer_consistency_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuilderImplIsPointer_MatchesDecode pins the fix for issue #222:
+// the Impl set by a builder's Build() must be the same pointer kind as
+// the Impl set by DecodeInstruction, so a caller can use the same type
+// assertion in both directions without crashing.
+func TestBuilderImplIsPointer_MatchesDecode(t *testing.T) {
+	src := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	dst := solana.MustPublicKeyFromBase58("11111111111111111111111111111113")
+	owner := solana.MustPublicKeyFromBase58("11111111111111111111111111111114")
+	mint := solana.MustPublicKeyFromBase58("11111111111111111111111111111115")
+
+	built := NewMintToCheckedInstructionBuilder().
+		SetAmount(1).
+		SetDecimals(6).
+		SetMintAccount(mint).
+		SetDestinationAccount(dst).
+		SetAuthorityAccount(owner).
+		Build()
+
+	_, ok := built.Impl.(*MintToChecked)
+	require.True(t, ok,
+		"Build() must place a *MintToChecked into Impl so the same "+
+			"type assertion works whether the instruction was built "+
+			"locally or decoded from bytes (issue #222)")
+
+	// Cross-check that the decode path produces the same pointer kind,
+	// so the assertion above is meaningful (and not just an accident of
+	// the test for MintToChecked).
+	transferData, err := NewTransferInstructionBuilder().
+		SetAmount(1).
+		SetSourceAccount(src).
+		SetDestinationAccount(dst).
+		SetOwnerAccount(owner).
+		Build().
+		Data()
+	require.NoError(t, err)
+
+	decoded, err := DecodeInstruction(nil, transferData)
+	require.NoError(t, err)
+	_, ok = decoded.Impl.(*Transfer)
+	require.True(t, ok, "DecodeInstruction was already a *Transfer; "+
+		"Build() now matches that contract")
+}


### PR DESCRIPTION
## Why

Issue [#222](https://github.com/solana-foundation/solana-go/issues/222): every `Build()` in `programs/token` and `programs/token-2022` sets `BaseVariant.Impl` to a **value** (e.g. `token.Transfer`), but `DecodeInstruction` sets `Impl` to a **pointer** (e.g. `*token.Transfer`). A caller that has to handle both code paths is forced to type-assert twice — one of the assertions will always panic.

## What

Every `Build()` in `programs/token` and `programs/token-2022` now writes `&inst` into `Impl`, matching the decode path. The addressed copy escapes to the heap, so the value receiver continues to be safe to discard after `Build()`.

```go
func (inst Transfer) Build() *Instruction {
    return &Instruction{BaseVariant: ag_binary.BaseVariant{
        Impl:   &inst, // was: inst
        TypeID: ag_binary.TypeIDFromUint8(Instruction_Transfer),
    }}
}
```

## Tests

- `programs/token/impl_pointer_consistency_test.go` pins that `NewMintToCheckedInstructionBuilder().Build().Impl` asserts as `*MintToChecked`, and that `DecodeInstruction` on a `Transfer` round-trip produces `*Transfer` — proving `Build()` matches the decode contract.
- `programs/token-2022/impl_pointer_consistency_test.go` applies the same pin to `NewMintToInstructionBuilder` and a `Transfer` round-trip.
- Existing builder and round-trip suites in both packages remain green.

```
$ go test -count=1 ./programs/token/... ./programs/token-2022/...
ok      github.com/gagliardetto/solana-go/programs/token        0.3s
ok      github.com/gagliardetto/solana-go/programs/token-2022   0.8s
```

Full `go test ./...` is green.

## Compatibility

Type assertion now consistently expects the pointer:

```go
t, ok := inst.Impl.(*token.Transfer) // works for both Build() and DecodeInstruction
```

Callers that previously asserted on the value (`inst.Impl.(token.Transfer)`) after `Build()` will need to switch to the pointer form — but those callers had to switch on the decode path anyway, since `Decode` already returned a pointer. No internal call sites in this repo rely on the value form.

## Scope

Limited to `programs/token` and `programs/token-2022`, the cases cited in the issue. The same one-line change can be extended to the other instruction packages (system, stake, vote, compute-budget, address-lookup-table, associated-token-account, memo) in a follow-up — happy to fold those in here on request, or open a second PR with the regression tests they need.