### PR TITLE
feat(rpc): forward MinContextSlot in getInflationReward / getSupply / getStakeMinimumDelegation / getFeeForMessage

### DIFF
--- a/rpc/getFeeForMessage.go
+++ b/rpc/getFeeForMessage.go
@@ -24,9 +24,37 @@ func (cl *Client) GetFeeForMessage(
 	message string, // Base-64 encoded Message
 	commitment CommitmentType, // optional
 ) (out *GetFeeForMessageResult, err error) {
+	return cl.GetFeeForMessageWithOpts(ctx, message, &GetFeeForMessageOpts{Commitment: commitment})
+}
+
+// GetFeeForMessageOpts groups the optional configuration accepted by the
+// getFeeForMessage RPC.
+type GetFeeForMessageOpts struct {
+	Commitment CommitmentType
+
+	// The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64
+}
+
+// GetFeeForMessageWithOpts is the variant of GetFeeForMessage that accepts the
+// full optional configuration set, including MinContextSlot.
+func (cl *Client) GetFeeForMessageWithOpts(
+	ctx context.Context,
+	message string, // Base-64 encoded Message
+	opts *GetFeeForMessageOpts,
+) (out *GetFeeForMessageResult, err error) {
 	params := []any{message}
-	if commitment != "" {
-		params = append(params, M{"commitment": commitment})
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getFeeForMessage", params)
 	return

--- a/rpc/getInflationReward.go
+++ b/rpc/getInflationReward.go
@@ -26,6 +26,9 @@ type GetInflationRewardOpts struct {
 	// An epoch for which the reward occurs.
 	// If omitted, the previous epoch will be used.
 	Epoch *uint64
+
+	// The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64
 }
 
 // GetInflationReward returns the inflation / staking reward for a list of addresses for an epoch.
@@ -46,6 +49,9 @@ func (cl *Client) GetInflationReward(
 		}
 		if opts.Epoch != nil {
 			obj["epoch"] = opts.Epoch
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
 		}
 		if len(obj) > 0 {
 			params = append(params, obj)

--- a/rpc/getMinContextSlot_test.go
+++ b/rpc/getMinContextSlot_test.go
@@ -444,3 +444,154 @@ func TestClient_GetTokenAccountBalance_BackCompat_NoOpts(t *testing.T) {
 		reqBody,
 	)
 }
+
+// TestClient_GetInflationReward_MinContextSlot pins that the minContextSlot
+// opt is forwarded into the params object for getInflationReward.
+func TestClient_GetInflationReward_MinContextSlot(t *testing.T) {
+	responseBody := `[null]`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	addrString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	addr := solana.MustPublicKeyFromBase58(addrString)
+
+	minSlot := uint64(987654321)
+	_, err := client.GetInflationReward(
+		context.Background(),
+		[]solana.PublicKey{addr},
+		&GetInflationRewardOpts{
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getInflationReward",
+			"params": []any{
+				[]any{addrString},
+				map[string]any{
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetSupplyWithOpts_MinContextSlot pins that the minContextSlot
+// opt is forwarded into the params object for getSupply.
+func TestClient_GetSupplyWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":{"total":1,"circulating":1,"nonCirculating":0,"nonCirculatingAccounts":[]}}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	minSlot := uint64(42)
+	_, err := client.GetSupplyWithOpts(
+		context.Background(),
+		&GetSupplyOpts{
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getSupply",
+			"params": []any{
+				map[string]any{
+					"commitment":                        "confirmed",
+					"excludeNonCirculatingAccountsList": false,
+					"minContextSlot":                    float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetStakeMinimumDelegationWithOpts_MinContextSlot pins that the
+// minContextSlot opt is forwarded into the params object for
+// getStakeMinimumDelegation.
+func TestClient_GetStakeMinimumDelegationWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":1000000000}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	minSlot := uint64(7)
+	_, err := client.GetStakeMinimumDelegationWithOpts(
+		context.Background(),
+		&GetStakeMinimumDelegationOpts{
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getStakeMinimumDelegation",
+			"params": []any{
+				map[string]any{
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}
+
+// TestClient_GetFeeForMessageWithOpts_MinContextSlot pins that the
+// minContextSlot opt is forwarded into the params object for getFeeForMessage.
+func TestClient_GetFeeForMessageWithOpts_MinContextSlot(t *testing.T) {
+	responseBody := `{"context":{"slot":1},"value":5000}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	encodedMessage := "AQABA..."
+	minSlot := uint64(99)
+	_, err := client.GetFeeForMessageWithOpts(
+		context.Background(),
+		encodedMessage,
+		&GetFeeForMessageOpts{
+			MinContextSlot: &minSlot,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getFeeForMessage",
+			"params": []any{
+				encodedMessage,
+				map[string]any{
+					"minContextSlot": float64(minSlot),
+				},
+			},
+		},
+		reqBody,
+	)
+}

--- a/rpc/getStakeMinimumDelegation.go
+++ b/rpc/getStakeMinimumDelegation.go
@@ -23,9 +23,36 @@ func (cl *Client) GetStakeMinimumDelegation(
 	ctx context.Context,
 	commitment CommitmentType, // optional
 ) (out *GetStakeMinimumDelegationResult, err error) {
+	return cl.GetStakeMinimumDelegationWithOpts(ctx, &GetStakeMinimumDelegationOpts{Commitment: commitment})
+}
+
+// GetStakeMinimumDelegationOpts groups the optional configuration accepted by
+// the getStakeMinimumDelegation RPC.
+type GetStakeMinimumDelegationOpts struct {
+	Commitment CommitmentType
+
+	// The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64
+}
+
+// GetStakeMinimumDelegationWithOpts is the variant of GetStakeMinimumDelegation
+// that accepts the full optional configuration set, including MinContextSlot.
+func (cl *Client) GetStakeMinimumDelegationWithOpts(
+	ctx context.Context,
+	opts *GetStakeMinimumDelegationOpts,
+) (out *GetStakeMinimumDelegationResult, err error) {
 	params := []interface{}{}
-	if commitment != "" {
-		params = append(params, M{"commitment": string(commitment)})
+	if opts != nil {
+		obj := M{}
+		if opts.Commitment != "" {
+			obj["commitment"] = string(opts.Commitment)
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
 	}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getStakeMinimumDelegation", params)
 	return

--- a/rpc/getSupply.go
+++ b/rpc/getSupply.go
@@ -38,6 +38,9 @@ func (cl *Client) GetSupplyWithOpts(
 			obj["commitment"] = opts.Commitment
 		}
 		obj["excludeNonCirculatingAccountsList"] = opts.ExcludeNonCirculatingAccountsList
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
 	}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "getSupply", []any{obj})
@@ -48,6 +51,9 @@ type GetSupplyOpts struct {
 	Commitment CommitmentType `json:"commitment,omitempty"`
 
 	ExcludeNonCirculatingAccountsList bool `json:"excludeNonCirculatingAccountsList,omitempty"` // exclude non circulating accounts list from response
+
+	// The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64 `json:"minContextSlot,omitempty"`
 }
 
 type GetSupplyResult struct {


### PR DESCRIPTION
## Summary

Follow-up to #431 (getProgramAccounts / getTokenAccounts) and #442 (getBalance / getLatestBlockhash / getSlot / getTokenAccountBalance). Closes the remaining parity gap with the Solana JSON-RPC spec for the four endpoints that still accepted no \`minContextSlot\` path.

| Endpoint | Change |
|---|---|
| \`getInflationReward\` | Added \`MinContextSlot *uint64\` to existing \`GetInflationRewardOpts\`; forwarded when non-nil. |
| \`getSupply\` | Added \`MinContextSlot *uint64\` to existing \`GetSupplyOpts\`; forwarded when non-nil. |
| \`getStakeMinimumDelegation\` | Original API took commitment as a positional arg with no opts surface. Added \`GetStakeMinimumDelegationOpts\` + \`GetStakeMinimumDelegationWithOpts\`. The existing \`GetStakeMinimumDelegation\` signature is preserved and delegates to the WithOpts variant — existing callers compile unchanged. |
| \`getFeeForMessage\` | Same shape — added \`GetFeeForMessageOpts\` + \`GetFeeForMessageWithOpts\`, kept the original signature delegating to the new variant. |

## Test plan

- [x] \`go build ./...\` clean
- [x] 4 new regression tests in \`rpc/getMinContextSlot_test.go\` (matching the existing pattern from #431) pin that \`minContextSlot\` lands in the params object for each endpoint
- [x] \`go test -count=1 ./rpc/\` green