### PR TITLE
fix(programs): correct account flags in vote Withdraw and stake Initialize

### DIFF
--- a/programs/stake/Initialize.go
+++ b/programs/stake/Initialize.go
@@ -31,7 +31,7 @@ type Initialize struct {
 	// Lockup settings for stake account
 	Lockup *Lockup
 
-	// [0] = [WRITE SIGNER] StakeAccount
+	// [0] = [WRITE] StakeAccount
 	// ··········· Stake account getting initialized
 	//
 	// [1] = [] RentSysvar
@@ -104,7 +104,7 @@ func (inst *Initialize) Validate() error {
 
 // Stake account account
 func (inst *Initialize) SetStakeAccount(stakeAccount solana.PublicKey) *Initialize {
-	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE().SIGNER()
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE()
 	return inst
 }
 

--- a/programs/stake/Initialize_test.go
+++ b/programs/stake/Initialize_test.go
@@ -37,3 +37,19 @@ func TestRoundTrip_Initialize(t *testing.T) {
 	require.Equal(t, uint64(42), *init.Lockup.Epoch)
 	require.Equal(t, custodian, *init.Lockup.Custodian)
 }
+
+// TestInitialize_AccountFlags pins the canonical Solana account spec for the
+// stake Initialize instruction: the stake account is writable but NOT a signer
+// (its keypair signs the preceding SystemProgram::CreateAccount, not this
+// instruction), and the rent sysvar is read-only.
+func TestInitialize_AccountFlags(t *testing.T) {
+	inst := NewInitializeInstruction(pubkeyOf(1), pubkeyOf(2), pubkeyOf(10))
+
+	stakeAccount := inst.GetStakeAccount()
+	require.True(t, stakeAccount.IsWritable, "stake account must be writable")
+	require.False(t, stakeAccount.IsSigner, "stake account must not be a signer")
+
+	rent := inst.GetRentSysvarAccount()
+	require.False(t, rent.IsWritable, "rent sysvar must be read-only")
+	require.False(t, rent.IsSigner, "rent sysvar must not be a signer")
+}

--- a/programs/vote/Withdraw.go
+++ b/programs/vote/Withdraw.go
@@ -35,7 +35,7 @@ type Withdraw struct {
 	// [1] = [WRITE] ToAccount
 	// ··········· Account to receive the funds
 	//
-	// [2] = [WRITE SIGNER] AuthorizedWithdrawerPubkey
+	// [2] = [SIGNER] AuthorizedWithdrawerPubkey
 	// ··········· Account authorized to do the witdraw
 	//
 	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -94,7 +94,7 @@ func (inst *Withdraw) SetRecipientAccount(recipientAccount solana.PublicKey) *Wi
 
 // Withdraw authority account
 func (inst *Withdraw) SetWithdrawAuthorityAccount(withdrawAccount solana.PublicKey) *Withdraw {
-	inst.AccountMetaSlice[2] = solana.Meta(withdrawAccount).WRITE().SIGNER()
+	inst.AccountMetaSlice[2] = solana.Meta(withdrawAccount).SIGNER()
 	return inst
 }
 

--- a/programs/vote/Withdraw_test.go
+++ b/programs/vote/Withdraw_test.go
@@ -20,3 +20,23 @@ func TestRoundTrip_Withdraw(t *testing.T) {
 	w := decoded.Impl.(*Withdraw)
 	require.Equal(t, uint64(1_000_000_000), *w.Lamports)
 }
+
+// TestWithdraw_AccountFlags pins the canonical Solana account spec for the vote
+// Withdraw instruction: the vote account and recipient are writable non-signers,
+// and the authorized withdrawer is a read-only signer (it authorizes the
+// withdraw but is not itself mutated, so it must not carry the writable flag).
+func TestWithdraw_AccountFlags(t *testing.T) {
+	inst := NewWithdrawInstruction(1, pubkeyOf(1), pubkeyOf(2), pubkeyOf(3))
+
+	vote := inst.GetVoteAccount()
+	require.True(t, vote.IsWritable, "vote account must be writable")
+	require.False(t, vote.IsSigner, "vote account must not be a signer")
+
+	recipient := inst.GetRecipientAccount()
+	require.True(t, recipient.IsWritable, "recipient must be writable")
+	require.False(t, recipient.IsSigner, "recipient must not be a signer")
+
+	withdrawer := inst.GetWithdrawAuthorityAccount()
+	require.False(t, withdrawer.IsWritable, "withdraw authority must be read-only")
+	require.True(t, withdrawer.IsSigner, "withdraw authority must be a signer")
+}


### PR DESCRIPTION
Corrects two native-program instruction builders that set account-meta flags not present in the canonical Solana account spec. Both add an extra flag to the on-chain instruction's account list. Same class as #452.

**vote `Withdraw`** — the authorized withdrawer was `WRITE().SIGNER()`; canonical `withdraw` marks it `new_readonly(withdrawer, true)` (read-only signer). The authority only authorizes and is not mutated, so the writable flag is spurious. Every other vote instruction taking the authority (`Authorize`, `UpdateCommission`, `UpdateValidatorIdentity`) marks it signer-only — `Withdraw` was the lone outlier.

**stake `Initialize`** — the stake account was `WRITE().SIGNER()`; canonical `Initialize` marks it `new(stake_pubkey, false)` (writable, not signer). The stake account's keypair signs the preceding `SystemProgram::CreateAccount`, not `Initialize`.

Both spurious flags inflate the message header (extra required signature / extra writable lock). Doc comments corrected to match. Added flag-assertion tests (`TestWithdraw_AccountFlags`, `TestInitialize_AccountFlags`).

`go build ./...`, `go vet`, `gofmt`, and `go test ./programs/stake/ ./programs/vote/` all pass.

Closes #458
