### PR TITLE
feat: add sysvars

### DIFF
--- a/fee_calculator.go
+++ b/fee_calculator.go
@@ -1,0 +1,36 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solana
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// FeeCalculator records the cost, in lamports per signature, to process a
+// transaction. Mirrors solana-sdk fee-calculator's FeeCalculator.
+type FeeCalculator struct {
+	LamportsPerSignature uint64
+}
+
+func (obj FeeCalculator) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	return encoder.WriteUint64(obj.LamportsPerSignature, binary.LittleEndian)
+}
+
+func (obj *FeeCalculator) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	obj.LamportsPerSignature, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
+}

--- a/sysvar/clock.go
+++ b/sysvar/clock.go
@@ -1,0 +1,113 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// ClockSize is the serialized size, in bytes, of the Clock sysvar (5 x u64/i64).
+const ClockSize = 40
+
+// Cluster timing constants from the solana-sdk clock crate.
+const (
+	DefaultTicksPerSecond  uint64 = 160
+	DefaultTicksPerSlot    uint64 = 64
+	DefaultHashesPerSecond uint64 = 10_000_000
+	SecondsPerDay          uint64 = 24 * 60 * 60
+	TicksPerDay            uint64 = DefaultTicksPerSecond * SecondsPerDay
+	// DefaultSlotsPerEpoch is ~2 days of slots (432000).
+	DefaultSlotsPerEpoch uint64 = 2 * TicksPerDay / DefaultTicksPerSlot
+	// DefaultMsPerSlot is the default slot duration in milliseconds (400).
+	DefaultMsPerSlot uint64 = 1000 * DefaultTicksPerSlot / DefaultTicksPerSecond
+	// MaxRecentBlockhashes is the number of blockhashes kept in the
+	// RecentBlockhashes sysvar (300).
+	MaxRecentBlockhashes uint64 = 120 * DefaultTicksPerSecond / DefaultTicksPerSlot
+	// MaxProcessingAge is the number of blocks a blockhash is valid for (150).
+	MaxProcessingAge uint64 = MaxRecentBlockhashes / 2
+)
+
+// Clock is the data of the Clock sysvar (account solana.SysVarClockPubkey). It records
+// the cluster's notion of time. Mirrors solana-sdk clock::Clock.
+type Clock struct {
+	// Slot is the current slot.
+	Slot uint64
+	// EpochStartTimestamp is the Unix timestamp (seconds) of the first slot in
+	// the current epoch. Signed.
+	EpochStartTimestamp int64
+	// Epoch is the current epoch.
+	Epoch uint64
+	// LeaderScheduleEpoch is the most recent epoch for which the leader schedule
+	// has been calculated.
+	LeaderScheduleEpoch uint64
+	// UnixTimestamp is the validator-estimated Unix timestamp (seconds) of the
+	// current slot. Signed.
+	UnixTimestamp int64
+}
+
+func (c Clock) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(c.Slot, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(uint64(c.EpochStartTimestamp), binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(c.Epoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(c.LeaderScheduleEpoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	return encoder.WriteUint64(uint64(c.UnixTimestamp), binary.LittleEndian)
+}
+
+func (c *Clock) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	var err error
+	if c.Slot, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	v, err := decoder.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	c.EpochStartTimestamp = int64(v)
+	if c.Epoch, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if c.LeaderScheduleEpoch, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if v, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	c.UnixTimestamp = int64(v)
+	return nil
+}
+
+func (c Clock) MarshalBinary() ([]byte, error) { return encodeSysvar(c) }
+func (c *Clock) UnmarshalBinary(data []byte) error {
+	return c.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeClock decodes Clock sysvar account data.
+func DecodeClock(data []byte) (*Clock, error) {
+	var c Clock
+	if err := c.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}

--- a/sysvar/epoch_rewards.go
+++ b/sysvar/epoch_rewards.go
@@ -1,0 +1,122 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+)
+
+// EpochRewardsSize is the serialized size, in bytes, of the EpochRewards sysvar.
+const EpochRewardsSize = 81
+
+// EpochRewards is the data of the EpochRewards sysvar (account
+// solana.SysVarEpochRewardsPubkey): the state of the partitioned epoch-rewards
+// distribution. Mirrors solana-sdk epoch_rewards::EpochRewards.
+type EpochRewards struct {
+	// DistributionStartingBlockHeight is the block height at which rewards
+	// distribution started for the current epoch.
+	DistributionStartingBlockHeight uint64
+	// NumPartitions is the number of partitions rewards are split across.
+	NumPartitions uint64
+	// ParentBlockhash is the blockhash of the epoch's last block, used to seed
+	// the partition shuffle.
+	ParentBlockhash solana.Hash
+	// TotalPoints is the total rewards points (u128) calculated for the epoch.
+	TotalPoints bin.Uint128
+	// TotalRewards is the total rewards, in lamports, for the epoch.
+	TotalRewards uint64
+	// DistributedRewards is the rewards, in lamports, distributed so far.
+	DistributedRewards uint64
+	// Active reports whether rewards distribution is in progress.
+	Active bool
+}
+
+// Distribute records that amount more lamports of rewards have been distributed.
+// It returns an error if that would push DistributedRewards above TotalRewards
+// (or overflow), mirroring the assertion in EpochRewards::distribute.
+func (e *EpochRewards) Distribute(amount uint64) error {
+	newDistributed := e.DistributedRewards + amount
+	if newDistributed < e.DistributedRewards || newDistributed > e.TotalRewards {
+		return fmt.Errorf("epoch rewards: distributing %d would exceed total rewards %d", amount, e.TotalRewards)
+	}
+	e.DistributedRewards = newDistributed
+	return nil
+}
+
+func (e EpochRewards) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(e.DistributionStartingBlockHeight, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(e.NumPartitions, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteBytes(e.ParentBlockhash[:], false); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint128(e.TotalPoints, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(e.TotalRewards, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(e.DistributedRewards, binary.LittleEndian); err != nil {
+		return err
+	}
+	return encoder.WriteBool(e.Active)
+}
+
+func (e *EpochRewards) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	var err error
+	if e.DistributionStartingBlockHeight, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if e.NumPartitions, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	buf, err := decoder.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	copy(e.ParentBlockhash[:], buf)
+	if e.TotalPoints, err = decoder.ReadUint128(binary.LittleEndian); err != nil {
+		return err
+	}
+	if e.TotalRewards, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if e.DistributedRewards, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	e.Active, err = decoder.ReadBool()
+	return err
+}
+
+func (e EpochRewards) MarshalBinary() ([]byte, error) { return encodeSysvar(e) }
+func (e *EpochRewards) UnmarshalBinary(data []byte) error {
+	return e.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeEpochRewards decodes EpochRewards sysvar account data.
+func DecodeEpochRewards(data []byte) (*EpochRewards, error) {
+	var e EpochRewards
+	if err := e.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &e, nil
+}

--- a/sysvar/epoch_schedule.go
+++ b/sysvar/epoch_schedule.go
@@ -1,0 +1,186 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// EpochScheduleSize is the serialized size, in bytes, of the EpochSchedule
+// sysvar (u64 + u64 + bool + u64 + u64).
+const EpochScheduleSize = 33
+
+// MinimumSlotsPerEpoch is the minimum number of slots per epoch.
+const MinimumSlotsPerEpoch uint64 = 32
+
+// minSlotsPerEpochTrailingZeros == bits.TrailingZeros64(MinimumSlotsPerEpoch).
+const minSlotsPerEpochTrailingZeros uint32 = 5
+
+// EpochSchedule is the data of the EpochSchedule sysvar (account
+// solana.SysVarEpochSchedulePubkey): the cluster's epoch length configuration and the
+// warmup schedule. Mirrors solana-sdk epoch_schedule::EpochSchedule.
+type EpochSchedule struct {
+	// SlotsPerEpoch is the number of slots in each normal epoch.
+	SlotsPerEpoch uint64
+	// LeaderScheduleSlotOffset is how many slots before an epoch its leader
+	// schedule is calculated.
+	LeaderScheduleSlotOffset uint64
+	// Warmup reports whether epochs start short and grow to SlotsPerEpoch.
+	Warmup bool
+	// FirstNormalEpoch is the first epoch with SlotsPerEpoch slots (post-warmup).
+	FirstNormalEpoch uint64
+	// FirstNormalSlot is the first slot of FirstNormalEpoch.
+	FirstNormalSlot uint64
+}
+
+// NewEpochScheduleCustom builds an EpochSchedule, computing the warmup
+// boundaries. Mirrors EpochSchedule::custom (slotsPerEpoch must be >=
+// MinimumSlotsPerEpoch).
+func NewEpochScheduleCustom(slotsPerEpoch, leaderScheduleSlotOffset uint64, warmup bool) EpochSchedule {
+	var firstNormalEpoch, firstNormalSlot uint64
+	if warmup {
+		npot := nextPowerOfTwo(slotsPerEpoch)
+		log2 := satSubU32(uint32(numTrailingZeros64(npot)), minSlotsPerEpochTrailingZeros)
+		firstNormalEpoch = uint64(log2)
+		firstNormalSlot = satSubU64(npot, MinimumSlotsPerEpoch)
+	}
+	return EpochSchedule{
+		SlotsPerEpoch:            slotsPerEpoch,
+		LeaderScheduleSlotOffset: leaderScheduleSlotOffset,
+		Warmup:                   warmup,
+		FirstNormalEpoch:         firstNormalEpoch,
+		FirstNormalSlot:          firstNormalSlot,
+	}
+}
+
+// NewEpochSchedule builds an EpochSchedule with warmup enabled and the leader
+// schedule offset equal to slotsPerEpoch. Mirrors EpochSchedule::new.
+func NewEpochSchedule(slotsPerEpoch uint64) EpochSchedule {
+	return NewEpochScheduleCustom(slotsPerEpoch, slotsPerEpoch, true)
+}
+
+// GetEpoch returns the epoch containing the given slot.
+func (es EpochSchedule) GetEpoch(slot uint64) uint64 {
+	epoch, _ := es.GetEpochAndSlotIndex(slot)
+	return epoch
+}
+
+// GetEpochAndSlotIndex returns the epoch containing slot and the slot's index
+// within that epoch. Mirrors EpochSchedule::get_epoch_and_slot_index.
+func (es EpochSchedule) GetEpochAndSlotIndex(slot uint64) (epoch, slotIndex uint64) {
+	if slot < es.FirstNormalSlot {
+		npot := nextPowerOfTwo(satAddU64(satAddU64(slot, MinimumSlotsPerEpoch), 1))
+		tz := uint32(numTrailingZeros64(npot))
+		ep := satSubU32(satSubU32(tz, minSlotsPerEpochTrailingZeros), 1)
+		epochLen := satPow2(satAddU32(ep, minSlotsPerEpochTrailingZeros))
+		return uint64(ep), satSubU64(slot, satSubU64(epochLen, MinimumSlotsPerEpoch))
+	}
+	normalSlotIndex := satSubU64(slot, es.FirstNormalSlot)
+	var normalEpochIndex uint64
+	if es.SlotsPerEpoch != 0 {
+		normalEpochIndex = normalSlotIndex / es.SlotsPerEpoch
+		slotIndex = normalSlotIndex % es.SlotsPerEpoch
+	}
+	return satAddU64(es.FirstNormalEpoch, normalEpochIndex), slotIndex
+}
+
+// GetSlotsInEpoch returns the number of slots in the given epoch (accounting for
+// warmup). Mirrors EpochSchedule::get_slots_in_epoch.
+func (es EpochSchedule) GetSlotsInEpoch(epoch uint64) uint64 {
+	if epoch < es.FirstNormalEpoch {
+		return satPow2(satAddU32(uint32(epoch), minSlotsPerEpochTrailingZeros))
+	}
+	return es.SlotsPerEpoch
+}
+
+// GetFirstSlotInEpoch returns the first slot of the given epoch.
+// Mirrors EpochSchedule::get_first_slot_in_epoch.
+func (es EpochSchedule) GetFirstSlotInEpoch(epoch uint64) uint64 {
+	if epoch <= es.FirstNormalEpoch {
+		return satMulU64(satSubU64(satPow2(uint32(epoch)), 1), MinimumSlotsPerEpoch)
+	}
+	return satAddU64(satMulU64(satSubU64(epoch, es.FirstNormalEpoch), es.SlotsPerEpoch), es.FirstNormalSlot)
+}
+
+// GetLastSlotInEpoch returns the last slot of the given epoch.
+func (es EpochSchedule) GetLastSlotInEpoch(epoch uint64) uint64 {
+	return satSubU64(satAddU64(es.GetFirstSlotInEpoch(epoch), es.GetSlotsInEpoch(epoch)), 1)
+}
+
+// GetLeaderScheduleEpoch returns the epoch whose leader schedule should be
+// computed at the given slot. Mirrors EpochSchedule::get_leader_schedule_epoch.
+func (es EpochSchedule) GetLeaderScheduleEpoch(slot uint64) uint64 {
+	if slot < es.FirstNormalSlot {
+		epoch, _ := es.GetEpochAndSlotIndex(slot)
+		return satAddU64(epoch, 1)
+	}
+	newSlots := satSubU64(slot, es.FirstNormalSlot)
+	newFirst := satAddU64(newSlots, es.LeaderScheduleSlotOffset)
+	var newEpochs uint64
+	if es.SlotsPerEpoch != 0 {
+		newEpochs = newFirst / es.SlotsPerEpoch
+	}
+	return satAddU64(es.FirstNormalEpoch, newEpochs)
+}
+
+func (es EpochSchedule) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(es.SlotsPerEpoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(es.LeaderScheduleSlotOffset, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteBool(es.Warmup); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(es.FirstNormalEpoch, binary.LittleEndian); err != nil {
+		return err
+	}
+	return encoder.WriteUint64(es.FirstNormalSlot, binary.LittleEndian)
+}
+
+func (es *EpochSchedule) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	var err error
+	if es.SlotsPerEpoch, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if es.LeaderScheduleSlotOffset, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if es.Warmup, err = decoder.ReadBool(); err != nil {
+		return err
+	}
+	if es.FirstNormalEpoch, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	es.FirstNormalSlot, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
+}
+
+func (es EpochSchedule) MarshalBinary() ([]byte, error) { return encodeSysvar(es) }
+func (es *EpochSchedule) UnmarshalBinary(data []byte) error {
+	return es.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeEpochSchedule decodes EpochSchedule sysvar account data.
+func DecodeEpochSchedule(data []byte) (*EpochSchedule, error) {
+	var es EpochSchedule
+	if err := es.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &es, nil
+}

--- a/sysvar/fees.go
+++ b/sysvar/fees.go
@@ -1,0 +1,57 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+)
+
+// FeesSize is the serialized size, in bytes, of the Fees sysvar (one
+// FeeCalculator).
+const FeesSize = 8
+
+// Fees is the data of the (deprecated) Fees sysvar (account solana.SysVarFeesPubkey):
+// the fee calculator for the current slot.
+//
+// Deprecated: the Fees sysvar is deprecated; use the getFeeForMessage RPC
+// (rpc.GetFeeForMessage) to estimate transaction fees instead.
+type Fees struct {
+	FeeCalculator solana.FeeCalculator
+}
+
+func (f Fees) MarshalWithEncoder(encoder *bin.Encoder) error {
+	return f.FeeCalculator.MarshalWithEncoder(encoder)
+}
+
+func (f *Fees) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	return f.FeeCalculator.UnmarshalWithDecoder(decoder)
+}
+
+func (f Fees) MarshalBinary() ([]byte, error) { return encodeSysvar(f) }
+func (f *Fees) UnmarshalBinary(data []byte) error {
+	return f.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeFees decodes Fees sysvar account data.
+//
+// Deprecated: see Fees.
+func DecodeFees(data []byte) (*Fees, error) {
+	var f Fees
+	if err := f.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &f, nil
+}

--- a/sysvar/ids.go
+++ b/sysvar/ids.go
@@ -1,0 +1,40 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import solana "github.com/gagliardetto/solana-go"
+
+// Sysvar account addresses, paired with the data types in this package. These
+// re-export the canonical constants from the root package for convenience, so
+// callers can fetch and decode with a single import, e.g.
+//
+//	resp, _ := rpcClient.GetAccountInfo(ctx, sysvar.ClockID)
+//	clock, _ := sysvar.DecodeClock(resp.Value.Data.GetBinary())
+var (
+	ClockID           = solana.SysVarClockPubkey
+	EpochRewardsID    = solana.SysVarEpochRewardsPubkey
+	EpochScheduleID   = solana.SysVarEpochSchedulePubkey
+	LastRestartSlotID = solana.SysVarLastRestartSlotPubkey
+	RentID            = solana.SysVarRentPubkey
+	SlotHashesID      = solana.SysVarSlotHashesPubkey
+	SlotHistoryID     = solana.SysVarSlotHistoryPubkey
+	StakeHistoryID    = solana.SysVarStakeHistoryPubkey
+
+	// Deprecated: the Fees sysvar is deprecated; use the getFeeForMessage RPC.
+	FeesID = solana.SysVarFeesPubkey
+	// Deprecated: the RecentBlockhashes sysvar is deprecated; use the
+	// getLatestBlockhash RPC.
+	RecentBlockhashesID = solana.SysVarRecentBlockHashesPubkey
+)

--- a/sysvar/last_restart_slot.go
+++ b/sysvar/last_restart_slot.go
@@ -1,0 +1,56 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// LastRestartSlotSize is the serialized size, in bytes, of the LastRestartSlot
+// sysvar.
+const LastRestartSlotSize = 8
+
+// LastRestartSlot is the data of the LastRestartSlot sysvar (account
+// solana.SysVarLastRestartSlotPubkey): the slot of the last cluster restart, or 0 if
+// none. Mirrors solana-sdk last_restart_slot::LastRestartSlot.
+type LastRestartSlot struct {
+	LastRestartSlot uint64
+}
+
+func (l LastRestartSlot) MarshalWithEncoder(encoder *bin.Encoder) error {
+	return encoder.WriteUint64(l.LastRestartSlot, binary.LittleEndian)
+}
+
+func (l *LastRestartSlot) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	var err error
+	l.LastRestartSlot, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
+}
+
+func (l LastRestartSlot) MarshalBinary() ([]byte, error) { return encodeSysvar(l) }
+func (l *LastRestartSlot) UnmarshalBinary(data []byte) error {
+	return l.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeLastRestartSlot decodes LastRestartSlot sysvar account data.
+func DecodeLastRestartSlot(data []byte) (*LastRestartSlot, error) {
+	var l LastRestartSlot
+	if err := l.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}

--- a/sysvar/recent_blockhashes.go
+++ b/sysvar/recent_blockhashes.go
@@ -1,0 +1,104 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+)
+
+const (
+	// RecentBlockhashesMaxEntries is the maximum number of entries in the
+	// RecentBlockhashes sysvar.
+	RecentBlockhashesMaxEntries = 150
+	// RecentBlockhashesEntrySerializedSize is the serialized size of one entry
+	// (Hash + FeeCalculator).
+	RecentBlockhashesEntrySerializedSize = 32 + 8
+	// RecentBlockhashesSize is the fixed on-chain account size (u64 length
+	// prefix + MAX_ENTRIES * entry size).
+	RecentBlockhashesSize = 8 + RecentBlockhashesMaxEntries*RecentBlockhashesEntrySerializedSize
+)
+
+// RecentBlockhashesEntry is one (blockhash, fee_calculator) entry of the
+// RecentBlockhashes sysvar.
+//
+// Deprecated: see RecentBlockhashes.
+type RecentBlockhashesEntry struct {
+	Blockhash     solana.Hash
+	FeeCalculator solana.FeeCalculator
+}
+
+// RecentBlockhashes is the data of the (deprecated) RecentBlockhashes sysvar
+// (account solana.SysVarRecentBlockHashesPubkey): the most recent blockhashes,
+// ordered newest first.
+//
+// Deprecated: the RecentBlockhashes sysvar is deprecated; fetch a recent
+// blockhash via the getLatestBlockhash RPC (rpc.GetLatestBlockhash) instead.
+type RecentBlockhashes []RecentBlockhashesEntry
+
+func (rb RecentBlockhashes) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(uint64(len(rb)), binary.LittleEndian); err != nil {
+		return err
+	}
+	for _, e := range rb {
+		if err := encoder.WriteBytes(e.Blockhash[:], false); err != nil {
+			return err
+		}
+		if err := e.FeeCalculator.MarshalWithEncoder(encoder); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rb *RecentBlockhashes) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	n, err := decoder.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	out := make(RecentBlockhashes, 0, min(n, uint64(decoder.Remaining()/RecentBlockhashesEntrySerializedSize)))
+	for range n {
+		buf, err := decoder.ReadNBytes(32)
+		if err != nil {
+			return err
+		}
+		var e RecentBlockhashesEntry
+		copy(e.Blockhash[:], buf)
+		if err := e.FeeCalculator.UnmarshalWithDecoder(decoder); err != nil {
+			return err
+		}
+		out = append(out, e)
+	}
+	*rb = out
+	return nil
+}
+
+func (rb RecentBlockhashes) MarshalBinary() ([]byte, error) { return encodeSysvar(rb) }
+func (rb *RecentBlockhashes) UnmarshalBinary(data []byte) error {
+	return rb.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeRecentBlockhashes decodes RecentBlockhashes sysvar account data.
+//
+// Deprecated: see RecentBlockhashes.
+func DecodeRecentBlockhashes(data []byte) (RecentBlockhashes, error) {
+	var rb RecentBlockhashes
+	if err := rb.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return rb, nil
+}

--- a/sysvar/rent.go
+++ b/sysvar/rent.go
@@ -1,0 +1,150 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// RentSize is the serialized size, in bytes, of the Rent sysvar
+// (u64 + f64 + u8).
+const RentSize = 17
+
+// Rent parameters from the solana-sdk rent crate.
+const (
+	// AccountStorageOverhead is the number of bytes charged for an account with
+	// no data, added to data length when computing the rent-exempt minimum.
+	AccountStorageOverhead uint64 = 128
+	// DefaultLamportsPerByte is the current default rental rate in
+	// lamports/byte (SIMD-0194).
+	DefaultLamportsPerByte uint64 = 6_960
+	// DefaultExemptionThreshold is the current default exemption threshold
+	// (SIMD-0194 reduced this from 2.0 to 1.0).
+	DefaultExemptionThreshold float64 = 1.0
+	// DefaultBurnPercent is the percentage of collected rent that is burned.
+	DefaultBurnPercent uint8 = 50
+	// MaxPermittedDataLength is the maximum permitted account data length
+	// (10 MiB) when computing a rent-exempt minimum.
+	MaxPermittedDataLength uint64 = 10 * 1024 * 1024
+
+	// simd0194MaxLamportsPerByte / currentMaxLamportsPerByte bound LamportsPerByte
+	// (per exemption threshold) so TryMinimumBalance cannot overflow.
+	simd0194MaxLamportsPerByte uint64 = 1_759_197_129_867
+	currentMaxLamportsPerByte  uint64 = 879_598_564_933
+)
+
+// Rent is the data of the Rent sysvar (account solana.SysVarRentPubkey): the cluster's
+// rent parameters. Mirrors solana-sdk rent::Rent.
+//
+// Note: SIMD-0194 renamed the first field from lamports_per_byte_year to
+// lamports_per_byte and changed the default exemption threshold to 1.0. The
+// wire format is unchanged: u64 lamports_per_byte, then exemption_threshold as
+// the 8-byte little-endian IEEE-754 bit pattern of an f64, then u8 burn_percent.
+type Rent struct {
+	// LamportsPerByte is the rental rate in lamports per byte.
+	LamportsPerByte uint64
+	// ExemptionThreshold multiplies the base rent to yield the rent-exempt
+	// minimum balance.
+	ExemptionThreshold float64
+	// BurnPercent is the percentage of collected rent that is burned.
+	BurnPercent uint8
+}
+
+// DefaultRent returns the current default rent configuration.
+func DefaultRent() Rent {
+	return Rent{
+		LamportsPerByte:    DefaultLamportsPerByte,
+		ExemptionThreshold: DefaultExemptionThreshold,
+		BurnPercent:        DefaultBurnPercent,
+	}
+}
+
+// MinimumBalance returns the minimum balance, in lamports, for an account of
+// dataLen bytes to be rent-exempt:
+// floor((ACCOUNT_STORAGE_OVERHEAD + dataLen) * LamportsPerByte * ExemptionThreshold).
+//
+// Like Rent::minimum_balance_unchecked, the two default thresholds (1.0 and 2.0)
+// use exact integer math; other thresholds fall back to floating point. It does
+// not guard against overflow — use TryMinimumBalance for that.
+func (r Rent) MinimumBalance(dataLen uint64) uint64 {
+	base := (AccountStorageOverhead + dataLen) * r.LamportsPerByte
+	switch r.ExemptionThreshold {
+	case 1.0:
+		return base
+	case 2.0:
+		return 2 * base
+	default:
+		return uint64(float64(base) * r.ExemptionThreshold)
+	}
+}
+
+// TryMinimumBalance is MinimumBalance with the overflow guards from
+// Rent::try_minimum_balance: it returns ok=false when dataLen exceeds
+// MaxPermittedDataLength, or when LamportsPerByte is large enough (for the 1.0
+// or 2.0 threshold) that the computation could overflow.
+func (r Rent) TryMinimumBalance(dataLen uint64) (uint64, bool) {
+	if dataLen > MaxPermittedDataLength {
+		return 0, false
+	}
+	if (r.ExemptionThreshold == 2.0 && r.LamportsPerByte > currentMaxLamportsPerByte) ||
+		(r.ExemptionThreshold == 1.0 && r.LamportsPerByte > simd0194MaxLamportsPerByte) {
+		return 0, false
+	}
+	return r.MinimumBalance(dataLen), true
+}
+
+// IsExempt reports whether balance is enough for an account of dataLen bytes to
+// be rent-exempt.
+func (r Rent) IsExempt(balance, dataLen uint64) bool {
+	return balance >= r.MinimumBalance(dataLen)
+}
+
+func (r Rent) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(r.LamportsPerByte, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteFloat64(r.ExemptionThreshold, binary.LittleEndian); err != nil {
+		return err
+	}
+	return encoder.WriteByte(r.BurnPercent)
+}
+
+func (r *Rent) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	var err error
+	if r.LamportsPerByte, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	if r.ExemptionThreshold, err = decoder.ReadFloat64(binary.LittleEndian); err != nil {
+		return err
+	}
+	r.BurnPercent, err = decoder.ReadByte()
+	return err
+}
+
+func (r Rent) MarshalBinary() ([]byte, error) { return encodeSysvar(r) }
+func (r *Rent) UnmarshalBinary(data []byte) error {
+	return r.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeRent decodes Rent sysvar account data.
+func DecodeRent(data []byte) (*Rent, error) {
+	var r Rent
+	if err := r.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/sysvar/rent.go
+++ b/sysvar/rent.go
@@ -16,6 +16,8 @@ package sysvar
 
 import (
 	"encoding/binary"
+	"math"
+	"math/bits"
 
 	bin "github.com/gagliardetto/binary"
 )
@@ -40,11 +42,6 @@ const (
 	// MaxPermittedDataLength is the maximum permitted account data length
 	// (10 MiB) when computing a rent-exempt minimum.
 	MaxPermittedDataLength uint64 = 10 * 1024 * 1024
-
-	// simd0194MaxLamportsPerByte / currentMaxLamportsPerByte bound LamportsPerByte
-	// (per exemption threshold) so TryMinimumBalance cannot overflow.
-	simd0194MaxLamportsPerByte uint64 = 1_759_197_129_867
-	currentMaxLamportsPerByte  uint64 = 879_598_564_933
 )
 
 // Rent is the data of the Rent sysvar (account solana.SysVarRentPubkey): the cluster's
@@ -77,38 +74,61 @@ func DefaultRent() Rent {
 // dataLen bytes to be rent-exempt:
 // floor((ACCOUNT_STORAGE_OVERHEAD + dataLen) * LamportsPerByte * ExemptionThreshold).
 //
-// Like Rent::minimum_balance_unchecked, the two default thresholds (1.0 and 2.0)
-// use exact integer math; other thresholds fall back to floating point. It does
-// not guard against overflow — use TryMinimumBalance for that.
+// The two default thresholds (1.0 and 2.0) use exact integer math; other
+// thresholds fall back to floating point. If the computation would overflow
+// uint64 (e.g. a fixture or hostile account with a huge LamportsPerByte), it
+// saturates to math.MaxUint64 so an underfunded account is never reported
+// rent-exempt. Use TryMinimumBalance to detect the overflow explicitly.
 func (r Rent) MinimumBalance(dataLen uint64) uint64 {
-	base := (AccountStorageOverhead + dataLen) * r.LamportsPerByte
-	switch r.ExemptionThreshold {
-	case 1.0:
-		return base
-	case 2.0:
-		return 2 * base
-	default:
-		return uint64(float64(base) * r.ExemptionThreshold)
+	v, overflow := r.computeMinimumBalance(dataLen)
+	if overflow {
+		return math.MaxUint64
 	}
+	return v
 }
 
-// TryMinimumBalance is MinimumBalance with the overflow guards from
-// Rent::try_minimum_balance: it returns ok=false when dataLen exceeds
-// MaxPermittedDataLength, or when LamportsPerByte is large enough (for the 1.0
-// or 2.0 threshold) that the computation could overflow.
+// TryMinimumBalance is MinimumBalance but reports ok=false when dataLen exceeds
+// MaxPermittedDataLength or the computation would overflow uint64. Mirrors the
+// guards in Rent::try_minimum_balance.
 func (r Rent) TryMinimumBalance(dataLen uint64) (uint64, bool) {
 	if dataLen > MaxPermittedDataLength {
 		return 0, false
 	}
-	if (r.ExemptionThreshold == 2.0 && r.LamportsPerByte > currentMaxLamportsPerByte) ||
-		(r.ExemptionThreshold == 1.0 && r.LamportsPerByte > simd0194MaxLamportsPerByte) {
-		return 0, false
+	v, overflow := r.computeMinimumBalance(dataLen)
+	return v, !overflow
+}
+
+// computeMinimumBalance returns the rent-exempt minimum and whether computing it
+// overflowed uint64.
+func (r Rent) computeMinimumBalance(dataLen uint64) (uint64, bool) {
+	bytes := AccountStorageOverhead + dataLen
+	if bytes < dataLen { // overflow in the byte count
+		return 0, true
 	}
-	return r.MinimumBalance(dataLen), true
+	hi, base := bits.Mul64(bytes, r.LamportsPerByte)
+	if hi != 0 { // overflow in base rent
+		return 0, true
+	}
+	switch r.ExemptionThreshold {
+	case 1.0:
+		return base, false
+	case 2.0:
+		if base > math.MaxUint64/2 {
+			return 0, true
+		}
+		return base * 2, false
+	default:
+		v := float64(base) * r.ExemptionThreshold
+		if math.IsNaN(v) || v < 0 || v >= float64(math.MaxUint64) {
+			return 0, true
+		}
+		return uint64(v), false
+	}
 }
 
 // IsExempt reports whether balance is enough for an account of dataLen bytes to
-// be rent-exempt.
+// be rent-exempt. Because MinimumBalance saturates on overflow, IsExempt never
+// reports an underfunded account as exempt.
 func (r Rent) IsExempt(balance, dataLen uint64) bool {
 	return balance >= r.MinimumBalance(dataLen)
 }

--- a/sysvar/slot_hashes.go
+++ b/sysvar/slot_hashes.go
@@ -1,0 +1,145 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+	"sort"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+)
+
+const (
+	// SlotHashesMaxEntries is the maximum number of (slot, hash) pairs the
+	// SlotHashes sysvar holds (the most recent 512 slots).
+	SlotHashesMaxEntries = 512
+	// SlotHashSerializedSize is the serialized size of one SlotHash (u64 + Hash).
+	SlotHashSerializedSize = 8 + 32
+	// SlotHashesSize is the fixed on-chain account size of the SlotHashes sysvar
+	// (u64 length prefix + MAX_ENTRIES * SlotHashSerializedSize).
+	SlotHashesSize = 8 + SlotHashesMaxEntries*SlotHashSerializedSize
+)
+
+// SlotHash is one (slot, hash) entry of the SlotHashes sysvar.
+type SlotHash struct {
+	Slot uint64
+	Hash solana.Hash
+}
+
+// SlotHashes is the data of the SlotHashes sysvar (account solana.SysVarSlotHashesPubkey):
+// the hashes of the most recent slots. Entries are kept sorted by slot
+// DESCENDING (index 0 is the newest slot). Mirrors solana-sdk slot_hashes::SlotHashes.
+type SlotHashes []SlotHash
+
+// NewSlotHashes builds a SlotHashes from entries, sorting them by slot
+// descending. Mirrors SlotHashes::new.
+func NewSlotHashes(entries ...SlotHash) SlotHashes {
+	sh := make(SlotHashes, len(entries))
+	copy(sh, entries)
+	sort.SliceStable(sh, func(i, j int) bool { return sh[i].Slot > sh[j].Slot })
+	return sh
+}
+
+// search returns the index of slot (or its descending-order insertion point) and
+// whether an exact match was found.
+func (sh SlotHashes) search(slot uint64) (int, bool) {
+	i := sort.Search(len(sh), func(i int) bool { return sh[i].Slot <= slot })
+	if i < len(sh) && sh[i].Slot == slot {
+		return i, true
+	}
+	return i, false
+}
+
+// Get returns the hash recorded for slot, if present.
+func (sh SlotHashes) Get(slot uint64) (solana.Hash, bool) {
+	if i, ok := sh.search(slot); ok {
+		return sh[i].Hash, true
+	}
+	return solana.Hash{}, false
+}
+
+// Position returns the index of slot within the entries, if present.
+func (sh SlotHashes) Position(slot uint64) (int, bool) {
+	return sh.search(slot)
+}
+
+// Add inserts or updates the hash for slot, keeping entries sorted by slot
+// descending and capped at SlotHashesMaxEntries. Mirrors SlotHashes::add.
+func (sh *SlotHashes) Add(slot uint64, hash solana.Hash) {
+	i, found := sh.search(slot)
+	if found {
+		(*sh)[i].Hash = hash
+	} else {
+		*sh = append(*sh, SlotHash{})
+		copy((*sh)[i+1:], (*sh)[i:])
+		(*sh)[i] = SlotHash{Slot: slot, Hash: hash}
+	}
+	if len(*sh) > SlotHashesMaxEntries {
+		*sh = (*sh)[:SlotHashesMaxEntries]
+	}
+}
+
+func (sh SlotHashes) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(uint64(len(sh)), binary.LittleEndian); err != nil {
+		return err
+	}
+	for _, e := range sh {
+		if err := encoder.WriteUint64(e.Slot, binary.LittleEndian); err != nil {
+			return err
+		}
+		if err := encoder.WriteBytes(e.Hash[:], false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (sh *SlotHashes) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	n, err := decoder.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	out := make(SlotHashes, 0, min(n, uint64(decoder.Remaining()/SlotHashSerializedSize)))
+	for range n {
+		slot, err := decoder.ReadUint64(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		buf, err := decoder.ReadNBytes(32)
+		if err != nil {
+			return err
+		}
+		var h solana.Hash
+		copy(h[:], buf)
+		out = append(out, SlotHash{Slot: slot, Hash: h})
+	}
+	*sh = out
+	return nil
+}
+
+func (sh SlotHashes) MarshalBinary() ([]byte, error) { return encodeSysvar(sh) }
+func (sh *SlotHashes) UnmarshalBinary(data []byte) error {
+	return sh.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeSlotHashes decodes SlotHashes sysvar account data.
+func DecodeSlotHashes(data []byte) (SlotHashes, error) {
+	var sh SlotHashes
+	if err := sh.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return sh, nil
+}

--- a/sysvar/slot_hashes.go
+++ b/sysvar/slot_hashes.go
@@ -126,6 +126,10 @@ func (sh *SlotHashes) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 		copy(h[:], buf)
 		out = append(out, SlotHash{Slot: slot, Hash: h})
 	}
+	// Normalize to the descending-by-slot invariant that Get/Position/Add rely
+	// on, so lookups stay correct even for an out-of-order (forked or hostile)
+	// buffer. A well-formed account is already sorted, so this is a no-op.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Slot > out[j].Slot })
 	*sh = out
 	return nil
 }

--- a/sysvar/slot_history.go
+++ b/sysvar/slot_history.go
@@ -128,10 +128,22 @@ func (sh *SlotHistory) Check(slot uint64) SlotHistoryCheck {
 	}
 }
 
-// Add records slot as present, clearing any slots skipped since NextSlot.
-// Mirrors SlotHistory::add.
+// Add records slot as present. For a slot at or beyond NextSlot it advances the
+// window, clearing any skipped slots (mirroring the runtime's SlotHistory::add,
+// which assumes monotonically increasing slots).
+//
+// Unlike the runtime, adding an OLDER slot does not rewind NextSlot: the slot is
+// simply marked present if it is still within the window, and ignored if it has
+// already aged out. This keeps Check correct for newer slots that were already
+// recorded.
 func (sh *SlotHistory) Add(slot uint64) {
-	if slot > sh.NextSlot && slot-sh.NextSlot >= SlotHistoryMaxEntries {
+	if slot < sh.NextSlot {
+		if slot >= sh.Oldest() {
+			sh.setBit(slot%SlotHistoryMaxEntries, true)
+		}
+		return
+	}
+	if slot-sh.NextSlot >= SlotHistoryMaxEntries {
 		// Wrapped all the way around: clear everything.
 		for i := range sh.Bits {
 			sh.Bits[i] = 0

--- a/sysvar/slot_history.go
+++ b/sysvar/slot_history.go
@@ -1,0 +1,214 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+const (
+	// SlotHistoryMaxEntries is the number of slots tracked by the SlotHistory
+	// sysvar bitvector (1,048,576 slots, ~5 days).
+	SlotHistoryMaxEntries = 1024 * 1024
+	// slotHistoryBlocks is the number of u64 blocks backing the bitvector.
+	slotHistoryBlocks = SlotHistoryMaxEntries / 64 // 16384
+	// SlotHistorySize is the fixed on-chain account size of the SlotHistory
+	// sysvar: 1 (Option tag) + 8 (slice len) + blocks*8 + 8 (bit len) + 8 (next_slot).
+	SlotHistorySize = 1 + 8 + slotHistoryBlocks*8 + 8 + 8 // 131097
+)
+
+// SlotHistoryCheck is the result of SlotHistory.Check.
+type SlotHistoryCheck int
+
+const (
+	// SlotHistoryFuture means the slot is newer than anything recorded.
+	SlotHistoryFuture SlotHistoryCheck = iota
+	// SlotHistoryTooOld means the slot has aged out of the window.
+	SlotHistoryTooOld
+	// SlotHistoryFound means the slot is recorded as present.
+	SlotHistoryFound
+	// SlotHistoryNotFound means the slot is within the window but absent.
+	SlotHistoryNotFound
+)
+
+func (c SlotHistoryCheck) String() string {
+	switch c {
+	case SlotHistoryFuture:
+		return "Future"
+	case SlotHistoryTooOld:
+		return "TooOld"
+	case SlotHistoryFound:
+		return "Found"
+	case SlotHistoryNotFound:
+		return "NotFound"
+	default:
+		return fmt.Sprintf("SlotHistoryCheck(%d)", int(c))
+	}
+}
+
+// SlotHistory is the data of the SlotHistory sysvar (account
+// solana.SysVarSlotHistoryPubkey): a bitvector recording which of the most recent
+// SlotHistoryMaxEntries slots were rooted. Mirrors solana-sdk
+// slot_history::SlotHistory.
+type SlotHistory struct {
+	// Bits is the backing bitvector, one bit per slot modulo SlotHistoryMaxEntries
+	// (bit i lives at Bits[i/64] bit i%64). A full SlotHistory has
+	// slotHistoryBlocks (16384) blocks.
+	Bits []uint64
+	// NextSlot is one past the newest recorded slot.
+	NextSlot uint64
+}
+
+// NewSlotHistory returns a SlotHistory in its genesis state: an all-false
+// bitvector with slot 0 marked present and NextSlot == 1. Mirrors the upstream
+// SlotHistory::default.
+func NewSlotHistory() *SlotHistory {
+	sh := &SlotHistory{Bits: make([]uint64, slotHistoryBlocks), NextSlot: 1}
+	sh.setBit(0, true)
+	return sh
+}
+
+func (sh *SlotHistory) getBit(i uint64) bool {
+	block := i / 64
+	if block >= uint64(len(sh.Bits)) {
+		return false
+	}
+	return (sh.Bits[block]>>(i%64))&1 == 1
+}
+
+func (sh *SlotHistory) setBit(i uint64, v bool) {
+	block := i / 64
+	if block >= uint64(len(sh.Bits)) {
+		return
+	}
+	mask := uint64(1) << (i % 64)
+	if v {
+		sh.Bits[block] |= mask
+	} else {
+		sh.Bits[block] &^= mask
+	}
+}
+
+// Newest returns the most recently recorded slot. Mirrors SlotHistory::newest.
+// It assumes NextSlot >= 1, which holds for any SlotHistory from NewSlotHistory
+// or decoded from a real account.
+func (sh *SlotHistory) Newest() uint64 { return sh.NextSlot - 1 }
+
+// Oldest returns the oldest slot still within the window. Mirrors
+// SlotHistory::oldest.
+func (sh *SlotHistory) Oldest() uint64 { return satSubU64(sh.NextSlot, SlotHistoryMaxEntries) }
+
+// Check reports the status of slot relative to the recorded window. Mirrors
+// SlotHistory::check.
+func (sh *SlotHistory) Check(slot uint64) SlotHistoryCheck {
+	switch {
+	case slot > sh.Newest():
+		return SlotHistoryFuture
+	case slot < sh.Oldest():
+		return SlotHistoryTooOld
+	case sh.getBit(slot % SlotHistoryMaxEntries):
+		return SlotHistoryFound
+	default:
+		return SlotHistoryNotFound
+	}
+}
+
+// Add records slot as present, clearing any slots skipped since NextSlot.
+// Mirrors SlotHistory::add.
+func (sh *SlotHistory) Add(slot uint64) {
+	if slot > sh.NextSlot && slot-sh.NextSlot >= SlotHistoryMaxEntries {
+		// Wrapped all the way around: clear everything.
+		for i := range sh.Bits {
+			sh.Bits[i] = 0
+		}
+	} else {
+		for skipped := sh.NextSlot; skipped < slot; skipped++ {
+			sh.setBit(skipped%SlotHistoryMaxEntries, false)
+		}
+	}
+	sh.setBit(slot%SlotHistoryMaxEntries, true)
+	sh.NextSlot = slot + 1
+}
+
+func (sh SlotHistory) MarshalWithEncoder(encoder *bin.Encoder) error {
+	// bits: bv::BitVec<u64> serializes as Option<Box<[u64]>> then the u64 bit length.
+	if err := encoder.WriteByte(0x01); err != nil { // Some
+		return err
+	}
+	if err := encoder.WriteUint64(uint64(len(sh.Bits)), binary.LittleEndian); err != nil {
+		return err
+	}
+	for _, block := range sh.Bits {
+		if err := encoder.WriteUint64(block, binary.LittleEndian); err != nil {
+			return err
+		}
+	}
+	// BitVec bit length: blocks * 64 (== SlotHistoryMaxEntries for a full,
+	// well-formed SlotHistory).
+	if err := encoder.WriteUint64(uint64(len(sh.Bits))*64, binary.LittleEndian); err != nil {
+		return err
+	}
+	return encoder.WriteUint64(sh.NextSlot, binary.LittleEndian)
+}
+
+func (sh *SlotHistory) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	tag, err := decoder.ReadByte()
+	if err != nil {
+		return err
+	}
+	switch tag {
+	case 0x00:
+		sh.Bits = nil
+	case 0x01:
+		n, err := decoder.ReadUint64(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		blocks := make([]uint64, 0, min(n, uint64(decoder.Remaining()/8)))
+		for range n {
+			block, err := decoder.ReadUint64(binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			blocks = append(blocks, block)
+		}
+		sh.Bits = blocks
+	default:
+		return fmt.Errorf("invalid slot history bitvec option tag: %d", tag)
+	}
+	// bit length (always SlotHistoryMaxEntries); read and discard.
+	if _, err := decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	sh.NextSlot, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
+}
+
+func (sh SlotHistory) MarshalBinary() ([]byte, error) { return encodeSysvar(sh) }
+func (sh *SlotHistory) UnmarshalBinary(data []byte) error {
+	return sh.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeSlotHistory decodes SlotHistory sysvar account data.
+func DecodeSlotHistory(data []byte) (*SlotHistory, error) {
+	var sh SlotHistory
+	if err := sh.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &sh, nil
+}

--- a/sysvar/stake_history.go
+++ b/sysvar/stake_history.go
@@ -1,0 +1,132 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+import (
+	"encoding/binary"
+	"sort"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+const (
+	// StakeHistoryMaxEntries is the maximum number of epochs the StakeHistory
+	// sysvar holds.
+	StakeHistoryMaxEntries = 512
+	// StakeHistoryEntrySerializedSize is the serialized size of one
+	// (epoch, entry) pair (4 x u64).
+	StakeHistoryEntrySerializedSize = 32
+	// StakeHistorySize is the fixed on-chain account size of the StakeHistory
+	// sysvar (u64 length prefix + MAX_ENTRIES * StakeHistoryEntrySerializedSize).
+	StakeHistorySize = 8 + StakeHistoryMaxEntries*StakeHistoryEntrySerializedSize
+)
+
+// StakeHistoryEntry is the cluster-wide stake activation state for one epoch.
+type StakeHistoryEntry struct {
+	// Effective is the effective stake at this epoch.
+	Effective uint64
+	// Activating is the sum of stake activating at this epoch.
+	Activating uint64
+	// Deactivating is the sum of stake deactivating at this epoch.
+	Deactivating uint64
+}
+
+// StakeHistoryItem pairs an epoch with its StakeHistoryEntry.
+type StakeHistoryItem struct {
+	Epoch uint64
+	Entry StakeHistoryEntry
+}
+
+// StakeHistory is the data of the StakeHistory sysvar (account
+// solana.SysVarStakeHistoryPubkey): per-epoch stake activation history, kept sorted by
+// epoch DESCENDING (index 0 is the newest epoch). Mirrors solana-sdk
+// stake_history::StakeHistory.
+type StakeHistory []StakeHistoryItem
+
+// Get returns the StakeHistoryEntry for epoch, if present.
+func (sh StakeHistory) Get(epoch uint64) (StakeHistoryEntry, bool) {
+	i := sort.Search(len(sh), func(i int) bool { return sh[i].Epoch <= epoch })
+	if i < len(sh) && sh[i].Epoch == epoch {
+		return sh[i].Entry, true
+	}
+	return StakeHistoryEntry{}, false
+}
+
+// Add inserts or updates the entry for epoch, keeping entries sorted by epoch
+// descending and capped at StakeHistoryMaxEntries (dropping the oldest).
+// Mirrors StakeHistory::add.
+func (sh *StakeHistory) Add(epoch uint64, entry StakeHistoryEntry) {
+	i := sort.Search(len(*sh), func(i int) bool { return (*sh)[i].Epoch <= epoch })
+	if i < len(*sh) && (*sh)[i].Epoch == epoch {
+		(*sh)[i].Entry = entry
+	} else {
+		*sh = append(*sh, StakeHistoryItem{})
+		copy((*sh)[i+1:], (*sh)[i:])
+		(*sh)[i] = StakeHistoryItem{Epoch: epoch, Entry: entry}
+	}
+	if len(*sh) > StakeHistoryMaxEntries {
+		*sh = (*sh)[:StakeHistoryMaxEntries]
+	}
+}
+
+func (sh StakeHistory) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(uint64(len(sh)), binary.LittleEndian); err != nil {
+		return err
+	}
+	for _, it := range sh {
+		for _, v := range [4]uint64{it.Epoch, it.Entry.Effective, it.Entry.Activating, it.Entry.Deactivating} {
+			if err := encoder.WriteUint64(v, binary.LittleEndian); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (sh *StakeHistory) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	n, err := decoder.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	out := make(StakeHistory, 0, min(n, uint64(decoder.Remaining()/StakeHistoryEntrySerializedSize)))
+	for range n {
+		var vals [4]uint64
+		for j := range vals {
+			if vals[j], err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+				return err
+			}
+		}
+		out = append(out, StakeHistoryItem{
+			Epoch: vals[0],
+			Entry: StakeHistoryEntry{Effective: vals[1], Activating: vals[2], Deactivating: vals[3]},
+		})
+	}
+	*sh = out
+	return nil
+}
+
+func (sh StakeHistory) MarshalBinary() ([]byte, error) { return encodeSysvar(sh) }
+func (sh *StakeHistory) UnmarshalBinary(data []byte) error {
+	return sh.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeStakeHistory decodes StakeHistory sysvar account data.
+func DecodeStakeHistory(data []byte) (StakeHistory, error) {
+	var sh StakeHistory
+	if err := sh.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return sh, nil
+}

--- a/sysvar/stake_history.go
+++ b/sysvar/stake_history.go
@@ -113,6 +113,10 @@ func (sh *StakeHistory) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 			Entry: StakeHistoryEntry{Effective: vals[1], Activating: vals[2], Deactivating: vals[3]},
 		})
 	}
+	// Normalize to the descending-by-epoch invariant that Get/Add rely on, so
+	// lookups stay correct even for an out-of-order (forked or hostile) buffer.
+	// A well-formed account is already sorted, so this is a no-op.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Epoch > out[j].Epoch })
 	*sh = out
 	return nil
 }

--- a/sysvar/sysvar_codec.go
+++ b/sysvar/sysvar_codec.go
@@ -1,0 +1,107 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+// Shared helpers for the sysvar account-data types (clock.go, rent.go,
+// epoch_schedule.go, slot_hashes.go, slot_history.go, stake_history.go,
+// epoch_rewards.go, last_restart_slot.go, fees.go, recent_blockhashes.go).
+//
+// All sysvar account data uses standard bincode: little-endian integers and a
+// u64 little-endian length prefix for Vec<T> (NOT the compact-u16/short-vec
+// encoding used in transaction wire formats).
+
+import (
+	"bytes"
+	"math"
+	"math/bits"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// encodeSysvar bincode-serializes a sysvar value via its MarshalWithEncoder.
+func encodeSysvar(m interface{ MarshalWithEncoder(*bin.Encoder) error }) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := m.MarshalWithEncoder(bin.NewBinEncoder(buf)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Saturating unsigned arithmetic mirroring Rust's saturating_add/sub/mul. Used
+// by the EpochSchedule slot/epoch math so results match the runtime exactly.
+
+func satAddU64(a, b uint64) uint64 {
+	s := a + b
+	if s < a {
+		return math.MaxUint64
+	}
+	return s
+}
+
+func satSubU64(a, b uint64) uint64 {
+	if a < b {
+		return 0
+	}
+	return a - b
+}
+
+func satMulU64(a, b uint64) uint64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	c := a * b
+	if c/a != b {
+		return math.MaxUint64
+	}
+	return c
+}
+
+func satAddU32(a, b uint32) uint32 {
+	s := a + b
+	if s < a {
+		return math.MaxUint32
+	}
+	return s
+}
+
+func satSubU32(a, b uint32) uint32 {
+	if a < b {
+		return 0
+	}
+	return a - b
+}
+
+// nextPowerOfTwo returns the smallest power of two >= n (n<=1 -> 1), matching
+// Rust's u64::next_power_of_two.
+func nextPowerOfTwo(n uint64) uint64 {
+	if n <= 1 {
+		return 1
+	}
+	return uint64(1) << bits.Len64(n-1)
+}
+
+// satPow2 returns 2^exp, saturating at math.MaxUint64, matching
+// 2u64.saturating_pow(exp).
+func satPow2(exp uint32) uint64 {
+	if exp >= 64 {
+		return math.MaxUint64
+	}
+	return uint64(1) << exp
+}
+
+// numTrailingZeros64 mirrors u64::trailing_zeros.
+func numTrailingZeros64(n uint64) int {
+	return bits.TrailingZeros64(n)
+}

--- a/sysvar/sysvars_test.go
+++ b/sysvar/sysvars_test.go
@@ -31,6 +31,7 @@ package sysvar
 
 import (
 	"encoding/hex"
+	"math"
 	"testing"
 
 	bin "github.com/gagliardetto/binary"
@@ -473,6 +474,70 @@ func FuzzDecodeSysvars(f *testing.F) {
 		_, _ = DecodeFees(data)
 		_, _ = DecodeRecentBlockhashes(data)
 	})
+}
+
+// ============================ regression tests ============================
+
+// TestRentMinimumBalanceOverflow guards against the unchecked multiply wrapping
+// and making an underfunded account look rent-exempt.
+func TestRentMinimumBalanceOverflow(t *testing.T) {
+	r := Rent{LamportsPerByte: math.MaxUint64, ExemptionThreshold: 1.0}
+	assert.Equal(t, uint64(math.MaxUint64), r.MinimumBalance(0)) // saturates, never wraps low
+	assert.False(t, r.IsExempt(1_000_000_000, 0))                // underfunded => not exempt
+	_, ok := r.TryMinimumBalance(0)
+	assert.False(t, ok)
+
+	// The 2.0-threshold doubling overflow also saturates rather than wrapping.
+	r2 := Rent{LamportsPerByte: math.MaxUint64 / 200, ExemptionThreshold: 2.0}
+	assert.Equal(t, uint64(math.MaxUint64), r2.MinimumBalance(0))
+	assert.False(t, r2.IsExempt(math.MaxUint64-1, 0))
+}
+
+// TestSlotHistoryAddOlderSlot guards against an older Add rewinding NextSlot and
+// hiding newer recorded slots.
+func TestSlotHistoryAddOlderSlot(t *testing.T) {
+	sh := NewSlotHistory()
+	sh.Add(100)
+	sh.Add(101)
+	sh.Add(102)
+	require.Equal(t, uint64(103), sh.NextSlot)
+
+	sh.Add(50) // older, still within the window
+	assert.Equal(t, uint64(103), sh.NextSlot, "NextSlot must not rewind")
+	assert.Equal(t, SlotHistoryFound, sh.Check(102))
+	assert.Equal(t, SlotHistoryFound, sh.Check(101))
+	assert.Equal(t, SlotHistoryFound, sh.Check(50)) // the older slot is now recorded
+}
+
+// TestDecodeSlotHashesNormalizesOrder guards against an out-of-order buffer
+// breaking the binary-search lookups.
+func TestDecodeSlotHashesNormalizesOrder(t *testing.T) {
+	ascending := SlotHashes{{Slot: 1, Hash: filledHash(1)}, {Slot: 2, Hash: filledHash(2)}, {Slot: 3, Hash: filledHash(3)}}
+	raw, err := ascending.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeSlotHashes(raw)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{3, 2, 1}, []uint64{got[0].Slot, got[1].Slot, got[2].Slot})
+	h, ok := got.Get(2)
+	require.True(t, ok)
+	assert.Equal(t, filledHash(2), h)
+}
+
+// TestDecodeStakeHistoryNormalizesOrder is the StakeHistory analog.
+func TestDecodeStakeHistoryNormalizesOrder(t *testing.T) {
+	ascending := StakeHistory{
+		{Epoch: 1, Entry: StakeHistoryEntry{Effective: 10}},
+		{Epoch: 2, Entry: StakeHistoryEntry{Effective: 20}},
+		{Epoch: 3, Entry: StakeHistoryEntry{Effective: 30}},
+	}
+	raw, err := ascending.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeStakeHistory(raw)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{3, 2, 1}, []uint64{got[0].Epoch, got[1].Epoch, got[2].Epoch})
+	e, ok := got.Get(2)
+	require.True(t, ok)
+	assert.Equal(t, StakeHistoryEntry{Effective: 20}, e)
 }
 
 func TestSysvarSizeConstants(t *testing.T) {

--- a/sysvar/sysvars_test.go
+++ b/sysvar/sysvars_test.go
@@ -1,0 +1,489 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+// Tests ported from the upstream anza-xyz/solana-sdk sysvar crates to match the
+// same functionality, one Go test per upstream test:
+//   clock/src/lib.rs           -> TestClockSizeOf, TestClockClone
+//   rent/src/lib.rs            -> TestRentSizeOf, TestRentClone, TestRentExemptionThreshold, TestRentMinimumBalance
+//   epoch-schedule/src/lib.rs  -> TestEpochSchedule, TestEpochScheduleClone
+//   slot-hashes/src/lib.rs     -> TestSlotHashesSizeOf, TestSlotHashes
+//   slot-history/src/lib.rs    -> TestSlotHistory (slot_history_test1)
+//   stake-history/src/lib.rs   -> TestStakeHistory
+//   epoch-rewards/src/lib.rs   -> TestEpochRewardsSizeOf, TestEpochRewardsNew, TestEpochRewardsDistribute, TestEpochRewardsDistributePanic
+//   last-restart-slot/src/lib.rs -> TestLastRestartSlotSizeOf
+//   sysvar/src/fees.rs         -> TestFeesSizeOf, TestFeesClone
+//   sysvar/src/recent_blockhashes.rs -> TestRecentBlockhashesSizeOf, TestRecentBlockhashesCanHoldAllActiveBlockhashes
+// Plus Go-specific extras: live-mainnet golden vectors for the static sysvars
+// (Rent, EpochSchedule) and encode/decode round-trips.
+
+import (
+	"encoding/hex"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+func filledHash(b byte) solana.Hash {
+	var h solana.Hash
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// ============================ Clock ============================
+
+func TestClockSizeOf(t *testing.T) {
+	raw, err := Clock{}.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, ClockSize)
+}
+
+func TestClockClone(t *testing.T) {
+	c := Clock{Slot: 1, EpochStartTimestamp: 2, Epoch: 3, LeaderScheduleEpoch: 4, UnixTimestamp: 5}
+	raw, err := c.MarshalBinary()
+	require.NoError(t, err)
+	// 5 x 8-byte little-endian fields.
+	assert.Equal(t,
+		mustHex(t, "01000000000000000200000000000000030000000000000004000000000000000500000000000000"),
+		raw)
+	got, err := DecodeClock(raw)
+	require.NoError(t, err)
+	assert.Equal(t, c, *got)
+
+	// Negative i64 timestamps round-trip.
+	c2 := Clock{Slot: 100, EpochStartTimestamp: -7, Epoch: 9, UnixTimestamp: -1}
+	raw2, err := c2.MarshalBinary()
+	require.NoError(t, err)
+	got2, err := DecodeClock(raw2)
+	require.NoError(t, err)
+	assert.Equal(t, c2, *got2)
+}
+
+// ============================ Rent ============================
+
+func TestRentSizeOf(t *testing.T) {
+	raw, err := DefaultRent().MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, RentSize)
+}
+
+func TestRentClone(t *testing.T) {
+	r := Rent{LamportsPerByte: 1, ExemptionThreshold: 2.2, BurnPercent: 3}
+	raw, err := r.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeRent(raw)
+	require.NoError(t, err)
+	assert.Equal(t, r, *got)
+}
+
+// TestRentExemptionThreshold ports rent::test_exemption_threshold: the wire form
+// of the threshold is the f64 little-endian byte pattern.
+func TestRentExemptionThreshold(t *testing.T) {
+	wireBytes := func(v float64) []byte {
+		raw, err := Rent{ExemptionThreshold: v}.MarshalBinary()
+		require.NoError(t, err)
+		return raw[8:16]
+	}
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0xf0, 0x3f}, wireBytes(1.0)) // SIMD-0194 default
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0x40}, wireBytes(2.0))    // legacy default
+}
+
+// TestRentMinimumBalance ports rent::test_minimum_balance: the SIMD-0194 default
+// (6960 lamports/byte, threshold 1.0) yields the same minimum as the legacy
+// parameters (3480 lamports/byte, threshold 2.0), equal to the float formula.
+func TestRentMinimumBalance(t *testing.T) {
+	def := DefaultRent()
+	prev := Rent{LamportsPerByte: DefaultLamportsPerByte / 2, ExemptionThreshold: 2.0, BurnPercent: DefaultBurnPercent}
+	for _, bytes := range []uint64{0, 1, 165, 1000, MaxPermittedDataLength} {
+		defCalc := def.MinimumBalance(bytes)
+		assert.Equal(t, defCalc, prev.MinimumBalance(bytes), "bytes=%d", bytes)
+		floatCalc := uint64(float64((AccountStorageOverhead+bytes)*prev.LamportsPerByte) * 2.0)
+		assert.Equal(t, floatCalc, defCalc, "bytes=%d", bytes)
+	}
+	// The famous 0-byte rent-exempt minimum.
+	assert.Equal(t, uint64(890880), def.MinimumBalance(0))
+	assert.True(t, def.IsExempt(890880, 0))
+	assert.False(t, def.IsExempt(890879, 0))
+}
+
+func TestRentGoldenVector(t *testing.T) {
+	// Live mainnet Rent sysvar account data (static; SIMD-0194 form).
+	data := mustHex(t, "301b000000000000000000000000f03f32")
+	require.Len(t, data, RentSize)
+	r, err := DecodeRent(data)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(6960), r.LamportsPerByte)
+	assert.Equal(t, 1.0, r.ExemptionThreshold)
+	assert.Equal(t, uint8(50), r.BurnPercent)
+	assert.Equal(t, DefaultRent(), *r)
+	raw, err := r.MarshalBinary()
+	require.NoError(t, err)
+	assert.Equal(t, data, raw)
+}
+
+// ============================ EpochSchedule ============================
+
+// TestEpochSchedule ports epoch_schedule::test_epoch_schedule.
+func TestEpochSchedule(t *testing.T) {
+	for spe := MinimumSlotsPerEpoch; spe <= MinimumSlotsPerEpoch*16; spe++ {
+		es := NewEpochScheduleCustom(spe, spe/2, true)
+
+		require.Equal(t, uint64(0), es.GetFirstSlotInEpoch(0), "spe=%d", spe)
+		require.Equal(t, MinimumSlotsPerEpoch-1, es.GetLastSlotInEpoch(0), "spe=%d", spe)
+
+		var lastLeaderSchedule, lastEpoch, lastSlotsInEpoch uint64 = 0, 0, MinimumSlotsPerEpoch
+		for slot := uint64(0); slot < 2*spe; slot++ {
+			// leader_schedule_epoch is continuous over warmup into the first normal epoch.
+			ls := es.GetLeaderScheduleEpoch(slot)
+			if ls != lastLeaderSchedule {
+				if ls != lastLeaderSchedule+1 {
+					t.Fatalf("spe=%d slot=%d: leader schedule jumped %d->%d", spe, slot, lastLeaderSchedule, ls)
+				}
+				lastLeaderSchedule = ls
+			}
+
+			epoch, offset := es.GetEpochAndSlotIndex(slot)
+			if epoch != lastEpoch {
+				if epoch != lastEpoch+1 {
+					t.Fatalf("spe=%d slot=%d: epoch jumped %d->%d", spe, slot, lastEpoch, epoch)
+				}
+				lastEpoch = epoch
+				if got := es.GetFirstSlotInEpoch(epoch); got != slot {
+					t.Fatalf("spe=%d: GetFirstSlotInEpoch(%d)=%d, want %d", spe, epoch, got, slot)
+				}
+				if got := es.GetLastSlotInEpoch(epoch - 1); got != slot-1 {
+					t.Fatalf("spe=%d: GetLastSlotInEpoch(%d)=%d, want %d", spe, epoch-1, got, slot-1)
+				}
+				// slots per epoch double over warmup until they reach spe.
+				slotsInEpoch := es.GetSlotsInEpoch(epoch)
+				if slotsInEpoch != lastSlotsInEpoch && slotsInEpoch != spe && slotsInEpoch != lastSlotsInEpoch*2 {
+					t.Fatalf("spe=%d epoch=%d: slots_in_epoch=%d, want %d or %d", spe, epoch, slotsInEpoch, lastSlotsInEpoch*2, spe)
+				}
+				lastSlotsInEpoch = slotsInEpoch
+			}
+			if offset >= lastSlotsInEpoch {
+				t.Fatalf("spe=%d slot=%d: offset %d >= slots_in_epoch %d", spe, slot, offset, lastSlotsInEpoch)
+			}
+		}
+		require.NotZero(t, lastLeaderSchedule, "spe=%d", spe)
+		require.NotZero(t, lastEpoch, "spe=%d", spe)
+		require.Equal(t, spe, lastSlotsInEpoch, "spe=%d: never reached normal mode", spe)
+	}
+}
+
+func TestEpochScheduleClone(t *testing.T) {
+	es := EpochSchedule{SlotsPerEpoch: 1, LeaderScheduleSlotOffset: 2, Warmup: true, FirstNormalEpoch: 4, FirstNormalSlot: 5}
+	raw, err := es.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeEpochSchedule(raw)
+	require.NoError(t, err)
+	assert.Equal(t, es, *got)
+}
+
+func TestEpochScheduleGoldenVector(t *testing.T) {
+	// Live mainnet EpochSchedule sysvar account data (static, no warmup).
+	data := mustHex(t, "809706000000000080970600000000000000000000000000000000000000000000")
+	require.Len(t, data, EpochScheduleSize)
+	es, err := DecodeEpochSchedule(data)
+	require.NoError(t, err)
+	assert.Equal(t, EpochSchedule{SlotsPerEpoch: 432000, LeaderScheduleSlotOffset: 432000}, *es)
+	assert.Equal(t, uint64(0), es.GetEpoch(431999))
+	assert.Equal(t, uint64(1), es.GetEpoch(432000))
+	assert.Equal(t, uint64(864000), es.GetFirstSlotInEpoch(2))
+	raw, err := es.MarshalBinary()
+	require.NoError(t, err)
+	assert.Equal(t, data, raw)
+}
+
+// ============================ SlotHashes ============================
+
+func TestSlotHashesSizeOf(t *testing.T) {
+	sh := make(SlotHashes, SlotHashesMaxEntries)
+	raw, err := sh.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, SlotHashesSize)
+}
+
+// TestSlotHashes ports slot_hashes::tests::test.
+func TestSlotHashes(t *testing.T) {
+	sh := NewSlotHashes(SlotHash{Slot: 1}, SlotHash{Slot: 3})
+	sh.Add(2, solana.Hash{})
+	assert.Equal(t, SlotHashes{{Slot: 3}, {Slot: 2}, {Slot: 1}}, sh)
+
+	var sh2 SlotHashes
+	for i := uint64(0); i < SlotHashesMaxEntries+1; i++ {
+		sh2.Add(i, filledHash(byte(i)))
+	}
+	require.Len(t, sh2, SlotHashesMaxEntries)
+	for i := 0; i < SlotHashesMaxEntries; i++ {
+		require.Equal(t, uint64(SlotHashesMaxEntries-i), sh2[i].Slot, "i=%d", i)
+	}
+
+	// Round-trip.
+	raw, err := sh2.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeSlotHashes(raw)
+	require.NoError(t, err)
+	assert.Equal(t, sh2, got)
+}
+
+// ============================ SlotHistory ============================
+
+// checkRange asserts sh.Check(i) == want for all i in [lo, hi), failing fast.
+func checkRange(t *testing.T, sh *SlotHistory, lo, hi uint64, want SlotHistoryCheck) {
+	t.Helper()
+	for i := lo; i < hi; i++ {
+		if got := sh.Check(i); got != want {
+			t.Fatalf("Check(%d) = %v, want %v", i, got, want)
+		}
+	}
+}
+
+// TestSlotHistory ports slot_history::slot_history_test1.
+func TestSlotHistory(t *testing.T) {
+	require.Zero(t, SlotHistoryMaxEntries%64) // clear logic works on 64-bit blocks
+
+	sh := NewSlotHistory()
+	sh.Add(2)
+	assert.Equal(t, SlotHistoryFound, sh.Check(0))
+	assert.Equal(t, SlotHistoryNotFound, sh.Check(1))
+	checkRange(t, sh, 3, SlotHistoryMaxEntries, SlotHistoryFuture)
+
+	sh.Add(20)
+	sh.Add(SlotHistoryMaxEntries)
+	assert.Equal(t, SlotHistoryTooOld, sh.Check(0))
+	assert.Equal(t, SlotHistoryNotFound, sh.Check(1))
+	for _, i := range []uint64{2, 20, SlotHistoryMaxEntries} {
+		assert.Equal(t, SlotHistoryFound, sh.Check(i), "i=%d", i)
+	}
+	checkRange(t, sh, 3, 20, SlotHistoryNotFound)
+	checkRange(t, sh, 21, SlotHistoryMaxEntries, SlotHistoryNotFound)
+	assert.Equal(t, SlotHistoryFuture, sh.Check(SlotHistoryMaxEntries+1))
+
+	slot := uint64(3*SlotHistoryMaxEntries + 3)
+	sh.Add(slot)
+	for _, i := range []uint64{0, 1, 2, 20, 21, SlotHistoryMaxEntries} {
+		assert.Equal(t, SlotHistoryTooOld, sh.Check(i), "i=%d", i)
+	}
+	checkRange(t, sh, slot-SlotHistoryMaxEntries+1, slot, SlotHistoryNotFound)
+	assert.Equal(t, SlotHistoryFound, sh.Check(slot))
+
+	// Serialized account is the fixed sysvar size and round-trips.
+	raw, err := sh.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, SlotHistorySize)
+	got, err := DecodeSlotHistory(raw)
+	require.NoError(t, err)
+	assert.Equal(t, sh.NextSlot, got.NextSlot)
+	assert.Equal(t, sh.Bits, got.Bits)
+}
+
+// ============================ StakeHistory ============================
+
+// TestStakeHistory ports stake_history::test_stake_history.
+func TestStakeHistory(t *testing.T) {
+	var sh StakeHistory
+	currentEpoch := uint64(StakeHistoryMaxEntries) + 1
+	for i := uint64(0); i < currentEpoch; i++ {
+		sh.Add(i, StakeHistoryEntry{Activating: i})
+	}
+	require.Len(t, sh, StakeHistoryMaxEntries)
+	assert.Equal(t, uint64(1), sh[len(sh)-1].Epoch) // oldest retained epoch
+
+	_, ok := sh.Get(0)
+	assert.False(t, ok)
+	for epoch := uint64(1); epoch < currentEpoch; epoch++ {
+		e, ok := sh.Get(epoch)
+		require.True(t, ok, "epoch=%d", epoch)
+		assert.Equal(t, StakeHistoryEntry{Activating: epoch}, e)
+	}
+	_, ok = sh.Get(currentEpoch)
+	assert.False(t, ok)
+
+	// Round-trip a small history.
+	small := StakeHistory{{Epoch: 9, Entry: StakeHistoryEntry{Effective: 100, Activating: 10, Deactivating: 1}}}
+	raw, err := small.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeStakeHistory(raw)
+	require.NoError(t, err)
+	assert.Equal(t, small, got)
+}
+
+// ============================ EpochRewards ============================
+
+func TestEpochRewardsSizeOf(t *testing.T) {
+	raw, err := EpochRewards{}.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, EpochRewardsSize)
+}
+
+// TestEpochRewardsNew ports epoch_rewards::test_epoch_rewards_new.
+func TestEpochRewardsNew(t *testing.T) {
+	e := EpochRewards{TotalRewards: 100, DistributedRewards: 0, DistributionStartingBlockHeight: 64}
+	assert.Equal(t, uint64(100), e.TotalRewards)
+	assert.Equal(t, uint64(0), e.DistributedRewards)
+	assert.Equal(t, uint64(64), e.DistributionStartingBlockHeight)
+}
+
+// TestEpochRewardsDistribute ports epoch_rewards::test_epoch_rewards_distribute.
+func TestEpochRewardsDistribute(t *testing.T) {
+	e := EpochRewards{TotalRewards: 100, DistributionStartingBlockHeight: 64}
+	require.NoError(t, e.Distribute(100))
+	assert.Equal(t, uint64(100), e.TotalRewards)
+	assert.Equal(t, uint64(100), e.DistributedRewards)
+}
+
+// TestEpochRewardsDistributeError ports epoch_rewards::test_epoch_rewards_distribute_panic
+// (the Go port returns an error rather than panicking).
+func TestEpochRewardsDistributeError(t *testing.T) {
+	e := EpochRewards{TotalRewards: 100, DistributionStartingBlockHeight: 64}
+	assert.Error(t, e.Distribute(200))
+	assert.Zero(t, e.DistributedRewards) // unchanged on error
+}
+
+func TestEpochRewardsRoundTrip(t *testing.T) {
+	e := EpochRewards{
+		DistributionStartingBlockHeight: 1000,
+		NumPartitions:                   8,
+		ParentBlockhash:                 filledHash(0x11),
+		TotalPoints:                     bin.Uint128{Lo: 0xdeadbeef, Hi: 1},
+		TotalRewards:                    5_000_000,
+		DistributedRewards:              1_000_000,
+		Active:                          true,
+	}
+	raw, err := e.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeEpochRewards(raw)
+	require.NoError(t, err)
+	assert.Equal(t, e.ParentBlockhash, got.ParentBlockhash)
+	assert.Equal(t, e.TotalPoints.Lo, got.TotalPoints.Lo)
+	assert.Equal(t, e.TotalPoints.Hi, got.TotalPoints.Hi)
+	assert.Equal(t, e.TotalRewards, got.TotalRewards)
+	assert.True(t, got.Active)
+}
+
+// ============================ LastRestartSlot ============================
+
+func TestLastRestartSlotSizeOf(t *testing.T) {
+	raw, err := LastRestartSlot{}.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, LastRestartSlotSize)
+
+	// round-trip
+	raw, err = LastRestartSlot{LastRestartSlot: 123456789}.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeLastRestartSlot(raw)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(123456789), got.LastRestartSlot)
+}
+
+// ============================ Fees (deprecated) ============================
+
+func TestFeesSizeOf(t *testing.T) {
+	raw, err := Fees{}.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, FeesSize)
+}
+
+func TestFeesClone(t *testing.T) {
+	f := Fees{FeeCalculator: solana.FeeCalculator{LamportsPerSignature: 1}}
+	raw, err := f.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeFees(raw)
+	require.NoError(t, err)
+	assert.Equal(t, f, *got)
+}
+
+// ============================ RecentBlockhashes (deprecated) ============================
+
+// TestRecentBlockhashesSizeOf ports recent_blockhashes::test_size_of.
+func TestRecentBlockhashesSizeOf(t *testing.T) {
+	rb := make(RecentBlockhashes, RecentBlockhashesMaxEntries)
+	raw, err := rb.MarshalBinary()
+	require.NoError(t, err)
+	assert.Len(t, raw, RecentBlockhashesSize)
+}
+
+// TestRecentBlockhashesCanHoldAllActiveBlockhashes ports
+// recent_blockhashes::test_sysvar_can_hold_all_active_blockhashes.
+func TestRecentBlockhashesCanHoldAllActiveBlockhashes(t *testing.T) {
+	assert.True(t, MaxProcessingAge <= RecentBlockhashesMaxEntries)
+}
+
+func TestRecentBlockhashesRoundTrip(t *testing.T) {
+	rb := RecentBlockhashes{
+		{Blockhash: filledHash(0x01), FeeCalculator: solana.FeeCalculator{LamportsPerSignature: 5000}},
+		{Blockhash: filledHash(0x02), FeeCalculator: solana.FeeCalculator{LamportsPerSignature: 4000}},
+	}
+	raw, err := rb.MarshalBinary()
+	require.NoError(t, err)
+	got, err := DecodeRecentBlockhashes(raw)
+	require.NoError(t, err)
+	assert.Equal(t, rb, got)
+}
+
+// ============================ size constants ============================
+
+// FuzzDecodeSysvars ensures no sysvar decoder panics on arbitrary input
+// (e.g. a hostile u64 length prefix must not blow up the allocator).
+func FuzzDecodeSysvars(f *testing.F) {
+	for _, s := range []string{
+		"",
+		"301b000000000000000000000000f03f32",
+		"809706000000000080970600000000000000000000000000000000000000000000",
+		"01000000000000000200000000000000030000000000000004000000000000000500000000000000",
+		"ffffffffffffffff", // hostile Vec length prefix
+	} {
+		b, _ := hex.DecodeString(s)
+		f.Add(b)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = DecodeClock(data)
+		_, _ = DecodeRent(data)
+		_, _ = DecodeEpochSchedule(data)
+		_, _ = DecodeEpochRewards(data)
+		_, _ = DecodeLastRestartSlot(data)
+		_, _ = DecodeSlotHashes(data)
+		_, _ = DecodeSlotHistory(data)
+		_, _ = DecodeStakeHistory(data)
+		_, _ = DecodeFees(data)
+		_, _ = DecodeRecentBlockhashes(data)
+	})
+}
+
+func TestSysvarSizeConstants(t *testing.T) {
+	assert.Equal(t, 40, ClockSize)
+	assert.Equal(t, 17, RentSize)
+	assert.Equal(t, 33, EpochScheduleSize)
+	assert.Equal(t, 81, EpochRewardsSize)
+	assert.Equal(t, 8, LastRestartSlotSize)
+	assert.Equal(t, 8, FeesSize)
+	assert.Equal(t, 20488, SlotHashesSize)
+	assert.Equal(t, 16392, StakeHistorySize)
+	assert.Equal(t, 131097, SlotHistorySize)
+	assert.Equal(t, 6008, RecentBlockhashesSize)
+}


### PR DESCRIPTION
### Problem

SDK exposed only the sysvar account addresses - `SysVar*Pubkey`, with no way to decode the account data those addresses hold

### Summary of Changes

added a sysvar subpackage that contains sysvar types, so client can decode (and re-encode)