### PR TITLE
fix(message): surface typed `ErrAddressTablesNotSet` from AccountMetaList (closes #280)

### DIFF
--- a/message.go
+++ b/message.go
@@ -38,7 +38,8 @@ import (
 var ErrAddressTablesNotSet = errors.New(
 	"address tables not set for versioned message with lookups; " +
 		"fetch each table id returned by Message.GetAddressTableLookups().GetTableIDs() " +
-		"(e.g. via rpc.Client.GetAddressLookupTableAddresses / GetMultipleAccounts) " +
+		"(e.g. via rpc.Client.GetMultipleAccounts, decoding each account with " +
+		"addresslookuptable.DecodeAddressLookupTableState) " +
 		"and pass the resolved {tableID -> []PublicKey} map to Message.SetAddressTables",
 )
 

--- a/message.go
+++ b/message.go
@@ -19,6 +19,7 @@ package solana
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
@@ -26,6 +27,19 @@ import (
 	gojson "github.com/goccy/go-json"
 
 	"github.com/gagliardetto/solana-go/text"
+)
+
+// ErrAddressTablesNotSet is returned by `(*Message).AccountMetaList`,
+// `(*Message).ResolveLookups`, and friends when the message is a
+// versioned (V0+) transaction with one or more address-table lookups
+// but the actual table contents have not been provided yet via
+// `(*Message).SetAddressTables`. Callers can use `errors.Is` to detect
+// this specific condition (see #280) without scraping the error text.
+var ErrAddressTablesNotSet = errors.New(
+	"address tables not set for versioned message with lookups; " +
+		"fetch each table id returned by Message.GetAddressTableLookups().GetTableIDs() " +
+		"(e.g. via rpc.Client.GetAddressLookupTableAddresses / GetMultipleAccounts) " +
+		"and pass the resolved {tableID -> []PublicKey} map to Message.SetAddressTables",
 )
 
 type MessageAddressTableLookupSlice []MessageAddressTableLookup
@@ -718,12 +732,16 @@ func (mx *Message) UnmarshalLegacy(decoder *bin.Decoder) (err error) {
 }
 
 func (m *Message) checkPreconditions() error {
-	// if this is versioned,
-	// and there are > 0 lookups,
-	// but the address table is empty,
-	// then we can't build the account meta list:
+	// Versioned (V0+) messages can reference accounts indirectly via
+	// address-table lookups. The lookup descriptors only carry the table
+	// account id + the writable/readonly indexes — the actual public keys
+	// have to be fetched from the chain and handed to the message via
+	// SetAddressTables before we can flatten them into AccountMetaList.
+	// Surface a typed error here so callers can detect this with
+	// errors.Is(err, ErrAddressTablesNotSet) and follow the recovery
+	// guidance the error wraps (see #280).
 	if m.IsVersioned() && m.AddressTableLookups.NumLookups() > 0 && len(m.addressTables) == 0 {
-		return fmt.Errorf("cannot build account meta list without address tables")
+		return ErrAddressTablesNotSet
 	}
 
 	return nil

--- a/message_test.go
+++ b/message_test.go
@@ -1,6 +1,8 @@
 package solana
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -679,7 +681,9 @@ func TestCheckPreconditions_MissingTables(t *testing.T) {
 
 	_, err := msg.AccountMetaList()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "without address tables")
+	// Typed sentinel from #280 — assert via errors.Is so callers can
+	// reliably detect this condition without scraping the message text.
+	require.ErrorIs(t, err, ErrAddressTablesNotSet)
 }
 
 // Tests base64 roundtrip.
@@ -1309,4 +1313,120 @@ func hasDuplicates(keys PublicKeySlice) bool {
 		seen[k] = struct{}{}
 	}
 	return false
+}
+
+// TestAccountMetaList_VersionedWithUnsetTables_ReturnsTypedError pins the
+// error contract from #280: a versioned message that carries
+// address-table lookups but no resolved tables must return
+// ErrAddressTablesNotSet (not a bespoke fmt.Errorf string) so callers
+// can detect this with errors.Is and surface the recovery guidance
+// from the sentinel's message verbatim.
+func TestAccountMetaList_VersionedWithUnsetTables_ReturnsTypedError(t *testing.T) {
+	tableKey := MustPublicKeyFromBase58("8YQHv2K84A7a7UA6tKKwrD4DsnKHAa24qLYMEH17Atwc")
+	payer := MustPublicKeyFromBase58("11111111111111111111111111111112")
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 0,
+		},
+		AccountKeys: PublicKeySlice{payer},
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey,
+				WritableIndexes: []uint8{0},
+				ReadonlyIndexes: []uint8{1},
+			},
+		},
+	}
+	if _, err := msg.SetVersion(MessageVersionV0); err != nil {
+		t.Fatalf("SetVersion: %v", err)
+	}
+
+	_, err := msg.AccountMetaList()
+	if err == nil {
+		t.Fatal("expected error when address tables are unset, got nil")
+	}
+	if !errors.Is(err, ErrAddressTablesNotSet) {
+		t.Fatalf("expected errors.Is(err, ErrAddressTablesNotSet) to be true, got %T: %v", err, err)
+	}
+
+	// Recovery guidance must point at the two API entry points users
+	// actually need: GetAddressTableLookups (to discover what to fetch)
+	// and SetAddressTables (to feed the resolved keys back in).
+	msgText := err.Error()
+	for _, needle := range []string{
+		"GetAddressTableLookups",
+		"SetAddressTables",
+	} {
+		if !strings.Contains(msgText, needle) {
+			t.Errorf("error guidance missing %q; full message: %s", needle, msgText)
+		}
+	}
+}
+
+// TestAccountMetaList_LegacyMessage_NoErrorBare is the negative
+// companion of the previous test: a legacy (pre-V0) message has no
+// AddressTableLookups by construction, so the precondition check must
+// not fire even when the addressTables map is nil.
+func TestAccountMetaList_LegacyMessage_NoErrorBare(t *testing.T) {
+	payer := MustPublicKeyFromBase58("11111111111111111111111111111112")
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 0,
+		},
+		AccountKeys: PublicKeySlice{payer},
+	}
+
+	if _, err := msg.AccountMetaList(); err != nil {
+		t.Fatalf("legacy message must not require address tables, got: %v", err)
+	}
+}
+
+// TestAccountMetaList_VersionedAfterSetAddressTables_Succeeds locks
+// the happy path the new error message tells callers to take.
+func TestAccountMetaList_VersionedAfterSetAddressTables_Succeeds(t *testing.T) {
+	tableKey := MustPublicKeyFromBase58("8YQHv2K84A7a7UA6tKKwrD4DsnKHAa24qLYMEH17Atwc")
+	payer := MustPublicKeyFromBase58("11111111111111111111111111111112")
+	writable := MustPublicKeyFromBase58("11111111111111111111111111111113")
+	readonly := MustPublicKeyFromBase58("11111111111111111111111111111114")
+
+	msg := Message{
+		Header: MessageHeader{
+			NumRequiredSignatures:       1,
+			NumReadonlySignedAccounts:   0,
+			NumReadonlyUnsignedAccounts: 0,
+		},
+		AccountKeys: PublicKeySlice{payer},
+		AddressTableLookups: MessageAddressTableLookupSlice{
+			{
+				AccountKey:      tableKey,
+				WritableIndexes: []uint8{0},
+				ReadonlyIndexes: []uint8{1},
+			},
+		},
+	}
+	if _, err := msg.SetVersion(MessageVersionV0); err != nil {
+		t.Fatalf("SetVersion: %v", err)
+	}
+
+	// `SetAddressTables` only needs the table id mapped to the full
+	// public-key list; the lookup descriptors then index into that list.
+	if err := msg.SetAddressTables(map[PublicKey]PublicKeySlice{
+		tableKey: {writable, readonly},
+	}); err != nil {
+		t.Fatalf("SetAddressTables: %v", err)
+	}
+
+	metas, err := msg.AccountMetaList()
+	if err != nil {
+		t.Fatalf("AccountMetaList after SetAddressTables: %v", err)
+	}
+	// Static payer + 1 writable + 1 readonly from the resolved table.
+	if got, want := len(metas), 3; got != want {
+		t.Fatalf("expected %d metas after lookup resolution, got %d", want, got)
+	}
 }


### PR DESCRIPTION
## Why

A versioned (V0+) message with address-table lookups raises `fmt.Errorf(\"cannot build account meta list without address tables\")` from `(*Message).checkPreconditions`. Issue [#280](https://github.com/solana-foundation/solana-go/issues/280) (and the wider \"cannot ResolveInstructionAccounts\" thread) shows the symptom is real but the error gives users no path forward: they hit it when parsing a fetched tx, search for the string, and don't discover that `(*Message).SetAddressTables` even exists.

## What

1. Export a sentinel **`ErrAddressTablesNotSet`** that wraps actionable recovery guidance — explicitly names `GetAddressTableLookups().GetTableIDs()` (to discover what to fetch) and `SetAddressTables` (to feed resolved keys back in). Callers can now detect this condition with `errors.Is(err, ErrAddressTablesNotSet)` instead of substring-matching the message text.
2. `checkPreconditions` returns the sentinel directly (was a bespoke `fmt.Errorf`). The existing `TestCheckPreconditions_MissingTables` is updated to assert via `errors.Is`.

```go
metas, err := tx.Message.AccountMetaList()
if errors.Is(err, solana.ErrAddressTablesNotSet) {
    // Fetch each table id, hand back a {tableID -> []PublicKey} map.
    tables := fetchAddressTables(rpcClient, tx.Message.GetAddressTableLookups().GetTableIDs())
    _ = tx.Message.SetAddressTables(tables)
    metas, err = tx.Message.AccountMetaList()
}
```

## Tests

- `TestAccountMetaList_VersionedWithUnsetTables_ReturnsTypedError` — versioned msg with one lookup but no resolved tables surfaces `ErrAddressTablesNotSet`; recovery guidance must include both `GetAddressTableLookups` and `SetAddressTables` so a future rewrite of the sentinel can't silently drop the actionable hint.
- `TestAccountMetaList_LegacyMessage_NoErrorBare` — legacy (pre-V0) message has no AddressTableLookups, precondition check must not fire.
- `TestAccountMetaList_VersionedAfterSetAddressTables_Succeeds` — happy path the new guidance points at: feed `SetAddressTables`, call `AccountMetaList`, get static + resolved metas back.

`go test ./...` clean across the repo.

Closes #280