### PR TITLE
feat(rpc): forward MinContextSlot in getBalance/getLatestBlockhash/getSlot/getTokenAccountBalance

### DIFF
--- a/rpc/getBalance.go
+++ b/rpc/getBalance.go
@@ -32,9 +32,48 @@ func (cl *Client) GetBalance(
 	// Commitment requirement. Optional.
 	commitment CommitmentType,
 ) (out *GetBalanceResult, err error) {
+	return cl.GetBalanceWithOpts(ctx, publicKey, &GetBalanceOpts{Commitment: commitment})
+}
+
+// GetBalanceOpts is the optional configuration object for `getBalance`,
+// mirroring the JSON-RPC spec for this method.
+//
+// See https://solana.com/docs/rpc/http/getbalance for the canonical field list.
+type GetBalanceOpts struct {
+	// Commitment level to query the balance at.
+	Commitment CommitmentType
+
+	// MinContextSlot is the minimum slot at which the RPC node should
+	// have processed the request. The validator returns a
+	// `MinContextSlotNotReached` error to the caller if the local slot
+	// has not yet caught up, instead of silently serving stale state.
+	MinContextSlot *uint64
+}
+
+// GetBalanceWithOpts returns the balance of the account of the provided
+// publicKey, with the full set of optional configuration fields the
+// `getBalance` JSON-RPC method accepts.
+//
+// Use this over `GetBalance` when you need `MinContextSlot` (closes
+// the parity gap with `GetAccountInfo` / `GetMultipleAccounts` after
+// #431; see #245 for the broader request).
+func (cl *Client) GetBalanceWithOpts(
+	ctx context.Context,
+	publicKey solana.PublicKey,
+	opts *GetBalanceOpts,
+) (out *GetBalanceResult, err error) {
 	params := []any{publicKey}
-	if commitment != "" {
-		params = append(params, M{"commitment": string(commitment)})
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = string(opts.Commitment)
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getBalance", params)

--- a/rpc/getLatestBlockhash.go
+++ b/rpc/getLatestBlockhash.go
@@ -27,9 +27,43 @@ func (cl *Client) GetLatestBlockhash(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out *GetLatestBlockhashResult, err error) {
+	return cl.GetLatestBlockhashWithOpts(ctx, &GetLatestBlockhashOpts{Commitment: commitment})
+}
+
+// GetLatestBlockhashOpts is the optional configuration object for
+// `getLatestBlockhash`, mirroring the JSON-RPC spec for this method.
+//
+// See https://solana.com/docs/rpc/http/getlatestblockhash.
+type GetLatestBlockhashOpts struct {
+	// Commitment level to query the blockhash at.
+	Commitment CommitmentType
+
+	// MinContextSlot is the minimum slot at which the RPC node should
+	// have processed the request. The validator returns a
+	// `MinContextSlotNotReached` error to the caller if the local slot
+	// has not yet caught up, instead of silently serving stale state.
+	MinContextSlot *uint64
+}
+
+// GetLatestBlockhashWithOpts returns the latest blockhash, with the
+// full set of optional configuration fields the `getLatestBlockhash`
+// JSON-RPC method accepts.
+func (cl *Client) GetLatestBlockhashWithOpts(
+	ctx context.Context,
+	opts *GetLatestBlockhashOpts,
+) (out *GetLatestBlockhashResult, err error) {
 	params := []any{}
-	if commitment != "" {
-		params = append(params, M{"commitment": commitment})
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getLatestBlockhash", params)

--- a/rpc/getMinContextSlot_test.go
+++ b/rpc/getMinContextSlot_test.go
@@ -136,3 +136,187 @@ func TestClient_GetTokenAccountsByDelegate_MinContextSlot(t *testing.T) {
 		reqBody,
 	)
 }
+
+// TestClient_GetBalanceWithOpts_MinContextSlot pins minContextSlot
+// forwarding on the new GetBalanceWithOpts variant. Closes the parity
+// gap with getAccountInfo / getMultipleAccounts for the single-balance
+// query path.
+func TestClient_GetBalanceWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":12345}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	minSlot := uint64(987654321)
+	_, err := client.GetBalanceWithOpts(
+		context.Background(),
+		pubKey,
+		&GetBalanceOpts{
+			Commitment:     CommitmentFinalized,
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getBalance",
+			"params": []any{
+				pubkeyString,
+				map[string]any{
+					"commitment":     "finalized",
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetBalance_BackCompat_NoOpts pins that the original
+// `GetBalance(ctx, pubkey, commitment)` signature still produces the
+// same wire shape it always did when commitment is empty — the new
+// WithOpts variant is purely additive.
+func TestClient_GetBalance_BackCompat_NoOpts(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":12345}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	_, err := client.GetBalance(context.Background(), pubKey, "")
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getBalance",
+			"params": []any{
+				pubkeyString,
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetLatestBlockhashWithOpts_MinContextSlot pins
+// minContextSlot forwarding on getLatestBlockhash.
+func TestClient_GetLatestBlockhashWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":{"blockhash":"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N","lastValidBlockHeight":42}}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	minSlot := uint64(777)
+	_, err := client.GetLatestBlockhashWithOpts(
+		context.Background(),
+		&GetLatestBlockhashOpts{
+			Commitment:     CommitmentConfirmed,
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getLatestBlockhash",
+			"params": []any{
+				map[string]any{
+					"commitment":     "confirmed",
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetSlotWithOpts_MinContextSlot pins minContextSlot
+// forwarding on getSlot.
+func TestClient_GetSlotWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `123`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	minSlot := uint64(555)
+	_, err := client.GetSlotWithOpts(
+		context.Background(),
+		&GetSlotOpts{MinContextSlot: &minSlot},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getSlot",
+			"params": []any{
+				map[string]any{
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetTokenAccountBalanceWithOpts_MinContextSlot pins
+// minContextSlot forwarding on getTokenAccountBalance.
+func TestClient_GetTokenAccountBalanceWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":{"amount":"100","decimals":6,"uiAmount":0.0001,"uiAmountString":"0.0001"}}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	minSlot := uint64(99)
+	_, err := client.GetTokenAccountBalanceWithOpts(
+		context.Background(),
+		pubKey,
+		&GetTokenAccountBalanceOpts{MinContextSlot: &minSlot},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getTokenAccountBalance",
+			"params": []any{
+				pubkeyString,
+				map[string]any{
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}

--- a/rpc/getMinContextSlot_test.go
+++ b/rpc/getMinContextSlot_test.go
@@ -320,3 +320,86 @@ func TestClient_GetTokenAccountBalanceWithOpts_MinContextSlot(t *testing.T) {
 		reqBody,
 	)
 }
+
+// TestClient_GetLatestBlockhash_BackCompat_NoOpts pins that the legacy
+// GetLatestBlockhash wrapper emits no params object when called with an
+// empty commitment, matching the pre-WithOpts wire shape.
+func TestClient_GetLatestBlockhash_BackCompat_NoOpts(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":{"blockhash":"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N","lastValidBlockHeight":42}}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	_, err := client.GetLatestBlockhash(context.Background(), "")
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getLatestBlockhash",
+			"params":  []any{},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetSlot_BackCompat_NoOpts pins that the legacy GetSlot
+// wrapper emits no params object when called with an empty commitment,
+// matching the pre-WithOpts wire shape.
+func TestClient_GetSlot_BackCompat_NoOpts(t *testing.T) {
+	responseBody := `123`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	_, err := client.GetSlot(context.Background(), "")
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getSlot",
+			"params":  []any{},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetTokenAccountBalance_BackCompat_NoOpts pins that the legacy
+// GetTokenAccountBalance wrapper sends only the account pubkey when called
+// with an empty commitment, matching the pre-WithOpts wire shape.
+func TestClient_GetTokenAccountBalance_BackCompat_NoOpts(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":{"amount":"100","decimals":6,"uiAmount":0.0001,"uiAmountString":"0.0001"}}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	_, err := client.GetTokenAccountBalance(context.Background(), pubKey, "")
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getTokenAccountBalance",
+			"params": []any{
+				pubkeyString,
+			},
+		},
+		reqBody,
+	)
+}

--- a/rpc/getSlot.go
+++ b/rpc/getSlot.go
@@ -25,9 +25,43 @@ func (cl *Client) GetSlot(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out uint64, err error) {
+	return cl.GetSlotWithOpts(ctx, &GetSlotOpts{Commitment: commitment})
+}
+
+// GetSlotOpts is the optional configuration object for `getSlot`,
+// mirroring the JSON-RPC spec for this method.
+//
+// See https://solana.com/docs/rpc/http/getslot.
+type GetSlotOpts struct {
+	// Commitment level to query the slot at.
+	Commitment CommitmentType
+
+	// MinContextSlot is the minimum slot at which the RPC node should
+	// have processed the request. The validator returns a
+	// `MinContextSlotNotReached` error to the caller if the local slot
+	// has not yet caught up, instead of silently serving stale state.
+	MinContextSlot *uint64
+}
+
+// GetSlotWithOpts returns the slot that has reached the given or
+// default commitment level, with the full set of optional configuration
+// fields the `getSlot` JSON-RPC method accepts.
+func (cl *Client) GetSlotWithOpts(
+	ctx context.Context,
+	opts *GetSlotOpts,
+) (out uint64, err error) {
 	params := []any{}
-	if commitment != "" {
-		params = append(params, M{"commitment": commitment})
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getSlot", params)

--- a/rpc/getTokenAccountBalance.go
+++ b/rpc/getTokenAccountBalance.go
@@ -26,11 +26,44 @@ func (cl *Client) GetTokenAccountBalance(
 	account solana.PublicKey,
 	commitment CommitmentType, // optional
 ) (out *GetTokenAccountBalanceResult, err error) {
+	return cl.GetTokenAccountBalanceWithOpts(ctx, account, &GetTokenAccountBalanceOpts{Commitment: commitment})
+}
+
+// GetTokenAccountBalanceOpts is the optional configuration object for
+// `getTokenAccountBalance`, mirroring the JSON-RPC spec for this method.
+//
+// See https://solana.com/docs/rpc/http/gettokenaccountbalance.
+type GetTokenAccountBalanceOpts struct {
+	// Commitment level to query the balance at.
+	Commitment CommitmentType
+
+	// MinContextSlot is the minimum slot at which the RPC node should
+	// have processed the request. The validator returns a
+	// `MinContextSlotNotReached` error to the caller if the local slot
+	// has not yet caught up, instead of silently serving stale state.
+	MinContextSlot *uint64
+}
+
+// GetTokenAccountBalanceWithOpts returns the token balance of an SPL
+// Token account, with the full set of optional configuration fields
+// the `getTokenAccountBalance` JSON-RPC method accepts.
+func (cl *Client) GetTokenAccountBalanceWithOpts(
+	ctx context.Context,
+	account solana.PublicKey,
+	opts *GetTokenAccountBalanceOpts,
+) (out *GetTokenAccountBalanceResult, err error) {
 	params := []any{account}
-	if commitment != "" {
-		params = append(params,
-			M{"commitment": commitment},
-		)
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getTokenAccountBalance", params)
 	return


### PR DESCRIPTION
## Why

Follow-up to [#431](https://github.com/solana-foundation/solana-go/pull/431) (forward `MinContextSlot` in `getProgramAccounts` / `getTokenAccounts`) and [#245](https://github.com/solana-foundation/solana-go/issues/245) (broader `MinContextSlot` parity request).

Four common single-arg / zero-arg RPC methods still didn't carry `minContextSlot` in their config object even though the Solana JSON-RPC spec accepts it:

- `getBalance`
- `getLatestBlockhash`
- `getSlot`
- `getTokenAccountBalance`

Without the field, callers that need read-your-write semantics from a behind-leader RPC node have no way to get the validator's `MinContextSlotNotReached` retry signal — the node silently serves stale state.

## What

For each method, add a `*WithOpts` variant taking a typed `Get<Method>Opts` struct that includes `Commitment` + `MinContextSlot *uint64`, plus a thin backwards-compatible wrapper that keeps the old `(ctx, commitment)` / `(ctx, account, commitment)` signature working by delegating into the opts variant.

```go
minSlot := uint64(987654321)
balance, err := client.GetBalanceWithOpts(ctx, pubKey, &rpc.GetBalanceOpts{
    Commitment:     rpc.CommitmentFinalized,
    MinContextSlot: &minSlot,
})
```

The opts variant only emits the config object when at least one field is set, so the no-opts call site (`client.GetBalance(ctx, pubKey, \"\")`) keeps the exact same wire shape it had before this refactor.

## Tests (`rpc/getMinContextSlot_test.go`)

- `TestClient_GetBalanceWithOpts_MinContextSlot` — pins the new opts variant's `minContextSlot` forwarding + commitment serialisation.
- `TestClient_GetBalance_BackCompat_NoOpts` — pins that the legacy signature with empty commitment still produces `[pubkey]` (no config object) on the wire, so existing callers see no behavioural change.
- `TestClient_GetLatestBlockhashWithOpts_MinContextSlot`, `TestClient_GetSlotWithOpts_MinContextSlot`, `TestClient_GetTokenAccountBalanceWithOpts_MinContextSlot` — forwarding pins for the other three methods.

`go test ./...` clean across the repo.