### PR TITLE
feat: add nonce account support

### DIFF
--- a/fee_calculator.go
+++ b/fee_calculator.go
@@ -1,0 +1,36 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solana
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// FeeCalculator records the cost, in lamports per signature, to process a
+// transaction. Mirrors solana-sdk fee-calculator's FeeCalculator.
+type FeeCalculator struct {
+	LamportsPerSignature uint64
+}
+
+func (obj FeeCalculator) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	return encoder.WriteUint64(obj.LamportsPerSignature, binary.LittleEndian)
+}
+
+func (obj *FeeCalculator) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	obj.LamportsPerSignature, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
+}

--- a/nonce.go
+++ b/nonce.go
@@ -1,0 +1,424 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solana
+
+// Durable transaction nonces.
+//
+// This is a port of the upstream anza-xyz/solana-sdk `nonce` and
+// `nonce-account` crates: the typed durable-nonce account state model
+// (DurableNonce / NonceData / NonceState / NonceVersions) plus the off-chain
+// helpers used to decode and verify a nonce account fetched from the cluster.
+//
+// It complements the transaction-level durable-nonce detection in this package
+// (Transaction.UsesDurableNonce / GetNonceAccount) and the system program's
+// nonce instruction builders (programs/system).
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// durableNonceHashPrefix is the domain-separation prefix mixed into a blockhash
+// when deriving a durable nonce. Durable nonces and real blockhashes live in
+// separate hash domains. Mirrors DURABLE_NONCE_HASH_PREFIX in
+// solana-sdk nonce/src/state.rs.
+const durableNonceHashPrefix = "DURABLE_NONCE"
+
+// NonceStateSize is the serialized size, in bytes, of a nonce account's data.
+// It is constant regardless of whether the account is initialized: the runtime
+// always allocates this many bytes. Mirrors solana_nonce::state::State::size().
+const NonceStateSize = 80
+
+// NonceVersion identifies the version of a nonce account's state. Only Current
+// nonces have durable-nonce and blockhash domains separated and can therefore
+// authorize durable-nonce transactions.
+type NonceVersion uint32
+
+const (
+	NonceVersionLegacy  NonceVersion = 0
+	NonceVersionCurrent NonceVersion = 1
+)
+
+// NonceStateKind identifies whether a nonce account has been initialized.
+type NonceStateKind uint32
+
+const (
+	NonceStateUninitialized NonceStateKind = 0
+	NonceStateInitialized   NonceStateKind = 1
+)
+
+// DurableNonce is the 32-byte value stored in an initialized nonce account and
+// used as the recent_blockhash field of a durable-nonce transaction.
+//
+// Although it is used in the recent_blockhash slot, it is NOT a real blockhash:
+// it is derived from one via DurableNonceFromBlockhash with a domain prefix.
+type DurableNonce Hash
+
+// DurableNonceFromBlockhash derives a durable nonce from a blockhash, computing
+// sha256("DURABLE_NONCE" || blockhash). Mirrors DurableNonce::from_blockhash.
+func DurableNonceFromBlockhash(blockhash Hash) DurableNonce {
+	h := sha256.New()
+	h.Write([]byte(durableNonceHashPrefix))
+	h.Write(blockhash[:])
+	var out DurableNonce
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// AsHash returns the durable nonce as a Hash, i.e. the value to place in a
+// transaction's recent_blockhash field. Mirrors DurableNonce::as_hash.
+func (d DurableNonce) AsHash() Hash { return Hash(d) }
+
+// Equals reports whether two durable nonces are equal.
+func (d DurableNonce) Equals(other DurableNonce) bool { return d == other }
+
+// IsZero reports whether the durable nonce is the zero value.
+func (d DurableNonce) IsZero() bool { return d == DurableNonce{} }
+
+func (d DurableNonce) String() string { return Hash(d).String() }
+
+// NonceData is the initialized data of a durable transaction nonce account.
+type NonceData struct {
+	// Authority is the address allowed to sign transactions that consume and
+	// advance this nonce.
+	Authority PublicKey
+	// DurableNonce is the current nonce value.
+	DurableNonce DurableNonce
+	// FeeCalculator records the fee in effect when the nonce was last advanced.
+	FeeCalculator FeeCalculator
+}
+
+// NewNonceData builds nonce data from an authority, durable nonce and the
+// lamports-per-signature fee. Mirrors Data::new.
+func NewNonceData(authority PublicKey, durableNonce DurableNonce, lamportsPerSignature uint64) NonceData {
+	return NonceData{
+		Authority:     authority,
+		DurableNonce:  durableNonce,
+		FeeCalculator: FeeCalculator{LamportsPerSignature: lamportsPerSignature},
+	}
+}
+
+// Blockhash returns the hash to use as a transaction's recent_blockhash when
+// spending this nonce. Mirrors Data::blockhash.
+func (d NonceData) Blockhash() Hash { return d.DurableNonce.AsHash() }
+
+// LamportsPerSignature returns the per-signature fee recorded for the next
+// transaction that uses this nonce. Mirrors Data::get_lamports_per_signature.
+func (d NonceData) LamportsPerSignature() uint64 { return d.FeeCalculator.LamportsPerSignature }
+
+func (d NonceData) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	if err = encoder.WriteBytes(d.Authority[:], false); err != nil {
+		return err
+	}
+	if err = encoder.WriteBytes(d.DurableNonce[:], false); err != nil {
+		return err
+	}
+	return d.FeeCalculator.MarshalWithEncoder(encoder)
+}
+
+func (d *NonceData) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	auth, err := decoder.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	d.Authority = PublicKeyFromBytes(auth)
+	nonce, err := decoder.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	copy(d.DurableNonce[:], nonce)
+	return d.FeeCalculator.UnmarshalWithDecoder(decoder)
+}
+
+// NonceState is the state of a durable transaction nonce account: a
+// discriminated union that is either Uninitialized or Initialized with NonceData.
+type NonceState struct {
+	Kind NonceStateKind
+	// Data is meaningful only when Kind == NonceStateInitialized.
+	Data NonceData
+}
+
+// NewInitializedNonceState builds an initialized nonce state.
+// Mirrors State::new_initialized.
+func NewInitializedNonceState(authority PublicKey, durableNonce DurableNonce, lamportsPerSignature uint64) NonceState {
+	return NonceState{
+		Kind: NonceStateInitialized,
+		Data: NewNonceData(authority, durableNonce, lamportsPerSignature),
+	}
+}
+
+// IsInitialized reports whether the nonce account has been initialized.
+func (s NonceState) IsInitialized() bool { return s.Kind == NonceStateInitialized }
+
+func (s NonceState) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	if err = encoder.WriteUint32(uint32(s.Kind), binary.LittleEndian); err != nil {
+		return err
+	}
+	if s.Kind == NonceStateInitialized {
+		return s.Data.MarshalWithEncoder(encoder)
+	}
+	return nil
+}
+
+func (s *NonceState) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	kind, err := decoder.ReadUint32(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	switch NonceStateKind(kind) {
+	case NonceStateUninitialized:
+		s.Kind = NonceStateUninitialized
+		s.Data = NonceData{}
+		return nil
+	case NonceStateInitialized:
+		s.Kind = NonceStateInitialized
+		return s.Data.UnmarshalWithDecoder(decoder)
+	default:
+		return fmt.Errorf("invalid nonce state discriminant: %d", kind)
+	}
+}
+
+// NonceVersions wraps a NonceState together with its version. It is the type
+// stored in a nonce account's data. Mirrors solana_nonce::versions::Versions.
+type NonceVersions struct {
+	Version NonceVersion
+	State   NonceState
+}
+
+// NewNonceVersions wraps a state in a Current version. Mirrors Versions::new.
+func NewNonceVersions(state NonceState) NonceVersions {
+	return NonceVersions{Version: NonceVersionCurrent, State: state}
+}
+
+func (v NonceVersions) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	if err = encoder.WriteUint32(uint32(v.Version), binary.LittleEndian); err != nil {
+		return err
+	}
+	return v.State.MarshalWithEncoder(encoder)
+}
+
+func (v *NonceVersions) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	ver, err := decoder.ReadUint32(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	if NonceVersion(ver) > NonceVersionCurrent {
+		return fmt.Errorf("invalid nonce version: %d", ver)
+	}
+	v.Version = NonceVersion(ver)
+	return v.State.UnmarshalWithDecoder(decoder)
+}
+
+// MarshalBinary returns the bincode-serialized nonce versions (8 bytes when
+// uninitialized, NonceStateSize bytes when initialized).
+func (v NonceVersions) MarshalBinary() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := v.MarshalWithEncoder(bin.NewBinEncoder(buf)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary decodes nonce versions from bincode-serialized bytes,
+// satisfying encoding.BinaryUnmarshaler as the counterpart to MarshalBinary.
+// Like DecodeNonceVersions it tolerates trailing bytes (e.g. account padding).
+func (v *NonceVersions) UnmarshalBinary(data []byte) error {
+	return v.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// MarshalAccountData returns the on-chain account data for this nonce, zero-
+// padded to NonceStateSize bytes the way the runtime allocates it.
+func (v NonceVersions) MarshalAccountData() ([]byte, error) {
+	b, err := v.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > NonceStateSize {
+		return nil, fmt.Errorf("nonce data too large: %d bytes", len(b))
+	}
+	out := make([]byte, NonceStateSize)
+	copy(out, b)
+	return out, nil
+}
+
+// DecodeNonceVersions decodes a nonce account's data into NonceVersions. Any
+// trailing bytes (e.g. the zero padding present because the account is
+// allocated at NonceStateSize) are ignored. The account-verification helpers
+// use decodeNonceVersionsStrict instead, to match upstream bincode semantics.
+func DecodeNonceVersions(data []byte) (*NonceVersions, error) {
+	var v NonceVersions
+	if err := v.UnmarshalWithDecoder(bin.NewBinDecoder(data)); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// decodeNonceVersionsStrict decodes nonce versions and, mirroring upstream
+// bincode::deserialize, rejects any input with bytes left over after the state.
+// This is what nonce-account's verify_nonce_account / lamports_per_signature_of
+// rely on: a real nonce account serializes to exactly its data length, so
+// trailing bytes mean the account is not a valid nonce.
+func decodeNonceVersionsStrict(data []byte) (*NonceVersions, error) {
+	dec := bin.NewBinDecoder(data)
+	var v NonceVersions
+	if err := v.UnmarshalWithDecoder(dec); err != nil {
+		return nil, err
+	}
+	if dec.Remaining() != 0 {
+		return nil, fmt.Errorf("nonce account: %d trailing byte(s) after state", dec.Remaining())
+	}
+	return &v, nil
+}
+
+// VerifyRecentBlockhash checks that recentBlockhash matches this nonce and
+// returns the nonce data if so. Legacy versions never verify, because durable
+// nonces in the legacy blockhash domain are invalid. Mirrors
+// Versions::verify_recent_blockhash.
+func (v NonceVersions) VerifyRecentBlockhash(recentBlockhash Hash) (*NonceData, bool) {
+	if v.Version != NonceVersionCurrent {
+		return nil, false
+	}
+	if v.State.Kind != NonceStateInitialized {
+		return nil, false
+	}
+	if v.State.Data.Blockhash() != recentBlockhash {
+		return nil, false
+	}
+	data := v.State.Data
+	return &data, true
+}
+
+// LamportsPerSignature returns the per-signature fee of an initialized nonce, or
+// (0, false) when uninitialized.
+func (v NonceVersions) LamportsPerSignature() (uint64, bool) {
+	if v.State.Kind != NonceStateInitialized {
+		return 0, false
+	}
+	return v.State.Data.LamportsPerSignature(), true
+}
+
+// Upgrade migrates a Legacy nonce into the Current durable-nonce domain. It
+// returns (_, false) when there is nothing to upgrade: the nonce is already
+// Current, or it is an uninitialized Legacy nonce (which is upgraded on
+// initialization instead). Mirrors Versions::upgrade.
+func (v NonceVersions) Upgrade() (NonceVersions, bool) {
+	if v.Version != NonceVersionLegacy || v.State.Kind != NonceStateInitialized {
+		return NonceVersions{}, false
+	}
+	data := v.State.Data
+	data.DurableNonce = DurableNonceFromBlockhash(data.DurableNonce.AsHash())
+	return NonceVersions{
+		Version: NonceVersionCurrent,
+		State:   NonceState{Kind: NonceStateInitialized, Data: data},
+	}, true
+}
+
+// ErrNonceUninitialized is returned by Authorize when the nonce account has not
+// been initialized.
+var ErrNonceUninitialized = errors.New("nonce account is uninitialized")
+
+// MissingRequiredSignatureError is returned by Authorize when the current nonce
+// authority is not among the provided signers.
+type MissingRequiredSignatureError struct {
+	// Authority is the nonce account's current authority whose signature is
+	// required.
+	Authority PublicKey
+}
+
+func (e *MissingRequiredSignatureError) Error() string {
+	return fmt.Sprintf("missing required signature for nonce authority %s", e.Authority)
+}
+
+// Authorize sets a new authority on the nonce account. The current authority
+// must be present in signers. The version variant is preserved because the
+// durable_nonce field is not changed here. Mirrors Versions::authorize.
+func (v NonceVersions) Authorize(signers []PublicKey, newAuthority PublicKey) (NonceVersions, error) {
+	if v.State.Kind != NonceStateInitialized {
+		return NonceVersions{}, ErrNonceUninitialized
+	}
+	current := v.State.Data
+	if !PublicKeySlice(signers).Contains(current.Authority) {
+		return NonceVersions{}, &MissingRequiredSignatureError{Authority: current.Authority}
+	}
+	return NonceVersions{
+		Version: v.Version,
+		State: NonceState{
+			Kind: NonceStateInitialized,
+			Data: NewNonceData(newAuthority, current.DurableNonce, current.LamportsPerSignature()),
+		},
+	}, nil
+}
+
+// SystemAccountKind classifies a system-program-owned account.
+type SystemAccountKind int
+
+const (
+	SystemAccountKindSystem SystemAccountKind = iota
+	SystemAccountKindNonce
+)
+
+// VerifyNonceAccount decodes a system-owned nonce account and verifies that
+// recentBlockhash matches its current nonce, returning the nonce data when
+// valid. The account owner must be the System program. Mirrors
+// nonce_account::verify_nonce_account.
+func VerifyNonceAccount(owner PublicKey, data []byte, recentBlockhash Hash) (*NonceData, bool) {
+	if !owner.Equals(SystemProgramID) {
+		return nil, false
+	}
+	v, err := decodeNonceVersionsStrict(data)
+	if err != nil {
+		return nil, false
+	}
+	return v.VerifyRecentBlockhash(recentBlockhash)
+}
+
+// LamportsPerSignatureOf decodes a nonce account and returns the per-signature
+// fee it records, or (0, false) when uninitialized or undecodable. Mirrors
+// nonce_account::lamports_per_signature_of.
+func LamportsPerSignatureOf(data []byte) (uint64, bool) {
+	v, err := decodeNonceVersionsStrict(data)
+	if err != nil {
+		return 0, false
+	}
+	return v.LamportsPerSignature()
+}
+
+// GetSystemAccountKind classifies a system-program-owned account as a plain
+// system account or an initialized nonce account, returning (_, false) for any
+// other account (wrong owner, or data that is neither empty nor a valid
+// initialized nonce). Mirrors nonce_account::get_system_account_kind.
+func GetSystemAccountKind(owner PublicKey, data []byte) (SystemAccountKind, bool) {
+	if !owner.Equals(SystemProgramID) {
+		return 0, false
+	}
+	if len(data) == 0 {
+		return SystemAccountKindSystem, true
+	}
+	if len(data) == NonceStateSize {
+		v, err := decodeNonceVersionsStrict(data)
+		if err != nil {
+			return 0, false
+		}
+		if v.State.Kind == NonceStateInitialized {
+			return SystemAccountKindNonce, true
+		}
+	}
+	return 0, false
+}

--- a/nonce.go
+++ b/nonce.go
@@ -389,9 +389,14 @@ func VerifyNonceAccount(owner PublicKey, data []byte, recentBlockhash Hash) (*No
 	return v.VerifyRecentBlockhash(recentBlockhash)
 }
 
-// LamportsPerSignatureOf decodes a nonce account and returns the per-signature
-// fee it records, or (0, false) when uninitialized or undecodable. Mirrors
-// nonce_account::lamports_per_signature_of.
+// LamportsPerSignatureOf decodes a nonce account's data and returns the
+// per-signature fee it records, or (0, false) when uninitialized or undecodable.
+//
+// Mirrors nonce_account::lamports_per_signature_of, which likewise does NOT
+// verify the account owner; this function only takes the data bytes and cannot.
+// Pass data you have already confirmed belongs to a System-owned nonce account
+// (e.g. via GetSystemAccountKind or VerifyNonceAccount), or treat the result as
+// advisory.
 func LamportsPerSignatureOf(data []byte) (uint64, bool) {
 	v, err := decodeNonceVersionsStrict(data)
 	if err != nil {

--- a/nonce_test.go
+++ b/nonce_test.go
@@ -1,0 +1,471 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solana
+
+// The tests in this file are ported 1:1 from the upstream anza-xyz/solana-sdk
+// `nonce` and `nonce-account` crates to match the same functionality:
+//   - nonce/src/state.rs       -> TestNonceStateDefaultIsUninitialized, TestNonceStateSize
+//   - nonce/src/versions.rs    -> TestVerifyRecentBlockhash, TestNonceVersionsUpgrade, TestNonceVersionsAuthorize
+//   - nonce-account/src/lib.rs -> TestVerifyBadAccountOwnerFails, TestVerifyNonceAccount,
+//                                 TestGetSystemAccountKind* (5 cases)
+// A few extra Go-specific tests pin the hashing vector, encode/decode round-trip
+// and decode error handling.
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func uniqueNonceKey(t *testing.T) PublicKey {
+	t.Helper()
+	pk, err := NewRandomPrivateKey()
+	require.NoError(t, err)
+	return pk.PublicKey()
+}
+
+func hashFilled(b byte) Hash {
+	var h Hash
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// newNonceAccountData mirrors the upstream test helper new_nonce_account: it
+// returns the exact serialized account data for a nonce Versions value (8 bytes
+// when uninitialized, NonceStateSize when initialized), the way
+// AccountSharedData::new_data allocates it.
+func newNonceAccountData(t *testing.T, v NonceVersions) []byte {
+	t.Helper()
+	data, err := v.MarshalBinary()
+	require.NoError(t, err)
+	return data
+}
+
+// ----------------------------------------------------------------------------
+// extra Go-specific coverage
+// ----------------------------------------------------------------------------
+
+// TestDurableNonceFromBlockhash pins the exact derivation algorithm
+// sha256("DURABLE_NONCE" || blockhash) against a precomputed vector.
+func TestDurableNonceFromBlockhash(t *testing.T) {
+	blockhash := hashFilled(0xab) // matches the Rust Hash::from([171; 32]) test fixture
+	dn := DurableNonceFromBlockhash(blockhash)
+
+	const wantBase58 = "Ab9CuAh7wGinrStS9J5txnEZ5XePj3p2BcrjBQcpYDZz"
+	assert.Equal(t, wantBase58, dn.String())
+	assert.Equal(t, MustHashFromBase58(wantBase58), dn.AsHash())
+
+	wantHex := []byte{
+		0x8e, 0x78, 0x35, 0x1b, 0x9e, 0x96, 0x20, 0x90, 0x14, 0xd3, 0xca, 0x60, 0x56, 0xeb, 0x9d, 0x6b,
+		0xea, 0x6c, 0x77, 0x2c, 0x38, 0xe8, 0x4f, 0x34, 0x4a, 0x83, 0xf1, 0x3d, 0x58, 0x1a, 0xd3, 0x91,
+	}
+	gotHash := dn.AsHash()
+	assert.Equal(t, wantHex, gotHash[:])
+
+	// Domain separation: deriving from the nonce itself yields a different value.
+	assert.NotEqual(t, dn, DurableNonceFromBlockhash(dn.AsHash()))
+	assert.False(t, dn.IsZero())
+}
+
+// TestNonceVersionsRoundTrip exercises the bincode encode/decode path both for
+// an initialized and an uninitialized (zero-padded) nonce account.
+func TestNonceVersionsRoundTrip(t *testing.T) {
+	authority := uniqueNonceKey(t)
+	durableNonce := DurableNonceFromBlockhash(hashFilled(0x07))
+
+	initialized := NewNonceVersions(NewInitializedNonceState(authority, durableNonce, 5000))
+
+	raw, err := initialized.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, NonceStateSize)
+
+	data, err := initialized.MarshalAccountData()
+	require.NoError(t, err)
+	assert.Len(t, data, NonceStateSize)
+	assert.Equal(t, raw, data)
+
+	got, err := DecodeNonceVersions(data)
+	require.NoError(t, err)
+	assert.Equal(t, initialized, *got)
+	assert.Equal(t, NonceVersionCurrent, got.Version)
+	assert.True(t, got.State.IsInitialized())
+	assert.Equal(t, authority, got.State.Data.Authority)
+	assert.Equal(t, durableNonce, got.State.Data.DurableNonce)
+	assert.Equal(t, uint64(5000), got.State.Data.LamportsPerSignature())
+
+	// Uninitialized: 8 bytes raw, NonceStateSize once padded into account data.
+	uninit := NewNonceVersions(NonceState{Kind: NonceStateUninitialized})
+	rawUninit, err := uninit.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, rawUninit, 8)
+
+	dataUninit, err := uninit.MarshalAccountData()
+	require.NoError(t, err)
+	assert.Len(t, dataUninit, NonceStateSize)
+
+	gotUninit, err := DecodeNonceVersions(dataUninit)
+	require.NoError(t, err)
+	assert.False(t, gotUninit.State.IsInitialized())
+	assert.Equal(t, uninit, *gotUninit)
+}
+
+func TestDecodeNonceVersionsInvalid(t *testing.T) {
+	_, err := DecodeNonceVersions([]byte{0x02, 0, 0, 0}) // version 2 is invalid
+	assert.Error(t, err)
+
+	_, err = DecodeNonceVersions([]byte{0x01, 0, 0, 0, 0x05, 0, 0, 0}) // state discriminant 5
+	assert.Error(t, err)
+
+	_, err = DecodeNonceVersions([]byte{0x01, 0, 0, 0, 0x01, 0, 0, 0}) // initialized but truncated
+	assert.Error(t, err)
+}
+
+// ----------------------------------------------------------------------------
+// nonce/src/state.rs
+// ----------------------------------------------------------------------------
+
+// TestNonceStateDefaultIsUninitialized ports state.rs::default_is_uninitialized.
+func TestNonceStateDefaultIsUninitialized(t *testing.T) {
+	var state NonceState
+	assert.Equal(t, NonceStateUninitialized, state.Kind)
+	assert.False(t, state.IsInitialized())
+}
+
+// TestNonceStateSize ports state.rs::test_nonce_state_size: the serialized size
+// of Versions::new(State::Initialized(Data::default())) is exactly 80 bytes.
+func TestNonceStateSize(t *testing.T) {
+	v := NewNonceVersions(NewInitializedNonceState(PublicKey{}, DurableNonce{}, 0))
+	raw, err := v.MarshalBinary()
+	require.NoError(t, err)
+	assert.Equal(t, NonceStateSize, len(raw))
+}
+
+// ----------------------------------------------------------------------------
+// nonce/src/versions.rs
+// ----------------------------------------------------------------------------
+
+// TestVerifyRecentBlockhash ports versions.rs::test_verify_recent_blockhash.
+func TestVerifyRecentBlockhash(t *testing.T) {
+	blockhash := hashFilled(0xab)
+
+	versions := NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateUninitialized}}
+	assertNoVerify(t, versions, blockhash)
+	assertNoVerify(t, versions, Hash{})
+	versions = NonceVersions{Version: NonceVersionCurrent, State: NonceState{Kind: NonceStateUninitialized}}
+	assertNoVerify(t, versions, blockhash)
+	assertNoVerify(t, versions, Hash{})
+
+	durableNonce := DurableNonceFromBlockhash(blockhash)
+	data := NonceData{
+		Authority:     uniqueNonceKey(t),
+		DurableNonce:  durableNonce,
+		FeeCalculator: FeeCalculator{LamportsPerSignature: 2718},
+	}
+
+	versions = NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateInitialized, Data: data}}
+	assertNoVerify(t, versions, Hash{})
+	assertNoVerify(t, versions, blockhash)
+	assertNoVerify(t, versions, data.Blockhash())
+	assertNoVerify(t, versions, durableNonce.AsHash())
+
+	durableNonce = DurableNonceFromBlockhash(durableNonce.AsHash())
+	assert.NotEqual(t, data.DurableNonce, durableNonce)
+	data.DurableNonce = durableNonce
+	versions = NonceVersions{Version: NonceVersionCurrent, State: NonceState{Kind: NonceStateInitialized, Data: data}}
+	assertNoVerify(t, versions, blockhash)
+	assertNoVerify(t, versions, Hash{})
+
+	got, ok := versions.VerifyRecentBlockhash(data.Blockhash())
+	require.True(t, ok)
+	assert.Equal(t, data, *got)
+	got, ok = versions.VerifyRecentBlockhash(durableNonce.AsHash())
+	require.True(t, ok)
+	assert.Equal(t, data, *got)
+}
+
+func assertNoVerify(t *testing.T, v NonceVersions, h Hash) {
+	t.Helper()
+	_, ok := v.VerifyRecentBlockhash(h)
+	assert.False(t, ok)
+}
+
+// TestNonceVersionsUpgrade ports versions.rs::test_nonce_versions_upgrade.
+func TestNonceVersionsUpgrade(t *testing.T) {
+	// Uninitialized
+	_, ok := NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateUninitialized}}.Upgrade()
+	assert.False(t, ok)
+
+	// Initialized
+	blockhash := hashFilled(0xab)
+	durableNonce := DurableNonceFromBlockhash(blockhash)
+	data := NonceData{
+		Authority:     uniqueNonceKey(t),
+		DurableNonce:  durableNonce,
+		FeeCalculator: FeeCalculator{LamportsPerSignature: 2718},
+	}
+	versions := NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateInitialized, Data: data}}
+
+	durableNonce = DurableNonceFromBlockhash(durableNonce.AsHash())
+	assert.NotEqual(t, data.DurableNonce, durableNonce)
+	data.DurableNonce = durableNonce
+
+	upgraded, ok := versions.Upgrade()
+	require.True(t, ok)
+	assert.Equal(t, NonceVersions{Version: NonceVersionCurrent, State: NonceState{Kind: NonceStateInitialized, Data: data}}, upgraded)
+
+	_, ok = upgraded.Upgrade()
+	assert.False(t, ok)
+}
+
+// TestNonceVersionsAuthorize ports versions.rs::test_nonce_versions_authorize.
+func TestNonceVersionsAuthorize(t *testing.T) {
+	// 16 unique signers, mirroring repeat_with(Pubkey::new_unique).take(16).
+	signers := make([]PublicKey, 0, 16)
+	for range 16 {
+		signers = append(signers, uniqueNonceKey(t))
+	}
+
+	// Uninitialized
+	_, err := NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateUninitialized}}.
+		Authorize(signers, uniqueNonceKey(t))
+	assert.ErrorIs(t, err, ErrNonceUninitialized)
+	_, err = NonceVersions{Version: NonceVersionCurrent, State: NonceState{Kind: NonceStateUninitialized}}.
+		Authorize(signers, uniqueNonceKey(t))
+	assert.ErrorIs(t, err, ErrNonceUninitialized)
+
+	durableNonce := DurableNonceFromBlockhash(hashFilled(0xab))
+
+	// Run the Legacy and Current variants identically; both preserve the version.
+	for _, version := range []NonceVersion{NonceVersionLegacy, NonceVersionCurrent} {
+		data := NonceData{
+			Authority:     uniqueNonceKey(t),
+			DurableNonce:  durableNonce,
+			FeeCalculator: FeeCalculator{LamportsPerSignature: 2718},
+		}
+		accountAuthority := data.Authority
+		versions := NonceVersions{Version: version, State: NonceState{Kind: NonceStateInitialized, Data: data}}
+
+		authority := uniqueNonceKey(t)
+		assert.NotEqual(t, authority, accountAuthority)
+		want := data
+		want.Authority = authority
+
+		// Without the account authority's signature: MissingRequiredSignature.
+		_, err := versions.Authorize(signers, authority)
+		var missing *MissingRequiredSignatureError
+		require.True(t, errors.As(err, &missing))
+		assert.Equal(t, accountAuthority, missing.Authority)
+
+		// With the account authority present, authorize succeeds and the
+		// version variant is preserved.
+		out, err := versions.Authorize(slices.Concat(signers, []PublicKey{accountAuthority}), authority)
+		require.NoError(t, err)
+		assert.Equal(t, NonceVersions{Version: version, State: NonceState{Kind: NonceStateInitialized, Data: want}}, out)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// nonce-account/src/lib.rs
+// ----------------------------------------------------------------------------
+
+// TestVerifyBadAccountOwnerFails ports
+// nonce-account::test_verify_bad_account_owner_fails.
+func TestVerifyBadAccountOwnerFails(t *testing.T) {
+	programID := uniqueNonceKey(t)
+	require.NotEqual(t, programID, SystemProgramID)
+
+	data, err := NewNonceVersions(NonceState{Kind: NonceStateUninitialized}).MarshalAccountData()
+	require.NoError(t, err)
+
+	_, ok := VerifyNonceAccount(programID, data, Hash{})
+	assert.False(t, ok)
+}
+
+// TestVerifyNonceAccount ports nonce-account::test_verify_nonce_account.
+func TestVerifyNonceAccount(t *testing.T) {
+	blockhash := hashFilled(0xab)
+
+	data := newNonceAccountData(t, NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateUninitialized}})
+	assertNoVerifyAccount(t, data, blockhash)
+	assertNoVerifyAccount(t, data, Hash{})
+
+	data = newNonceAccountData(t, NonceVersions{Version: NonceVersionCurrent, State: NonceState{Kind: NonceStateUninitialized}})
+	assertNoVerifyAccount(t, data, blockhash)
+	assertNoVerifyAccount(t, data, Hash{})
+
+	durableNonce := DurableNonceFromBlockhash(blockhash)
+	nonceData := NonceData{
+		Authority:     uniqueNonceKey(t),
+		DurableNonce:  durableNonce,
+		FeeCalculator: FeeCalculator{LamportsPerSignature: 2718},
+	}
+
+	data = newNonceAccountData(t, NonceVersions{Version: NonceVersionLegacy, State: NonceState{Kind: NonceStateInitialized, Data: nonceData}})
+	assertNoVerifyAccount(t, data, blockhash)
+	assertNoVerifyAccount(t, data, Hash{})
+	assertNoVerifyAccount(t, data, nonceData.Blockhash())
+	assertNoVerifyAccount(t, data, durableNonce.AsHash())
+
+	durableNonce = DurableNonceFromBlockhash(durableNonce.AsHash())
+	assert.NotEqual(t, nonceData.DurableNonce, durableNonce)
+	nonceData.DurableNonce = durableNonce
+
+	data = newNonceAccountData(t, NonceVersions{Version: NonceVersionCurrent, State: NonceState{Kind: NonceStateInitialized, Data: nonceData}})
+	assertNoVerifyAccount(t, data, blockhash)
+	assertNoVerifyAccount(t, data, Hash{})
+
+	got, ok := VerifyNonceAccount(SystemProgramID, data, nonceData.Blockhash())
+	require.True(t, ok)
+	assert.Equal(t, nonceData, *got)
+	got, ok = VerifyNonceAccount(SystemProgramID, data, durableNonce.AsHash())
+	require.True(t, ok)
+	assert.Equal(t, nonceData, *got)
+}
+
+func assertNoVerifyAccount(t *testing.T, data []byte, h Hash) {
+	t.Helper()
+	_, ok := VerifyNonceAccount(SystemProgramID, data, h)
+	assert.False(t, ok)
+}
+
+// TestGetSystemAccountKindSystemOk ports
+// nonce-account::test_get_system_account_kind_system_ok. A default account
+// (empty data, owner = all-zeros = system program) is a plain system account.
+func TestGetSystemAccountKindSystemOk(t *testing.T) {
+	kind, ok := GetSystemAccountKind(SystemProgramID, nil)
+	require.True(t, ok)
+	assert.Equal(t, SystemAccountKindSystem, kind)
+}
+
+// TestGetSystemAccountKindNonceOk ports
+// nonce-account::test_get_system_account_kind_nonce_ok.
+func TestGetSystemAccountKindNonceOk(t *testing.T) {
+	data, err := NewNonceVersions(NewInitializedNonceState(PublicKey{}, DurableNonce{}, 0)).MarshalAccountData()
+	require.NoError(t, err)
+
+	kind, ok := GetSystemAccountKind(SystemProgramID, data)
+	require.True(t, ok)
+	assert.Equal(t, SystemAccountKindNonce, kind)
+}
+
+// TestGetSystemAccountKindUninitializedNonceAccountFail ports
+// nonce-account::test_get_system_account_kind_uninitialized_nonce_account_fail.
+func TestGetSystemAccountKindUninitializedNonceAccountFail(t *testing.T) {
+	// create_account allocates State::size() bytes of uninitialized state.
+	data, err := NewNonceVersions(NonceState{Kind: NonceStateUninitialized}).MarshalAccountData()
+	require.NoError(t, err)
+
+	_, ok := GetSystemAccountKind(SystemProgramID, data)
+	assert.False(t, ok)
+}
+
+// TestGetSystemAccountKindSystemOwnerNonzeroNonNonceDataFail ports
+// nonce-account::test_get_system_account_kind_system_owner_nonzero_nonnonce_data_fail.
+func TestGetSystemAccountKindSystemOwnerNonzeroNonNonceDataFail(t *testing.T) {
+	_, ok := GetSystemAccountKind(SystemProgramID, []byte("other"))
+	assert.False(t, ok)
+}
+
+// TestGetSystemAccountKindNonsystemOwnerWithNonceDataFail ports
+// nonce-account::test_get_system_account_kind_nonsystem_owner_with_nonce_data_fail.
+func TestGetSystemAccountKindNonsystemOwnerWithNonceDataFail(t *testing.T) {
+	data, err := NewNonceVersions(NewInitializedNonceState(PublicKey{}, DurableNonce{}, 0)).MarshalAccountData()
+	require.NoError(t, err)
+
+	_, ok := GetSystemAccountKind(uniqueNonceKey(t), data)
+	assert.False(t, ok)
+}
+
+func TestLamportsPerSignatureOf(t *testing.T) {
+	initialized := NewNonceVersions(NewInitializedNonceState(uniqueNonceKey(t), DurableNonce{}, 5000))
+	data, err := initialized.MarshalAccountData()
+	require.NoError(t, err)
+
+	fee, ok := LamportsPerSignatureOf(data)
+	require.True(t, ok)
+	assert.Equal(t, uint64(5000), fee)
+
+	// Uninitialized has no recorded fee.
+	uninit, err := NewNonceVersions(NonceState{Kind: NonceStateUninitialized}).MarshalAccountData()
+	require.NoError(t, err)
+	_, ok = LamportsPerSignatureOf(uninit)
+	assert.False(t, ok)
+}
+
+// TestVerifyRejectsTrailingBytes guards the strict-decode behavior: a
+// system-owned buffer whose first NonceStateSize bytes form a valid initialized
+// nonce but which carries extra trailing bytes is NOT a valid nonce account,
+// matching upstream's strict bincode::deserialize (which rejects leftover bytes).
+func TestVerifyRejectsTrailingBytes(t *testing.T) {
+	durableNonce := DurableNonceFromBlockhash(hashFilled(0x42))
+	valid, err := NewNonceVersions(NewInitializedNonceState(uniqueNonceKey(t), durableNonce, 5000)).MarshalAccountData()
+	require.NoError(t, err)
+	require.Len(t, valid, NonceStateSize)
+
+	// Sanity check: the exact-size buffer verifies.
+	_, ok := VerifyNonceAccount(SystemProgramID, valid, durableNonce.AsHash())
+	require.True(t, ok)
+
+	// Same bytes plus one trailing byte must be rejected by every helper.
+	oversized := append(slices.Clone(valid), 0x00)
+	_, ok = VerifyNonceAccount(SystemProgramID, oversized, durableNonce.AsHash())
+	assert.False(t, ok)
+	_, ok = LamportsPerSignatureOf(oversized)
+	assert.False(t, ok)
+	_, ok = GetSystemAccountKind(SystemProgramID, oversized) // also fails the len==80 gate
+	assert.False(t, ok)
+}
+
+// FuzzDecodeNonceVersions ensures the deserializer never panics on arbitrary
+// input and that anything it accepts round-trips back to identical bytes.
+func FuzzDecodeNonceVersions(f *testing.F) {
+	for _, seed := range [][]byte{
+		nil,
+		{0x01, 0, 0, 0, 0, 0, 0, 0}, // Current, Uninitialized
+		mustMarshalAccountData(f, NonceVersionCurrent), // full initialized account
+		{0x02, 0, 0, 0}, // invalid version
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		v, err := DecodeNonceVersions(data)
+		if err != nil {
+			return
+		}
+		// Re-encoding an accepted value must reproduce the exact prefix it was
+		// decoded from (the decoder ignores only trailing padding).
+		raw, err := v.MarshalBinary()
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(raw), len(data))
+		assert.Equal(t, data[:len(raw)], raw)
+	})
+}
+
+func mustMarshalAccountData(f *testing.F, version NonceVersion) []byte {
+	f.Helper()
+	data, err := NonceVersions{
+		Version: version,
+		State:   NewInitializedNonceState(PublicKey{}, DurableNonce{}, 1),
+	}.MarshalAccountData()
+	if err != nil {
+		f.Fatal(err)
+	}
+	return data
+}

--- a/programs/system/accounts.go
+++ b/programs/system/accounts.go
@@ -29,9 +29,9 @@ type NonceAccount struct {
 	FeeCalculator    FeeCalculator
 }
 
-type FeeCalculator struct {
-	LamportsPerSignature uint64
-}
+// FeeCalculator aliases the canonical solana.FeeCalculator so this package and
+// the root package share a single definition (and wire format).
+type FeeCalculator = solana.FeeCalculator
 
 func (obj NonceAccount) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
 	err = encoder.WriteUint32(obj.Version, binary.LittleEndian)
@@ -81,13 +81,4 @@ func (obj *NonceAccount) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) 
 		obj.Nonce = solana.PublicKeyFromBytes(buf)
 	}
 	return obj.FeeCalculator.UnmarshalWithDecoder(decoder)
-}
-
-func (obj FeeCalculator) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
-	return encoder.WriteUint64(obj.LamportsPerSignature, binary.LittleEndian)
-}
-
-func (obj *FeeCalculator) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
-	obj.LamportsPerSignature, err = decoder.ReadUint64(binary.LittleEndian)
-	return err
 }

--- a/programs/system/accounts.go
+++ b/programs/system/accounts.go
@@ -29,9 +29,9 @@ type NonceAccount struct {
 	FeeCalculator    FeeCalculator
 }
 
-// FeeCalculator aliases the canonical solana.FeeCalculator so this package and
-// the root package share a single definition (and wire format).
-type FeeCalculator = solana.FeeCalculator
+type FeeCalculator struct {
+	LamportsPerSignature uint64
+}
 
 func (obj NonceAccount) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
 	err = encoder.WriteUint32(obj.Version, binary.LittleEndian)
@@ -81,4 +81,13 @@ func (obj *NonceAccount) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) 
 		obj.Nonce = solana.PublicKeyFromBytes(buf)
 	}
 	return obj.FeeCalculator.UnmarshalWithDecoder(decoder)
+}
+
+func (obj FeeCalculator) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	return encoder.WriteUint64(obj.LamportsPerSignature, binary.LittleEndian)
+}
+
+func (obj *FeeCalculator) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	obj.LamportsPerSignature, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
 }


### PR DESCRIPTION
### Problem

SDK could detect a durable-nonce transaction but had no typed model of a nonce account's on-chain state - only a flat wire struct `programs/system.NonceAccount` with no durable-nonce semantics or verification.


### Summary of Changes

- add nonce account state so client can decode, verify, and reason about nonce accounts
- extract `FeeCalculator` to the root of repo