### PR TITLE
feat(rpc): add getTransactionsForAddress client method (closes #343)

### DIFF
--- a/rpc/getTransactionsForAddress.go
+++ b/rpc/getTransactionsForAddress.go
@@ -69,6 +69,44 @@ type GetTransactionsForAddressOpts struct {
 	Filters *TransactionsForAddressFilters `json:"filters,omitempty"`
 }
 
+// TransactionStatus filters returned transactions by execution status.
+type TransactionStatus string
+
+const (
+	// TransactionStatusSucceeded matches transactions that executed successfully.
+	TransactionStatusSucceeded TransactionStatus = "succeeded"
+	// TransactionStatusFailed matches transactions that failed on chain.
+	TransactionStatusFailed TransactionStatus = "failed"
+	// TransactionStatusAny matches transactions regardless of status (the default).
+	TransactionStatusAny TransactionStatus = "any"
+)
+
+// TokenAccountsFilter narrows results by the queried address's token-account
+// activity within each transaction.
+type TokenAccountsFilter string
+
+const (
+	// TokenAccountsNone matches transactions with no token-account activity.
+	TokenAccountsNone TokenAccountsFilter = "none"
+	// TokenAccountsBalanceChanged matches transactions where a token balance changed.
+	TokenAccountsBalanceChanged TokenAccountsFilter = "balanceChanged"
+	// TokenAccountsAll matches transactions with any token-account activity.
+	TokenAccountsAll TokenAccountsFilter = "all"
+)
+
+// TokenTransferDirection constrains a token-transfer filter to a direction
+// relative to the queried address.
+type TokenTransferDirection string
+
+const (
+	// TokenTransferIn matches transfers into the queried address.
+	TokenTransferIn TokenTransferDirection = "in"
+	// TokenTransferOut matches transfers out of the queried address.
+	TokenTransferOut TokenTransferDirection = "out"
+	// TokenTransferAny matches transfers in either direction (the default).
+	TokenTransferAny TokenTransferDirection = "any"
+)
+
 // TransactionsForAddressFilters narrows the result set of
 // getTransactionsForAddress on the server side.
 type TransactionsForAddressFilters struct {
@@ -82,10 +120,10 @@ type TransactionsForAddressFilters struct {
 	Signature *RangeFilterString `json:"signature,omitempty"`
 
 	// Execution status: "succeeded", "failed", or "any".
-	Status string `json:"status,omitempty"`
+	Status TransactionStatus `json:"status,omitempty"`
 
 	// Token-account activity: "none", "balanceChanged", or "all".
-	TokenAccounts string `json:"tokenAccounts,omitempty"`
+	TokenAccounts TokenAccountsFilter `json:"tokenAccounts,omitempty"`
 
 	// Token-transfer constraints.
 	TokenTransfer *TokenTransferFilter `json:"tokenTransfer,omitempty"`
@@ -123,7 +161,7 @@ type TokenTransferFilter struct {
 	// Counterparty address.
 	With string `json:"with,omitempty"`
 	// Transfer direction relative to the queried address: "in", "out", or "any".
-	Direction string `json:"direction,omitempty"`
+	Direction TokenTransferDirection `json:"direction,omitempty"`
 	// Token mint address.
 	Mint string `json:"mint,omitempty"`
 	// Amount range comparisons.
@@ -181,8 +219,8 @@ type TransactionForAddress struct {
 // given address, newest first.
 //
 // NOTE: getTransactionsForAddress is not part of the core Solana JSON-RPC API;
-// it is offered by some RPC providers (e.g. Helius). Calls will fail against
-// endpoints that do not implement it.
+// it is a vendor extension offered by several RPC providers (e.g. Helius,
+// Triton, FluxRPC). Calls will fail against endpoints that do not implement it.
 func (cl *Client) GetTransactionsForAddress(
 	ctx context.Context,
 	account solana.PublicKey,
@@ -199,8 +237,8 @@ func (cl *Client) GetTransactionsForAddress(
 // server-side filters.
 //
 // NOTE: getTransactionsForAddress is not part of the core Solana JSON-RPC API;
-// it is offered by some RPC providers (e.g. Helius). Calls will fail against
-// endpoints that do not implement it.
+// it is a vendor extension offered by several RPC providers (e.g. Helius,
+// Triton, FluxRPC). Calls will fail against endpoints that do not implement it.
 func (cl *Client) GetTransactionsForAddressWithOpts(
 	ctx context.Context,
 	account solana.PublicKey,
@@ -232,6 +270,7 @@ func (cl *Client) GetTransactionsForAddressWithOpts(
 				solana.EncodingJSONParsed,
 				solana.EncodingBase58,
 				solana.EncodingBase64,
+				solana.EncodingBase64Zstd,
 			) {
 				return nil, fmt.Errorf("provided encoding is not supported: %s", opts.Encoding)
 			}

--- a/rpc/getTransactionsForAddress.go
+++ b/rpc/getTransactionsForAddress.go
@@ -1,0 +1,256 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// TransactionsForAddressSortOrder controls the order in which
+// getTransactionsForAddress returns results.
+type TransactionsForAddressSortOrder string
+
+const (
+	// TransactionsForAddressSortDesc returns the newest transactions first
+	// (the default when no sort order is provided).
+	TransactionsForAddressSortDesc TransactionsForAddressSortOrder = "desc"
+	// TransactionsForAddressSortAsc returns the oldest transactions first.
+	TransactionsForAddressSortAsc TransactionsForAddressSortOrder = "asc"
+)
+
+type GetTransactionsForAddressOpts struct {
+	// Level of transaction detail to return: "signatures" (default) or "full".
+	TransactionDetails TransactionDetailsType `json:"transactionDetails,omitempty"`
+
+	// Order of the returned transactions: "desc" (newest first, the default)
+	// or "asc" (oldest first).
+	SortOrder TransactionsForAddressSortOrder `json:"sortOrder,omitempty"`
+
+	// (optional) Maximum number of transactions to return (between 1 and 1,000,
+	// default: 1,000).
+	Limit *int `json:"limit,omitempty"`
+
+	// (optional) Cursor returned as PaginationToken by a previous response,
+	// in the "slot:position" format, used to fetch the next page.
+	PaginationToken string `json:"paginationToken,omitempty"`
+
+	// (optional) Commitment; "processed" is not supported.
+	// If not provided, the default is "finalized".
+	Commitment CommitmentType `json:"commitment,omitempty"`
+
+	// (optional) Encoding for the returned transactions when TransactionDetails
+	// is "full": "json", "jsonParsed", "base58" (slow), or "base64".
+	Encoding solana.EncodingType `json:"encoding,omitempty"`
+
+	// (optional) The max transaction version to return in responses.
+	// Set to 0 to return all (legacy and versioned) transactions; if a returned
+	// block contains a transaction with a higher version, an error is returned.
+	MaxSupportedTransactionVersion *uint64 `json:"maxSupportedTransactionVersion,omitempty"`
+
+	// (optional) The minimum slot that the request can be evaluated at.
+	MinContextSlot *uint64 `json:"minContextSlot,omitempty"`
+
+	// (optional) Server-side filters narrowing the returned transactions.
+	Filters *TransactionsForAddressFilters `json:"filters,omitempty"`
+}
+
+// TransactionsForAddressFilters narrows the result set of
+// getTransactionsForAddress on the server side.
+type TransactionsForAddressFilters struct {
+	// Slot-number range comparisons.
+	Slot *RangeFilterUint64 `json:"slot,omitempty"`
+
+	// Block-time (Unix timestamp) range comparisons.
+	BlockTime *RangeFilterInt64 `json:"blockTime,omitempty"`
+
+	// Signature-string range comparisons.
+	Signature *RangeFilterString `json:"signature,omitempty"`
+
+	// Execution status: "succeeded", "failed", or "any".
+	Status string `json:"status,omitempty"`
+
+	// Token-account activity: "none", "balanceChanged", or "all".
+	TokenAccounts string `json:"tokenAccounts,omitempty"`
+
+	// Token-transfer constraints.
+	TokenTransfer *TokenTransferFilter `json:"tokenTransfer,omitempty"`
+}
+
+// RangeFilterUint64 expresses greater/less-than(-or-equal) bounds on a uint64.
+type RangeFilterUint64 struct {
+	Gte *uint64 `json:"gte,omitempty"`
+	Gt  *uint64 `json:"gt,omitempty"`
+	Lte *uint64 `json:"lte,omitempty"`
+	Lt  *uint64 `json:"lt,omitempty"`
+}
+
+// RangeFilterInt64 expresses greater/less-than(-or-equal) and equality bounds
+// on an int64 (used for Unix timestamps).
+type RangeFilterInt64 struct {
+	Gte *int64 `json:"gte,omitempty"`
+	Gt  *int64 `json:"gt,omitempty"`
+	Lte *int64 `json:"lte,omitempty"`
+	Lt  *int64 `json:"lt,omitempty"`
+	Eq  *int64 `json:"eq,omitempty"`
+}
+
+// RangeFilterString expresses greater/less-than(-or-equal) bounds on a string.
+type RangeFilterString struct {
+	Gte string `json:"gte,omitempty"`
+	Gt  string `json:"gt,omitempty"`
+	Lte string `json:"lte,omitempty"`
+	Lt  string `json:"lt,omitempty"`
+}
+
+// TokenTransferFilter constrains results to transactions matching a token
+// transfer against a counterparty, mint, direction and/or amount.
+type TokenTransferFilter struct {
+	// Counterparty address.
+	With string `json:"with,omitempty"`
+	// Transfer direction relative to the queried address: "in", "out", or "any".
+	Direction string `json:"direction,omitempty"`
+	// Token mint address.
+	Mint string `json:"mint,omitempty"`
+	// Amount range comparisons.
+	Amount *RangeFilterUint64 `json:"amount,omitempty"`
+}
+
+// GetTransactionsForAddressResult is the response of getTransactionsForAddress.
+type GetTransactionsForAddressResult struct {
+	// The transactions matching the query, in the requested sort order.
+	Data []*TransactionForAddress `json:"data"`
+
+	// Opaque cursor ("slot:position") for the next page, or nil when there are
+	// no more results. Pass it back via GetTransactionsForAddressOpts.PaginationToken.
+	PaginationToken *string `json:"paginationToken"`
+}
+
+// TransactionForAddress is a single entry of a getTransactionsForAddress response.
+// Which fields are populated depends on the requested TransactionDetails level.
+type TransactionForAddress struct {
+	// The slot that contains the block with the transaction.
+	Slot uint64 `json:"slot"`
+
+	// The transaction's index within the block. This field is specific to
+	// getTransactionsForAddress.
+	TransactionIndex uint64 `json:"transactionIndex"`
+
+	// Estimated production time, as Unix timestamp (seconds since the Unix epoch)
+	// of when the transaction was processed. Nil if not available.
+	BlockTime *solana.UnixTimeSeconds `json:"blockTime"`
+
+	// Fields below are present when TransactionDetails is "signatures" (default):
+
+	// Transaction signature.
+	Signature solana.Signature `json:"signature,omitempty"`
+
+	// Error if the transaction failed, nil if it succeeded.
+	Err any `json:"err,omitempty"`
+
+	// Memo associated with the transaction, nil if none.
+	Memo *string `json:"memo,omitempty"`
+
+	// The transaction's cluster confirmation status.
+	ConfirmationStatus ConfirmationStatusType `json:"confirmationStatus,omitempty"`
+
+	// Fields below are present when TransactionDetails is "full":
+
+	// The decoded transaction, honoring the requested Encoding.
+	Transaction *DataBytesOrJSON `json:"transaction,omitempty"`
+
+	// Transaction status metadata object.
+	Meta *TransactionMeta `json:"meta,omitempty"`
+}
+
+// GetTransactionsForAddress returns confirmed transactions that involve the
+// given address, newest first.
+//
+// NOTE: getTransactionsForAddress is not part of the core Solana JSON-RPC API;
+// it is offered by some RPC providers (e.g. Helius). Calls will fail against
+// endpoints that do not implement it.
+func (cl *Client) GetTransactionsForAddress(
+	ctx context.Context,
+	account solana.PublicKey,
+) (out *GetTransactionsForAddressResult, err error) {
+	return cl.GetTransactionsForAddressWithOpts(
+		ctx,
+		account,
+		nil,
+	)
+}
+
+// GetTransactionsForAddressWithOpts returns confirmed transactions that involve
+// the given address, with control over detail level, ordering, paging and
+// server-side filters.
+//
+// NOTE: getTransactionsForAddress is not part of the core Solana JSON-RPC API;
+// it is offered by some RPC providers (e.g. Helius). Calls will fail against
+// endpoints that do not implement it.
+func (cl *Client) GetTransactionsForAddressWithOpts(
+	ctx context.Context,
+	account solana.PublicKey,
+	opts *GetTransactionsForAddressOpts,
+) (out *GetTransactionsForAddressResult, err error) {
+	params := []any{account}
+	if opts != nil {
+		obj := M{}
+		if opts.TransactionDetails != "" {
+			obj["transactionDetails"] = opts.TransactionDetails
+		}
+		if opts.SortOrder != "" {
+			obj["sortOrder"] = opts.SortOrder
+		}
+		if opts.Limit != nil {
+			obj["limit"] = opts.Limit
+		}
+		if opts.PaginationToken != "" {
+			obj["paginationToken"] = opts.PaginationToken
+		}
+		if opts.Commitment != "" {
+			obj["commitment"] = opts.Commitment
+		}
+		if opts.Encoding != "" {
+			if !solana.IsAnyOfEncodingType(
+				opts.Encoding,
+				// Valid encodings:
+				solana.EncodingJSON,
+				solana.EncodingJSONParsed,
+				solana.EncodingBase58,
+				solana.EncodingBase64,
+			) {
+				return nil, fmt.Errorf("provided encoding is not supported: %s", opts.Encoding)
+			}
+			obj["encoding"] = opts.Encoding
+		}
+		if opts.MaxSupportedTransactionVersion != nil {
+			obj["maxSupportedTransactionVersion"] = *opts.MaxSupportedTransactionVersion
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
+		}
+		if opts.Filters != nil {
+			obj["filters"] = opts.Filters
+		}
+		if len(obj) > 0 {
+			params = append(params, obj)
+		}
+	}
+
+	err = cl.rpcClient.CallForInto(ctx, &out, "getTransactionsForAddress", params)
+	return
+}

--- a/rpc/getTransactionsForAddress_test.go
+++ b/rpc/getTransactionsForAddress_test.go
@@ -46,7 +46,7 @@ func TestClient_GetTransactionsForAddress(t *testing.T) {
 		Commitment:         CommitmentFinalized,
 		MinContextSlot:     &minContextSlot,
 		Filters: &TransactionsForAddressFilters{
-			Status: "succeeded",
+			Status: TransactionStatusSucceeded,
 			Slot:   &RangeFilterUint64{Gte: &slotFloor},
 		},
 	}
@@ -165,6 +165,34 @@ func TestClient_GetTransactionsForAddress_FullDetail(t *testing.T) {
 	assert.Equal(t, uint64(2), out.Data[0].TransactionIndex)
 	require.NotNil(t, out.Data[0].Meta)
 	assert.Equal(t, uint64(5000), out.Data[0].Meta.Fee)
+}
+
+func TestClient_GetTransactionsForAddress_Base64ZstdEncoding(t *testing.T) {
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(`{"data":[],"paginationToken":null}`)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+
+	// base64+zstd is accepted everywhere else in this package (getBlock,
+	// getTransaction, blockSubscribe); it must be accepted here too rather
+	// than rejected client-side.
+	_, err := client.GetTransactionsForAddressWithOpts(
+		context.Background(),
+		pubKey,
+		&GetTransactionsForAddressOpts{
+			TransactionDetails: TransactionDetailsFull,
+			Encoding:           solana.EncodingBase64Zstd,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	params, ok := reqBody["params"].([]any)
+	require.True(t, ok)
+	cfg, ok := params[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, string(solana.EncodingBase64Zstd), cfg["encoding"])
 }
 
 func TestClient_GetTransactionsForAddress_InvalidEncoding(t *testing.T) {

--- a/rpc/getTransactionsForAddress_test.go
+++ b/rpc/getTransactionsForAddress_test.go
@@ -1,0 +1,186 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	stdjson "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+func TestClient_GetTransactionsForAddress(t *testing.T) {
+	responseBody := `{"data":[{"slot":83994671,"transactionIndex":3,"blockTime":1625231961,"signature":"4Yig3yd33o2hyZV2qZBJkScDArwVmzurkxhBfKdqJeujTrdKHwrR3U8KR6LrhN5eWNTyugS5rkkYagVXCNnk7pks","err":null,"memo":null,"confirmationStatus":"finalized"},{"slot":83994656,"transactionIndex":1,"blockTime":1625231952,"signature":"3oQ7qqpJs5CtH1Xnnn8Ru5MtxkR3SZgshqzXwokuxFRArLihKdvCb9km6gbSiiUaNSHE7zVJqUVUZGfYuEaqWZPV","err":null,"memo":null,"confirmationStatus":"finalized"}],"paginationToken":"83994656:1"}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	limit := 10
+	minContextSlot := uint64(123456)
+	slotFloor := uint64(83000000)
+
+	opts := GetTransactionsForAddressOpts{
+		TransactionDetails: TransactionDetailsSignatures,
+		SortOrder:          TransactionsForAddressSortDesc,
+		Limit:              &limit,
+		PaginationToken:    "83999999:0",
+		Commitment:         CommitmentFinalized,
+		MinContextSlot:     &minContextSlot,
+		Filters: &TransactionsForAddressFilters{
+			Status: "succeeded",
+			Slot:   &RangeFilterUint64{Gte: &slotFloor},
+		},
+	}
+	out, err := client.GetTransactionsForAddressWithOpts(
+		context.Background(),
+		pubKey,
+		&opts,
+	)
+	require.NoError(t, err)
+
+	// The id is random, so we can't assert it; check it is set, then drop it.
+	reqBody := server.RequestBody(t)
+	assert.NotNil(t, reqBody["id"])
+	reqBody["id"] = any(nil)
+
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getTransactionsForAddress",
+			"params": []any{
+				pubkeyString,
+				map[string]any{
+					"transactionDetails": string(TransactionDetailsSignatures),
+					"sortOrder":          string(TransactionsForAddressSortDesc),
+					"limit":              float64(limit),
+					"paginationToken":    "83999999:0",
+					"commitment":         string(CommitmentFinalized),
+					"minContextSlot":     float64(minContextSlot),
+					"filters": map[string]any{
+						"status": "succeeded",
+						"slot": map[string]any{
+							"gte": float64(slotFloor),
+						},
+					},
+				},
+			},
+		},
+		reqBody,
+	)
+
+	require.NotNil(t, out)
+	require.Len(t, out.Data, 2)
+	assert.Equal(t, uint64(83994671), out.Data[0].Slot)
+	assert.Equal(t, uint64(3), out.Data[0].TransactionIndex)
+	assert.Equal(t,
+		"4Yig3yd33o2hyZV2qZBJkScDArwVmzurkxhBfKdqJeujTrdKHwrR3U8KR6LrhN5eWNTyugS5rkkYagVXCNnk7pks",
+		out.Data[0].Signature.String(),
+	)
+	assert.Equal(t, ConfirmationStatusFinalized, out.Data[0].ConfirmationStatus)
+	require.NotNil(t, out.PaginationToken)
+	assert.Equal(t, "83994656:1", *out.PaginationToken)
+}
+
+func TestClient_GetTransactionsForAddress_NoOpts(t *testing.T) {
+	responseBody := `{"data":[],"paginationToken":null}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+
+	out, err := client.GetTransactionsForAddress(context.Background(), pubKey)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+
+	// With no opts, only the address is sent (no config object).
+	assert.Equal(t,
+		map[string]any{
+			"id":      any(nil),
+			"jsonrpc": "2.0",
+			"method":  "getTransactionsForAddress",
+			"params":  []any{pubkeyString},
+		},
+		reqBody,
+	)
+
+	require.NotNil(t, out)
+	assert.Empty(t, out.Data)
+	assert.Nil(t, out.PaginationToken)
+}
+
+func TestClient_GetTransactionsForAddress_FullDetail(t *testing.T) {
+	responseBody := `{"data":[{"slot":83994671,"transactionIndex":2,"blockTime":1625231961,"transaction":["AQ==","base64"],"meta":{"err":null,"fee":5000,"preBalances":[1000],"postBalances":[995]}}],"paginationToken":null}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+
+	out, err := client.GetTransactionsForAddressWithOpts(
+		context.Background(),
+		pubKey,
+		&GetTransactionsForAddressOpts{
+			TransactionDetails: TransactionDetailsFull,
+			Encoding:           solana.EncodingBase64,
+		},
+	)
+	require.NoError(t, err)
+
+	reqBody := server.RequestBody(t)
+	reqBody["id"] = any(nil)
+	params, ok := reqBody["params"].([]any)
+	require.True(t, ok)
+	cfg, ok := params[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, string(solana.EncodingBase64), cfg["encoding"])
+	assert.Equal(t, string(TransactionDetailsFull), cfg["transactionDetails"])
+
+	require.NotNil(t, out)
+	require.Len(t, out.Data, 1)
+	require.NotNil(t, out.Data[0].Transaction)
+	assert.Equal(t, uint64(2), out.Data[0].TransactionIndex)
+	require.NotNil(t, out.Data[0].Meta)
+	assert.Equal(t, uint64(5000), out.Data[0].Meta.Fee)
+}
+
+func TestClient_GetTransactionsForAddress_InvalidEncoding(t *testing.T) {
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(`{"data":[],"paginationToken":null}`)))
+	defer closer()
+	client := New(server.URL)
+
+	pubKey := solana.MustPublicKeyFromBase58("7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932")
+
+	_, err := client.GetTransactionsForAddressWithOpts(
+		context.Background(),
+		pubKey,
+		&GetTransactionsForAddressOpts{
+			Encoding: solana.EncodingType("not-a-real-encoding"),
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encoding is not supported")
+}


### PR DESCRIPTION
Adds a client binding for `getTransactionsForAddress`, requested in #343.

It returns confirmed transactions that involve an address, with the slot, the transaction index within the block, block time, and (depending on the requested detail level) either the signature row or the full decoded transaction + meta.

## API

```go
func (cl *Client) GetTransactionsForAddress(ctx, account) (*GetTransactionsForAddressResult, error)
func (cl *Client) GetTransactionsForAddressWithOpts(ctx, account, *GetTransactionsForAddressOpts) (*GetTransactionsForAddressResult, error)
```

`GetTransactionsForAddressWithOpts` covers the full config surface:

- `transactionDetails` — `signatures` (default) or `full`
- `sortOrder` — `desc` (default) or `asc`
- `limit`, `paginationToken` (the `slot:position` cursor)
- `commitment`, `minContextSlot`
- `encoding` (for `full` detail) — validated against `json` / `jsonParsed` / `base58` / `base64`
- `maxSupportedTransactionVersion`
- `filters` — slot / blockTime / signature ranges, `status`, `tokenAccounts`, and `tokenTransfer` constraints

The shape mirrors the existing `GetSignaturesForAddress` / `GetBlockWithOpts` methods (manual params object, only set fields are sent). Full transactions reuse the `DataBytesOrJSON` envelope so the requested encoding is honored, and the response exposes the opaque `PaginationToken` for paging.

## Note

`getTransactionsForAddress` is a provider extension (e.g. Helius), not part of the core Solana JSON-RPC API. This is documented on both methods; calls against endpoints that do not implement it will fail.

## Tests

```
go test ./rpc/   ok
```

- request wire shape with opts + filters
- no-opts request (address only, no config object)
- `full` detail decode (transaction envelope + meta)
- unsupported-encoding validation error