### PR TITLE
test(rpc): pin minContextSlot forwarding in GetMultipleAccountsWithOpts

### DIFF
--- a/rpc/getMinContextSlot_test.go
+++ b/rpc/getMinContextSlot_test.go
@@ -94,6 +94,47 @@ func TestClient_GetTokenAccountsByOwner_MinContextSlot(t *testing.T) {
 	)
 }
 
+// TestClient_GetMultipleAccountsWithOpts_MinContextSlot pins that the
+// minContextSlot opt is forwarded into the params object. The fix shipped
+// with #245; this test guards against future regressions and closes #170.
+func TestClient_GetMultipleAccountsWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":[null]}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	minSlot := uint64(555555)
+	_, err := client.GetMultipleAccountsWithOpts(
+		context.Background(),
+		[]solana.PublicKey{pubKey},
+		&GetMultipleAccountsOpts{
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getMultipleAccounts",
+			"params": []any{
+				[]any{pubkeyString},
+				map[string]any{
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
 // TestClient_GetTokenAccountsByDelegate_MinContextSlot pins the same for the
 // delegate variant.
 func TestClient_GetTokenAccountsByDelegate_MinContextSlot(t *testing.T) {


### PR DESCRIPTION
## Why

#170 has been sitting open since Jan 2024. The actual fix landed in #245 (Oct 2024) which added the `minContextSlot` forwarding to `GetMultipleAccountsWithOpts`, but the issue was never closed and no regression test was added for that specific method.

Meanwhile the rest of the `minContextSlot`-aware methods picked up regression tests in `rpc/getMinContextSlot_test.go`:

- `getProgramAccounts`
- `getTokenAccountsByOwner`
- `getTokenAccountsByDelegate`

`getMultipleAccounts` is the obvious gap.

## What

One new test, `TestClient_GetMultipleAccountsWithOpts_MinContextSlot`, mirroring the existing pattern: mock the JSON-RPC server, call `GetMultipleAccountsWithOpts` with `MinContextSlot` set, assert the outgoing request body has `minContextSlot` inside the params object.

No production code changes.

## Test plan

- [x] `go test ./rpc/... -run TestClient_GetMultipleAccountsWithOpts_MinContextSlot -v` passes
- [x] `go test ./rpc/...` passes
- [x] `go build ./...` clean

Closes #170.