### PR TITLE
test(keys): pin size-mismatch rejection in PrivateKeyFromBase58

### DIFF
--- a/keys_test.go
+++ b/keys_test.go
@@ -144,6 +144,41 @@ func TestPrivateKeyFromSolanaKeygenFile(t *testing.T) {
 	}
 }
 
+// TestPrivateKeyFromBase58RejectsWrongSizedInput pins that arbitrary base58
+// strings whose decoded length is not 64 bytes are rejected with the
+// "invalid private key size" error. Issue #232 reported that
+// PrivateKeyFromBase58 silently accepted random/invalid input; the
+// size-check path is the first line of defense and is exercised here.
+// Sibling tests below cover the seed/public-key mismatch and off-curve paths.
+func TestPrivateKeyFromBase58RejectsWrongSizedInput(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		// "abc" decodes to 2 bytes via base58 — far below 64.
+		{"short_base58", "abc"},
+		// "1111111111" decodes to 9 zero bytes — also far below 64.
+		{"all_ones_short", "1111111111"},
+		// A 32-byte all-ones base58 string decodes to roughly 22 bytes,
+		// still nowhere near the 64-byte ed25519 private-key size.
+		{"medium_random", "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PrivateKeyFromBase58(tc.input)
+			require.Error(t, err, "expected error for %q", tc.input)
+			require.Contains(
+				t,
+				err.Error(),
+				"invalid private key size",
+				"expected size-mismatch error, got: %v",
+				err,
+			)
+		})
+	}
+}
+
 func TestPrivateKeyFromBase58RejectsMismatchedSeedAndPublicKey(t *testing.T) {
 	original := MustPrivateKeyFromBase58("66cDvko73yAf8LYvFMM3r8vF5vJtkk7JKMgEKwkmBC86oHdq41C7i1a2vS3zE1yCcdLLk6VUatUb32ZzVjSBXtRs")
 	require.Len(t, original, PrivateKeyLength)


### PR DESCRIPTION
## Why

#232 (Jul 2024) reported that `PrivateKeyFromBase58` silently accepted random/invalid input. The validation path shipped some time later via `edcedcc` (\`reject malformed ed25519 private keys in PrivateKeyFromBase58\`), and `ValidatePrivateKey` now guards three failure modes:

1. wrong decoded size
2. seed/public-key mismatch (tampered seed)
3. off-curve public key half

(2) and (3) already have regression tests in `keys_test.go` — `TestPrivateKeyFromBase58RejectsMismatchedSeedAndPublicKey` and `TestPrivateKeyFromBase58ReturnsDiagnosticForOffCurvePublicKey`.

The first one — the size-mismatch path, which is by far the most common shape for the \"random str\" inputs the issue describes — was never pinned. #232 is still open, the stale PR #234 attempt is in conflict, and there is no test guarding against a future regression that, say, skips the size check.

## What

One new table test, `TestPrivateKeyFromBase58RejectsWrongSizedInput`, that feeds three differently-shaped invalid base58 inputs through `PrivateKeyFromBase58` and asserts the error contains `\"invalid private key size\"`.

No production code changes.

## Test plan

- [x] `go test -run TestPrivateKeyFromBase58RejectsWrongSizedInput -v .` passes (all three subcases)
- [x] `go test ./...` passes
- [x] `go build ./...` clean

Closes #232.